### PR TITLE
Fix folder + FTS crash and preserve rank-ordered cover selection

### DIFF
--- a/codex/models/functions.py
+++ b/codex/models/functions.py
@@ -86,3 +86,21 @@ class ComicFTSRank(Func):
     def __init__(self, *args, **kwargs) -> None:
         """output_field is set in the constructor."""
         super().__init__(*args, output_field=FloatField(), **kwargs)
+
+    @override
+    def as_sql(self, compiler, connection, **extra_context):
+        """
+        Resolve ``codex_comicfts`` to its query-local alias.
+
+        In a top-level browse query Django references ``codex_comicfts`` by
+        its table name, and the literal ``template`` works. Inside a nested
+        correlated subquery (e.g. the cover_pk subquery) Django aliases the
+        join as ``V4`` / ``U1``, and ``codex_comicfts.rank`` becomes an
+        unresolvable column reference. Look up whatever alias the current
+        query has assigned to ``codex_comicfts`` and emit that instead.
+        """
+        alias_map = compiler.query.alias_map
+        for alias, join in alias_map.items():
+            if getattr(join, "table_name", None) == "codex_comicfts":
+                return f'("{alias}"."rank" * -1)', []
+        return super().as_sql(compiler, connection, **extra_context)

--- a/codex/views/browser/annotate/cover.py
+++ b/codex/views/browser/annotate/cover.py
@@ -72,7 +72,13 @@ class BrowserAnnotateCoverView(BrowserAnnotateCardView):
         q = self._cover_filter_q(group_model)
         qs = Comic.objects.filter(q).distinct()
         qs = self.annotate_order_aggregates(qs, for_cover=True)
-        qs = self.add_order_by(qs)
+        # ``search_score`` relies on ``codex_comicfts.rank``, but the cover
+        # subquery filters FTS via a non-correlated ``pk__in`` over the
+        # pre-materialized match set — it never joins ``codex_comicfts``.
+        # Fall back to ``sort_name`` so SQLite has a real column to order on;
+        # the cover's tie-break isn't user-visible anyway.
+        cover_order_key = "sort_name" if self.order_key == "search_score" else ""
+        qs = self.add_order_by(qs, order_key=cover_order_key)
         return Subquery(qs.values("pk")[:1])
 
     def _cover_custom_subquery(self, group_model) -> Subquery | None:

--- a/codex/views/browser/annotate/cover.py
+++ b/codex/views/browser/annotate/cover.py
@@ -58,13 +58,21 @@ class BrowserAnnotateCoverView(BrowserAnnotateCardView):
         include_q, exclude_q, fts_q = self.get_search_filters(Comic)
         q &= include_q & ~exclude_q
         if fts_q:
-            # FTS MATCH inside a correlated Subquery re-scans the FTS5
-            # virtual table per outer row (~900ms on a 100-group page).
-            # Replace with a non-correlated sub-SELECT over the FTS match
-            # set — SQLite materializes it once and the correlated cover
-            # subquery becomes a simple indexed pk lookup.
+            # pk__in over the pre-materialized FTS match set: SQLite
+            # materializes this sub-SELECT once, giving the correlated cover
+            # subquery a cheap indexed membership test instead of re-scanning
+            # the FTS5 virtual table per outer group row for the filter.
             fts_sq = Comic.objects.filter(fts_q).values("pk")
             q &= Q(pk__in=fts_sq)
+            # Also apply fts_q directly: this forces a JOIN to
+            # ``codex_comicfts`` with MATCH active, populating
+            # ``codex_comicfts.rank`` so ``search_score=ComicFTSRank()`` is
+            # resolvable in the cover subquery's ORDER BY. Without this, the
+            # cover picked for a group would be arbitrary among the FTS
+            # matches rather than the highest-ranked one. The MATCH is
+            # constant across outer rows, so SQLite's planner typically
+            # hoists / shares it with the pre-materialized ``fts_sq``.
+            q &= fts_q
         return q
 
     def _cover_comic_subquery(self, group_model) -> Subquery:
@@ -72,13 +80,7 @@ class BrowserAnnotateCoverView(BrowserAnnotateCardView):
         q = self._cover_filter_q(group_model)
         qs = Comic.objects.filter(q).distinct()
         qs = self.annotate_order_aggregates(qs, for_cover=True)
-        # ``search_score`` relies on ``codex_comicfts.rank``, but the cover
-        # subquery filters FTS via a non-correlated ``pk__in`` over the
-        # pre-materialized match set — it never joins ``codex_comicfts``.
-        # Fall back to ``sort_name`` so SQLite has a real column to order on;
-        # the cover's tie-break isn't user-visible anyway.
-        cover_order_key = "sort_name" if self.order_key == "search_score" else ""
-        qs = self.add_order_by(qs, order_key=cover_order_key)
+        qs = self.add_order_by(qs)
         return Subquery(qs.values("pk")[:1])
 
     def _cover_custom_subquery(self, group_model) -> Subquery | None:

--- a/codex/views/browser/annotate/order.py
+++ b/codex/views/browser/annotate/order.py
@@ -204,21 +204,20 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
     def _annotate_search_scores(self, qs, *, for_cover: bool = False):
         """Annotate Search Scores."""
         if (
-            # ``ComicFTSRank`` dereferences ``codex_comicfts.rank``. The cover
-            # subquery filters via a non-correlated ``pk__in fts_sq`` (FTS
-            # pre-materialization), so ``codex_comicfts`` is never joined to
-            # the Comic subquery; annotating search_score there would fail
-            # with ``no such column: codex_comicfts.rank`` when SQLite tries
-            # to resolve the ORDER BY.
-            for_cover
-            or self.TARGET not in self._COVER_AND_CARD_TARGETS
+            self.TARGET not in self._COVER_AND_CARD_TARGETS
             or self.order_key != "search_score"
         ):
             return qs
 
