### PR TITLE
Harden cover endpoint against concurrent read/write races

### DIFF
--- a/codex/librarian/covers/create.py
+++ b/codex/librarian/covers/create.py
@@ -1,5 +1,6 @@
 """Create comic cover paths."""
 
+import os
 from abc import ABC
 from io import BytesIO
 from multiprocessing.queues import Queue
@@ -18,6 +19,7 @@ from codex.librarian.threads import QueuedThread
 from codex.models import Comic, CustomCover
 from codex.settings import COMICBOX_CONFIG
 
+_PID = os.getpid()
 _COVER_RATIO = 1.5372233400402415  # modal cover ratio
 THUMBNAIL_WIDTH = 165
 THUMBNAIL_HEIGHT = round(THUMBNAIL_WIDTH * _COVER_RATIO)
@@ -97,8 +99,17 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
         cover_path = Path(cover_path_str)
         cover_path.parent.mkdir(exist_ok=True, parents=True)
         if data:
-            with cover_path.open("wb") as cover_file:
-                cover_file.write(data)
+            # Atomic write: stage to a sibling tmp file, then os.replace so
+            # readers only ever observe the pre-existing state or the fully
+            # written new file — never a half-written one.
+            tmp_path = cover_path.with_name(f"{cover_path.name}.{_PID}.tmp")
+            try:
+                with tmp_path.open("wb") as cover_file:
+                    cover_file.write(data)
+                tmp_path.replace(cover_path)
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
         elif not cover_path.exists():
             # zero length file is code for missing.
             cover_path.touch()

--- a/codex/librarian/covers/purge.py
+++ b/codex/librarian/covers/purge.py
@@ -92,8 +92,22 @@ class CoverPurgeThread(CoverCreateThread, ABC):
 
         self.purge_cover_paths(orphan_cover_paths, cover_root)
 
+    def _cleanup_tmp_covers(self) -> None:
+        """Remove stale ``*.tmp`` files left behind by aborted atomic writes."""
+        for cover_root in (self.COVERS_ROOT, self.CUSTOM_COVERS_ROOT):
+            if not cover_root.exists():
+                continue
+            for tmp_path in cover_root.rglob("*.tmp"):
+                try:
+                    tmp_path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    self.log.warning(f"Could not remove stale {tmp_path}: {exc!r}")
+
     def cleanup_orphan_covers(self) -> None:
         """Cleanup both comic and custom covers."""
+        self._cleanup_tmp_covers()
         self._cleanup_orphan_covers(Comic, self.COVERS_ROOT, "comics")
         self._cleanup_orphan_covers(
             CustomCover, self.CUSTOM_COVERS_ROOT, "custom covers"

--- a/codex/views/browser/cover.py
+++ b/codex/views/browser/cover.py
@@ -65,11 +65,20 @@ class _CoverBaseView(AuthFilterAPIView):
     def _get_cover_response(cls, pk: int, *, custom: bool) -> HttpResponse:
         """Return a cached cover or enqueue one and return 202 Retry-After."""
         cover_path = CoverPathMixin.get_cover_path(pk, custom=custom)
-        if cover_path.exists():
-            if cover_path.stat().st_size > 0:
-                return HttpResponse(
-                    cover_path.read_bytes(), content_type=_WEBP_CONTENT_TYPE
-                )
+        # Single read — no exists()/stat() race window. The cover thread
+        # writes atomically via os.replace, so we only ever see the old state
+        # or the complete new file.
+        try:
+            cover_bytes = cover_path.read_bytes()
+        except FileNotFoundError:
+            cover_bytes = None
+        except OSError as exc:
+            logger.warning(f"Cover read error (pk={pk} custom={custom}): {exc!r}")
+            cover_bytes = None
+
+        if cover_bytes:
+            return HttpResponse(cover_bytes, content_type=_WEBP_CONTENT_TYPE)
+        if cover_bytes == b"":
             # Zero-byte marker = the cover thread already tried and failed.
             return cls._missing_cover_response()
 
@@ -78,7 +87,10 @@ class _CoverBaseView(AuthFilterAPIView):
         # placeholder at this URL so a subsequent fetch to the same URL (once
         # the cover thread has written the real thumb) actually hits the
         # network instead of serving the stale placeholder.
-        LIBRARIAN_QUEUE.put(CoverCreateTask(pks=(pk,), custom=custom))
+        try:
+            LIBRARIAN_QUEUE.put(CoverCreateTask(pks=(pk,), custom=custom))
+        except Exception as exc:
+            logger.warning(f"Cover enqueue failed (pk={pk} custom={custom}): {exc!r}")
         response = cls._missing_cover_response(status.HTTP_202_ACCEPTED)
         response["Retry-After"] = str(_RETRY_AFTER_SECONDS)
         response["Cache-Control"] = "no-store"
@@ -99,8 +111,8 @@ class CoverView(_CoverBaseView):
                 return self._missing_cover_response()
             return self._get_cover_response(pk, custom=False)
         except Exception:
-            logger.exception("Get comic cover by pk")
-            raise
+            logger.exception(f"Get comic cover by pk {pk}")
+            return self._missing_cover_response()
 
 
 class CustomCoverView(_CoverBaseView):
@@ -119,5 +131,5 @@ class CustomCoverView(_CoverBaseView):
         try:
             return self._get_cover_response(pk, custom=True)
         except Exception:
-            logger.exception("Get custom cover by pk")
-            raise
+            logger.exception(f"Get custom cover by pk {pk}")
+            return self._missing_cover_response()


### PR DESCRIPTION
## Summary

Follow-up to #580. Under a cold-cache page load, 32 HTTP workers hitting the cover endpoint at the same time the cover thread was writing thumbs returned 500s for a handful of covers (silently — Django's default 500 path wasn't captured by loguru). The endpoint used a three-step `exists()` / `stat()` / `read_bytes()` sequence that could race against an in-flight write, and `save_cover_to_cache` wrote directly to the target path so readers could observe a truncated file mid-write.

- **Atomic writes.** `save_cover_to_cache` stages to a `{name}.{pid}.tmp` sibling and renames with `Path.replace`, so a read either sees the pre-existing state or the fully written file — never a partial one. Stale temp files are unlinked on failure.
- **Race-safe view.** `_get_cover_response` collapses to a single `read_bytes()` that catches `FileNotFoundError` and logs `OSError`, then falls through to the 202 path. No window between stat and read.
- **500s always logged and never user-visible.** `LIBRARIAN_QUEUE.put` and the outer `get()` methods are wrapped in try/except that log and return the placeholder, so a surprise exception leaves a log line instead of bubbling up as an opaque 500.
- **Janitor sweeps `*.tmp`.** `cleanup_orphan_covers` runs `_cleanup_tmp_covers` first, walking both cover roots and unlinking any `*.tmp` left behind by a crashed writer.

## Test plan

- [x] `./bin/lint-python.sh` — clean
- [x] `make test-python` — 20 passed
- [ ] Cold-cache browse with a full page of 72 fresh covers: verify no 500s in the browser network pane, and any unexpected failure shows up in the Codex log instead of silently 500'ing
- [ ] After an imported library with many new comics, run the scheduled orphan cleanup and confirm any leftover `*.tmp` files are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)