### PR TITLE
Fix metadata cover fetching pk=0 after Stage 3 cover fan-out

### DIFF
--- a/codex/serializers/browser/metadata.py
+++ b/codex/serializers/browser/metadata.py
@@ -1,6 +1,6 @@
 """Codex Serializers for the metadata box."""
 
-from rest_framework.fields import CharField
+from rest_framework.fields import CharField, SerializerMethodField
 from rest_framework.serializers import IntegerField, ListField, Serializer, URLField
 
 from codex.serializers.browser.mixins import BrowserAggregateSerializerMixin
@@ -30,6 +30,22 @@ class MetadataSerializer(BrowserAggregateSerializerMixin, ComicSerializer):
     parent_folder_id = IntegerField(read_only=True, required=False)
     series_volume_count = IntegerField(read_only=True)
     volume_issue_count = IntegerField(read_only=True)
+
+    # cover_pk and cover_custom_pk are annotated on group querysets by
+    # BrowserAnnotateCoverView; Comic metadata skips the annotation and
+    # falls back to ``obj.pk`` — so the frontend can always build a
+    # ``/c/<pk>/cover.webp`` URL without a per-group branch.
+    cover_pk = SerializerMethodField(read_only=True)
+    cover_custom_pk = SerializerMethodField(read_only=True)
+
+    def get_cover_pk(self, obj) -> int:
+        """Return pre-computed cover pk, falling back to the object's own pk."""
+        value = getattr(obj, "cover_pk", None)
+        return value if value is not None else obj.pk
+
+    def get_cover_custom_pk(self, obj) -> int | None:
+        """Return the custom cover pk when present, else None."""
+        return getattr(obj, "cover_custom_pk", None)
 
     publisher_list = GroupSerializer(many=True, required=False)
     imprint_list = GroupSerializer(many=True, required=False)

--- a/codex/views/browser/metadata/__init__.py
+++ b/codex/views/browser/metadata/__init__.py
@@ -81,6 +81,7 @@ class MetadataView(MetadataCopyIntersectionsView):
         # Annotate
         qs = self.annotate_order_aggregates(qs)
         qs = self.annotate_card_aggregates(qs)
+        qs = self.annotate_cover(qs)
         qs = self.annotate_values_and_fks(qs, filtered_qs)
         qs = self.add_group_by(qs)
         qs = self.force_inner_joins(qs)

--- a/codex/views/browser/metadata/annotate.py
+++ b/codex/views/browser/metadata/annotate.py
@@ -4,7 +4,7 @@ from django.db.models import Count, IntegerField, Sum, Value
 from django.db.models.query import QuerySet
 
 from codex.models import Comic
-from codex.views.browser.annotate.card import BrowserAnnotateCardView
+from codex.views.browser.annotate.cover import BrowserAnnotateCoverView
 from codex.views.browser.metadata.const import (
     ADMIN_OR_FILE_VIEW_ENABLED_COMIC_VALUE_FIELDS,
     COMIC_RELATED_VALUE_FIELDS,
@@ -16,7 +16,7 @@ from codex.views.browser.metadata.const import (
 )
 
 
-class MetadataAnnotateView(BrowserAnnotateCardView):
+class MetadataAnnotateView(BrowserAnnotateCoverView):
     """Metadata Annotations."""
 
     def _get_comic_value_fields(self) -> tuple:

--- a/frontend/src/components/metadata/metadata-cover.vue
+++ b/frontend/src/components/metadata/metadata-cover.vue
@@ -10,6 +10,8 @@
       id="bookCover"
       :group="group"
       :pks="md.ids"
+      :cover-pk="md.coverPk"
+      :cover-custom-pk="md.coverCustomPk"
       :child-count="md.childCount"
       :mtime="md.mtime"
     />


### PR DESCRIPTION
## Summary

Every metadata dialog cover loaded \`/api/v3/c/0/cover.webp\` and rendered the missing-cover placeholder.

Stage 3's follow-up ([#579](https://github.com/ajslater/codex/pull/579), 2ff08524) dropped the legacy \`group+pks\` fallback from the frontend \`getCoverSrc()\` helper — it now builds per-pk URLs exclusively from \`coverPk\` / \`coverCustomPk\`. But the metadata endpoint was never wired into \`annotate_cover()\`, and \`metadata-cover.vue\` never forwarded the cover pks to \`BookCover\`. Result: both defaulted to 0.

Fix walks the annotation + serializer + component chain end-to-end:

- \`MetadataAnnotateView\` now inherits from \`BrowserAnnotateCoverView\` so \`annotate_cover()\` is available.
- \`MetadataView.get_object()\` calls \`annotate_cover(qs)\` after \`annotate_card_aggregates(qs)\` (same ordering as \`browser.py\`).
- \`MetadataSerializer\` exposes \`cover_pk\` / \`cover_custom_pk\` \`SerializerMethodField\`s with the same fallback-to-\`obj.pk\` semantics \`BrowserCardSerializer\` uses — so Comic metadata (\`group=c\`) works without annotation.
- \`metadata-cover.vue\` forwards \`md.coverPk\` / \`md.coverCustomPk\` into \`BookCover\`.

## Verification

| endpoint | coverPk before | coverPk after |
|---|---|---|
| \`/api/v3/p/6/metadata\` | 0 | 557 |
| \`/api/v3/i/41/metadata\` | 0 | 557 |
| \`/api/v3/s/325/metadata\` | 0 | 1451 |
| \`/api/v3/v/352/metadata\` | 0 | 1451 |
| \`/api/v3/f/2569/metadata\` | 0 | 13060 |
| \`/api/v3/c/10785/metadata\` | 0 | 10785 (fallback) |

No SQL query delta on \`flow_c_series_metadata\` (31 queries cold, same as before) — \`annotate_cover\` is a correlated \`Subquery\` that inlines into the outer SELECT.

## Test plan

- [x] \`uv run ruff check codex/views/browser/metadata/ codex/serializers/browser/metadata.py\`
- [x] \`uv run --group test pytest tests/ -q\` (20 passed)
- [x] Smoke: \`GET /api/v3/{p,i,s,v,f}/*/metadata\` → \`coverPk\` populated
- [x] Smoke: \`GET /api/v3/c/*/metadata\` → \`coverPk\` falls back to comic pk
- [x] Perf baseline unchanged on flow_c (31 cold SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)