-        # Rank is always the max of the relations, cannot aggregate?
-        # group by here fixes duplicates with story_arc, probably because it's a long relation
-        return qs.annotate(search_score=ComicFTSRank()).group_by("id")
+        qs = qs.annotate(search_score=ComicFTSRank())
+        # ``group_by`` dedupes rows that join long relations (e.g.
+        # story_arc) from the outer browse query. The cover subquery is
+        # already ``.distinct() ... LIMIT 1`` and the custom force-group-by
+        # emits a literal ``"codex_comic"."id"`` that does not survive the
+        # nested-subquery aliasing — skip it in the cover path.
+        if not for_cover:
+            qs = qs.group_by("id")
+        return qs
 
     def annotate_child_count(self, qs):
         """Annotate child count."""

--- a/codex/views/browser/annotate/order.py
+++ b/codex/views/browser/annotate/order.py
@@ -201,10 +201,17 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
             qs = qs.annotate(bookmark_updated_at=bmua_agg)
         return qs
 
-    def _annotate_search_scores(self, qs):
+    def _annotate_search_scores(self, qs, *, for_cover: bool = False):
         """Annotate Search Scores."""
         if (
-            self.TARGET not in self._COVER_AND_CARD_TARGETS
+            # ``ComicFTSRank`` dereferences ``codex_comicfts.rank``. The cover
+            # subquery filters via a non-correlated ``pk__in fts_sq`` (FTS
+            # pre-materialization), so ``codex_comicfts`` is never joined to
+            # the Comic subquery; annotating search_score there would fail
+            # with ``no such column: codex_comicfts.rank`` when SQLite tries
+            # to resolve the ORDER BY.
+            for_cover
+            or self.TARGET not in self._COVER_AND_CARD_TARGETS
             or self.order_key != "search_score"
         ):
             return qs
@@ -266,7 +273,7 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
         # subquery on BrowserView card annotation.
         if not for_cover:
             qs = qs.annotate(ids=JsonGroupArray("id", distinct=True, order_by="id"))
-        qs = self._annotate_search_scores(qs)
+        qs = self._annotate_search_scores(qs, for_cover=for_cover)
         qs = self._alias_sort_names(qs)
         qs = self._alias_filename(qs)
         qs = self._alias_story_arc_number(qs)


### PR DESCRIPTION
## Summary

Browsing any group with an FTS search and `orderBy=search_score` crashed with:

```
sqlite3.OperationalError: no such column: codex_comicfts.rank
```

…and even if the crash were patched, the cover chosen for each group card would not reflect the FTS rank — so users searching for `batman` on a Publisher page might see an alphabetically-first match rather than the top-ranked Batman issue.

### Root cause

Stage 3's cover fan-out builds a correlated Comic subquery per group card to pick `cover_pk`. The Stage 3 follow-up (#579) replaced the correlated `comicfts__match` filter with a non-correlated `pk__in fts_sq` pre-materialization — so the Comic subquery no longer joins `codex_comicfts`. But `annotate_order_aggregates` still annotated `search_score=ComicFTSRank()` on that subquery and `add_order_by` issued `ORDER BY "codex_comicfts"."rank" * -1` — which SQLite couldn't resolve from the subquery's FROM list.

On top of that, `ComicFTSRank.template` and the custom `.group_by("id")` compiler both emit literal table names. In a nested subquery Django aliases `codex_comicfts` as `V4` / `codex_comic` as `V0`, so even after the join was restored, literal references broke.

### Fix

- `_cover_filter_q` now applies `fts_q` directly **in addition to** `pk__in fts_sq`. The pre-materialized membership test keeps the filter cheap, and the `comicfts__match` Q forces a join to `codex_comicfts` with `rank` populated.
- `ComicFTSRank.as_sql` looks up the query-local alias for `codex_comicfts` in the compiler's alias map and emits `("V4"."rank" * -1)` instead of the unqualified literal. Top-level queries still work because the fallback returns the original template.
- `_annotate_search_scores` still takes `for_cover` but now only uses it to skip `.group_by("id")` in the cover path — the force-group-by compiler also emits a literal `"codex_comic"."id"` that fails under nested aliasing, and the cover subquery is already `.distinct() … LIMIT 1`.
- `_cover_comic_subquery` no longer falls back to `sort_name`; it uses the user's `order_key` so `search_score` picks the top-ranked comic per card.

### Verified

For each of the first four publishers returned by `GET /api/v3/r/0/1?q=batman&orderBy=search_score`, the annotated `coverPk` matches the top-ranked comic returned by a direct `ComicFTSRank` ordering within that publisher:

| Publisher | coverPk | top-rank pk | match |
|-----------|---------|-------------|-------|
| Foo | 16565 | 16565 | ✅ |
| Bar | 15956 | 15956 | ✅ |
| Cat | 16686 | 16686 | ✅ |
| Mavis | 10785 | 10785 | ✅ |

## Test plan

- [x] Original crash URL: `GET /api/v3/f/0/1?q=batman&orderBy=search_score` → HTTP 200
- [x] `GET /api/v3/{r,s,f}/0/1?q=batman&orderBy=search_score` all → HTTP 200
- [x] `GET /api/v3/{p,s,f}/<pk>/metadata` → 200, populated `coverPk`
- [x] Non-FTS browsing (`GET /api/v3/r/0/1`) → 200, unchanged
- [x] `uv run ruff check codex/models/functions.py codex/views/browser/annotate/`
- [x] `uv run pytest tests/ --ignore=tests/perf --ignore=tests/importer` → 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)