### PR TITLE
Force cover refresh after 202 so the placeholder doesn't stick

### DIFF
--- a/codex/views/browser/cover.py
+++ b/codex/views/browser/cover.py
@@ -74,9 +74,14 @@ class _CoverBaseView(AuthFilterAPIView):
             return cls._missing_cover_response()
 
         # Defer creation to the cover thread; respond with a placeholder.
+        # Cache-Control: no-store prevents the browser from caching the
+        # placeholder at this URL so a subsequent fetch to the same URL (once
+        # the cover thread has written the real thumb) actually hits the
+        # network instead of serving the stale placeholder.
         LIBRARIAN_QUEUE.put(CoverCreateTask(pks=(pk,), custom=custom))
         response = cls._missing_cover_response(status.HTTP_202_ACCEPTED)
         response["Retry-After"] = str(_RETRY_AFTER_SECONDS)
+        response["Cache-Control"] = "no-store"
         return response
 
 

--- a/frontend/src/components/book-cover.vue
+++ b/frontend/src/components/book-cover.vue
@@ -15,6 +15,9 @@
 <script>
 import { getCoverSrc } from "@/api/v3/browser";
 
+const MAX_RETRIES = 5;
+const DEFAULT_RETRY_AFTER_SEC = 2;
+
 export default {
   name: "BookCover",
   props: {
@@ -45,15 +48,21 @@ export default {
   },
   data() {
     return {
-      showPlaceholder: false,
+      retry: 0,
+      abort: null,
     };
   },
   computed: {
     coverSrc() {
-      return getCoverSrc(
+      const base = getCoverSrc(
         { coverPk: this.coverPk, coverCustomPk: this.coverCustomPk },
         this.mtime,
       );
+      if (this.retry <= 0) {
+        return base;
+      }
+      const sep = base.includes("?") ? "&" : "?";
+      return `${base}${sep}r=${this.retry}`;
     },
     multiPkClasses() {
       const len = this.pks.length;
@@ -66,14 +75,57 @@ export default {
       return classes;
     },
   },
-  mounted: function () {
-    this.delayPlaceholder();
+  mounted() {
+    this.pollCover();
+  },
+  unmounted() {
+    this.abort?.abort();
   },
   methods: {
-    delayPlaceholder: function () {
-      setTimeout(() => {
-        this.showPlaceholder = true;
-      }, 2000);
+    async pollCover() {
+      /*
+       * Probe the cover URL. The backend returns 202 Accepted with a
+       * Cache-Control: no-store placeholder while the cover thread is still
+       * generating the real thumb. Browsers don't honor Retry-After on <img>
+       * elements, so we poll here and bump `retry` (a cache-busting query
+       * param) to force v-img to re-fetch once the real cover is ready.
+       */
+      this.abort?.abort();
+      this.abort = new AbortController();
+      const signal = this.abort.signal;
+      let sawPending = false;
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        let resp;
+        try {
+          resp = await fetch(this.coverSrc, {
+            credentials: "same-origin",
+            signal,
+          });
+        } catch {
+          return;
+        }
+        if (resp.status !== 202) {
+          if (sawPending) {
+            this.retry = attempt + 1;
+          }
+          return;
+        }
+        sawPending = true;
+        const retryAfterSec =
+          Number.parseInt(resp.headers.get("Retry-After"), 10) ||
+          DEFAULT_RETRY_AFTER_SEC;
+        try {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, retryAfterSec * 1000);
+            signal.addEventListener("abort", () => {
+              clearTimeout(timer);
+              reject(new Error("aborted"));
+            });
+          });
+        } catch {
+          return;
+        }
+      }
     },
   },
 };


### PR DESCRIPTION
## Summary

Follow-up to #579. The 202 Accepted path shipped in that PR wasn't actually refreshing once the cover thread finished — browsers don't honor `Retry-After` on `<img>` elements and cached the placeholder at the cover URL, so v-img kept rendering the stale placeholder bytes indefinitely.

- **Backend** ([`codex/views/browser/cover.py`](../blob/claude/cover-202-refresh/codex/views/browser/cover.py)): 202 responses now set `Cache-Control: no-store` so the placeholder isn't cached at the URL.
- **Frontend** ([`frontend/src/components/book-cover.vue`](../blob/claude/cover-202-refresh/frontend/src/components/book-cover.vue)): `BookCover` probes the cover URL with `fetch()` on mount. On 202 it sleeps `Retry-After` then bumps a reactive `retry` counter that becomes a cache-busting `?r=N` query param on `coverSrc`, forcing `v-img` to re-fetch and pick up the real cover once the cover thread is done. Retries capped at 5; in-flight requests and timers aborted on unmount via `AbortController`.

## Test plan

- [x] `./bin/lint-python.sh` — clean
- [x] `bun run lint` — clean
- [x] `make test-python` — 20 passed
- [x] `bun run test` — passed
- [ ] Cold-cache browse: confirm placeholders swap to real covers within a few seconds without a page reload
- [ ] Warm-cache browse: confirm there's no redundant `?r=N` re-fetch when the initial request already returned 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)