### PR TITLE
Fix bookmark PATCH 405 and sort age-rating choices by index

### DIFF
--- a/codex/views/browser/choices.py
+++ b/codex/views/browser/choices.py
@@ -199,6 +199,13 @@ class BrowserChoicesView(BrowserChoicesViewBase):
         values = ["pk", "name"]
         if qs.model == Universe:
             values.append("designation")
+        elif qs.model == AgeRatingMetron:
+            # AgeRatingMetron.Meta.ordering = ("index",), but ``.distinct()``
+            # with ``.values("pk", "name")`` drops it because ``index`` isn't
+            # in the SELECT projection. Include it and sort explicitly so the
+            # UI shows ratings in rating order rather than alphabetical.
+            values.append("index")
+            qs = qs.order_by("index")
         qs = qs.values(*values)
 
         # Add null if it exists

--- a/frontend/src/api/v3/browser.js
+++ b/frontend/src/api/v3/browser.js
@@ -82,7 +82,7 @@ export const getGroupDownloadURL = ({ group, pks }, fn, settings, ts) => {
     ts,
   });
   fn = encodeURIComponent(fn);
-  return `${base}${hrefPath} / download / ${fn} ? ${queryString}`;
+  return `${base}${hrefPath}/download/${fn}?${queryString}`;
 };
 
 const updateGroupBookmarks = ({ group, ids }, settings, updates) => {
@@ -92,14 +92,11 @@ const updateGroupBookmarks = ({ group, ids }, settings, updates) => {
     updates.fitTo = "";
   }
   const pkList = ids.join(",");
-  return HTTP.patch(
-    `${group} / ${pkList} / bookmark ? ${queryString}`,
-    updates,
-  );
+  return HTTP.patch(`${group}/${pkList}/bookmark?${queryString}`, updates);
 };
 
 const getLazyImport = ({ group, pks }) => {
-  return HTTP.get(`/ ${group} / ${pks} /import `);
+  return HTTP.get(`/${group}/${pks}/import`);
 };
 
 const getSavedSettingsList = () => {
@@ -111,11 +108,11 @@ const saveSettings = (name) => {
 };
 
 const loadSavedSettings = (pk) => {
-  return HTTP.get(`/ r / settings / saved / ${pk}`);
+  return HTTP.get(`/r/settings/saved/${pk}`);
 };
 
 const deleteSavedSettings = (pk) => {
-  return HTTP.delete(`/ r / settings / saved / ${pk}`);
+  return HTTP.delete(`/r/settings/saved/${pk}`);
 };
 
 export default {


### PR DESCRIPTION
## Summary

- **Reader PATCH 405**: Five URL template literals in `frontend/src/api/v3/browser.js` had stray spaces around `/` and `?`, so every request resolved to `/` on the server. The reader's `updateGroupBookmarks` PATCH landed on the site root and Django logged `Method Not Allowed: /`. Fixed the bookmark URL plus four other affected endpoints (`getGroupDownloadURL`, `getLazyImport`, `loadSavedSettings`, `deleteSavedSettings`).
- **Age-Rating submenu sort**: The filter submenu was alphabetical even though `AgeRatingMetron.Meta.ordering = ("index",)` should have surfaced enum order. `.distinct()` combined with `.values("pk", "name")` drops the default ordering because `index` is not in the SELECT projection. Added `index` to the values list and an explicit `.order_by("index")` in `codex/views/browser/choices.py` so the submenu renders Everyone → Adult instead of alphabetically.

## Test plan

- [x] Python tests pass (`uv run pytest tests/`)
- [x] Frontend unit tests pass (`bun run test` in `frontend/`)
- [x] ESLint + Prettier clean
- [ ] Manual: open the reader — no `405 Method Not Allowed: /` in Django log
- [ ] Manual: download a group, lazy-import a group, save/load/delete saved settings — all resolve to real endpoints
- [ ] Manual: open the Age Rating filter submenu — choices render in enum order (Everyone, Teen, Teen Plus, Mature, Explicit, Adult) rather than alphabetically

🤖 Generated with [Claude Code](https://claude.com/claude-code)