### PR TITLE
Raise RLIMIT_NOFILE on startup to avoid macOS 256 FD cap

### DIFF
--- a/codex/run.py
+++ b/codex/run.py
@@ -58,6 +58,33 @@ def codex_shutdown() -> None:
         restart()
 
 
+def _raise_fd_limit() -> None:
+    """
+    Raise RLIMIT_NOFILE soft limit toward the hard cap.
+
+    macOS ships a 256 soft cap for RLIMIT_NOFILE which a cold burst of ~100
+    parallel cover requests can easily exhaust: each Django thread keeps a
+    sticky SQLite connection (CONN_MAX_AGE=600) and SQLite WAL mode opens
+    3 FDs per connection (main + -wal + -shm). Bumping the soft limit is a
+    non-invasive equivalent to running with ``ulimit -Sn 8192``.
+    No-op on platforms without the resource module (e.g. Windows).
+    """
+    try:
+        import resource
+    except ImportError:
+        return
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = 8192 if hard == resource.RLIM_INFINITY else min(hard, 8192)
+    if soft >= target:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+    except (OSError, ValueError) as exc:
+        logger.warning(f"Could not raise RLIMIT_NOFILE from {soft}: {exc}")
+        return
+    logger.debug(f"Raised RLIMIT_NOFILE soft limit: {soft} → {target}")
+
+
 def _build_server() -> Server:
     """
     Build the granian embedded server.
@@ -115,6 +142,7 @@ def main() -> None:
     """Set up and run Codex."""
     logger.debug(f"Starting {PACKAGE_NAME}")
     setproctitle(PACKAGE_NAME)
+    _raise_fd_limit()
     loguru_init()
     if codex_startup():
         run()


### PR DESCRIPTION
## Summary

- Bump `RLIMIT_NOFILE` soft limit toward the hard cap (or 8192, whichever is lower) at process start.
- Fixes intermittent `OSError: [Errno 24] Too many open files` when a cold browser session loads a 100-card grid in dev.
- Linux is unaffected (already runs with a high soft limit); macOS dev gets the meaningful relief.

## Diagnosis

Cold browser session triggers ~100 simultaneous cover requests. Trace of an idle codex process on macOS:

| Resource | FDs |
|---|---|
| `codex.sqlite3` (main) | 36 |
| `codex.sqlite3-wal` | 35 |
| `codex.sqlite3-shm` | 2 |
| `silk.sqlite3` | 8 |
| **SQLite at idle** | **~81** |

The math:

- macOS soft cap: `ulimit -Sn` = **256**
- Each Django thread keeps a sticky SQLite connection (`CONN_MAX_AGE=600`).
- SQLite WAL mode opens 3 FDs per connection (`main` + `-wal` + `-shm`).
- The thin cover endpoint dispatches to a `sync_to_async` threadpool. A burst of 100 cold cover requests spawns ~100 threads → ~300 SQLite FDs.
- ~300 FDs > 256 cap → EMFILE before page reads even start.

Bumping `RLIMIT_NOFILE` is the non-invasive equivalent of running `ulimit -Sn 8192` in the launcher shell.

## Implementation

`codex/run.py` gains `_raise_fd_limit()`, called from `main()` before `loguru_init()`:

- Imports `resource` defensively (no-op on Windows / platforms without it).
- Raises soft to `min(hard, 8192)` only when soft is below target.
- Logs a debug line on success, a warning on `OSError`/`ValueError`.

Smoke test confirms: simulated `(256, INF)` → `(8192, INF)`.

## Test plan

- [x] `make lint-python` clean (ruff, basedpyright, vulture, complexipy, codespell).
- [x] `make test-python` — 20 passed.
- [x] Smoke test the function directly with a forced 256 soft cap → bumps to 8192.
- [ ] Reload dev server, spam cold-burst cover loads, confirm no `EMFILE`.

## Follow-ups (not for this PR)

- Audit librarian/cron threads holding SQLite connections at idle (~35 connections is high).
- Consider a lower `CONN_MAX_AGE` on dev to reduce thread-local connection stickiness; weigh against per-request connection setup cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)