### PR TITLE
Run silk migrations on silky DB at startup

### DIFF
--- a/codex/startup/db.py
+++ b/codex/startup/db.py
@@ -109,6 +109,13 @@ def _rebuild_db() -> bool:
     return True
 
 
+def _migrate_silk_db() -> None:
+    """Apply silk migrations to the silky DB when it's configured."""
+    if "silky" not in connections.databases:
+        return
+    call_command("migrate", "silk", database="silky", verbosity=0)
+
+
 def ensure_db_schema() -> bool:
     """Ensure the db is good and up to date."""
     logger.info("Ensuring database is correct and up to date...")
@@ -121,5 +128,6 @@ def ensure_db_schema() -> bool:
     if db_exists and _has_unapplied_migrations():
         _backup_db_before_migration()
     call_command("migrate")
+    _migrate_silk_db()
     logger.success("Database ready.")
     return True


### PR DESCRIPTION
## Summary

Fix for the "no such table: silk_request" error AJ hit after merging Stage 1 ([#575](https://github.com/ajslater/codex/pull/575)).

Stage 0 ([#574](https://github.com/ajslater/codex/pull/574)) wired the `silky` SQLite DB and a `SilkRouter` that sends silk app reads/writes to that DB. But startup only ran `call_command("migrate")` against the default DB — the router correctly blocks silk migrations from landing there, so the silky DB was never populated. The first request through `SilkyMiddleware` then crashed trying to insert into a non-existent `silk_request` table.

This PR adds a `_migrate_silk_db()` step after the default migrate, guarded on `"silky" in connections.databases` so production (DEBUG=False, no silky DB) is a no-op. Mirrors the pattern already in [tests/perf/run_baseline.py](tests/perf/run_baseline.py).

## Test plan

- [ ] `rm -f ~/.config/codex/silk.sqlite3` then start codex in dev (DEBUG=True)
- [ ] Browse the main view — verify no "no such table: silk_request"
- [ ] `sqlite3 ~/.config/codex/silk.sqlite3 ".schema silk_request"` — table exists
- [ ] Start codex with DEBUG=False — verify `_migrate_silk_db()` is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)