### PR TITLE
Browser views perf: Stage 5b — annotation gating + m2m-aware distinct

### DIFF
--- a/codex/views/browser/annotate/card.py
+++ b/codex/views/browser/annotate/card.py
@@ -70,6 +70,14 @@ class BrowserAnnotateCardView(BrowserAnnotateBookmarkView):
         qs = self.annotate_bookmarks(qs)
         qs = self.annotate_progress(qs)
         qs = self._annotate_has_metadata(qs)
+        # ``updated_ats`` is read only by ``BrowserAggregateSerializerMixin``
+        # to compute the card mtime — and only browser + metadata responses
+        # use that mixin. OPDS feeds compute their own mtime from the
+        # bookmark aggregate; cover/download paths never read it. Skipping
+        # the JsonGroupArray on those targets removes one DISTINCT scalar
+        # aggregate per group row in the cold path.
+        if self.TARGET not in self.CARD_TARGETS:
+            return qs
         # For group models, traverse to Comic.updated_at via rel_prefix.
         # The group model's own updated_at is not reliably refreshed by
         # bulk_update / bulk_create(update_conflicts) because auto_now

--- a/codex/views/browser/annotate/order.py
+++ b/codex/views/browser/annotate/order.py
@@ -215,7 +215,14 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
         # already ``.distinct() ... LIMIT 1`` and the custom force-group-by
         # emits a literal ``"codex_comic"."id"`` that does not survive the
         # nested-subquery aliasing — skip it in the cover path.
-        if not for_cover:
+        if for_cover:
+            return qs
+        # Skip ``group_by("id")`` on Comic queries that don't actually fan out
+        # via an m2m join — there's nothing to dedupe and the GROUP BY just
+        # forces SQLite to materialize an unnecessary aggregate. Non-Comic
+        # queries traverse ``comic__`` (one-to-many) for ACL/group filters
+        # and always need the dedupe.
+        if qs.model is not Comic or self.comic_filter_uses_m2m:
             qs = qs.group_by("id")
         return qs
 

--- a/codex/views/browser/filters/filter.py
+++ b/codex/views/browser/filters/filter.py
@@ -1,10 +1,41 @@
 """Browser Filters."""
 
+from functools import cached_property
+from typing import Final
+
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import Q
 
 from codex.models.comic import Comic
 from codex.views.browser.filters.bookmark import BrowserFilterBookmarkView
+from codex.views.const import FOLDER_GROUP, STORY_ARC_GROUP
+
+# Active filter keys whose ORM rel crosses an m2m or m2m-through relation
+# on Comic. Field-list mirrors ``codex.views.browser.const.BROWSER_FILTER_KEYS``
+# minus the local-column / FK keys (year, decade, country, language,
+# critical_rating, monochrome, original_format, file_type, reading_direction,
+# tagger, age_rating_metron, age_rating_tagged).
+_M2M_FILTER_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "characters",
+        "credits",
+        "genres",
+        "identifier_source",
+        "locations",
+        "series_groups",
+        "stories",
+        "story_arcs",
+        "tags",
+        "teams",
+        "universes",
+    }
+)
+# TARGETs whose folder-group filter resolves to ``folders`` (m2m) or
+# ``comic__folders`` (download) rather than ``parent_folder`` (FK).
+# Mirrors the branches in :meth:`GroupFilterView._get_rel_for_pks`.
+_M2M_FOLDER_GROUP_TARGETS: Final[frozenset[str]] = frozenset(
+    {"cover", "choices", "bookmark", "download"}
+)
 
 
 class BrowserFilterView(BrowserFilterBookmarkView):
@@ -19,6 +50,28 @@ class BrowserFilterView(BrowserFilterBookmarkView):
             # Forcing INNER JOINS required to make fts5 work
             demote_tables.add("codex_comicfts")
         return qs.demote_joins(demote_tables)
+
+    @cached_property
+    def comic_filter_uses_m2m(self) -> bool:
+        """
+        Return True if the filter pipeline forces an m2m join on Comic.
+
+        Drives whether ``.distinct()`` and the ``search_score`` ``group_by("id")``
+        clause need to fire. Non-Comic queries always need them because the
+        ACL filter alone traverses ``comic__`` (one-to-many); for Comic
+        queries we can skip both unless a real m2m relation joins in.
+        """
+        group = self.kwargs.get("group")
+        pks = self.kwargs.get("pks")
+        if pks and 0 not in pks:
+            if group == STORY_ARC_GROUP:
+                # ``story_arc_numbers__story_arc`` is m2m-through on Comic.
+                return True
+            if group == FOLDER_GROUP and self.TARGET in _M2M_FOLDER_GROUP_TARGETS:
+                # ``folders`` / ``comic__folders`` m2m on these targets.
+                return True
+        filters = self.params.get("filters") or {}
+        return any(filters.get(k) for k in _M2M_FILTER_KEYS)
 
     def _get_query_filters(
         self,
@@ -61,5 +114,12 @@ class BrowserFilterView(BrowserFilterBookmarkView):
             group=group,
             pks=pks,
         )
-        # Distinct necessary for folder view with search
-        return model.objects.filter(query_filters).distinct()
+        qs = model.objects.filter(query_filters)
+        # Non-Comic queries traverse ``comic__`` for ACL/group/field filters,
+        # which is one-to-many and produces row duplicates that ``.distinct()``
+        # must collapse. Comic queries only duplicate when a real m2m relation
+        # joins in (story_arc browse, folder browse on cover/choices/bookmark/
+        # download targets, or any m2m field filter).
+        if model is not Comic or self.comic_filter_uses_m2m:
+            qs = qs.distinct()
+        return qs

--- a/tasks/browser-views-perf/05-replan.md
+++ b/tasks/browser-views-perf/05-replan.md
@@ -225,3 +225,93 @@ PR 5b (annotation gating + ACL cache bundle) is still open. Given that 5a alone
 collapsed Flow D warm to 0, the marginal value of 5.2-5.5 on the cover path has
 shrunk — they remain useful for cold paths and for the 202-retry window.
 Re-evaluate priority after 5a ships.
+
+---
+
+## 8. Stage 5b landed — annotation gating + m2m-aware distinct
+
+### What shipped
+
+| Item    | Change                                                                                                                    | File                                    |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **5.2** | Skip the `updated_ats` `JsonGroupArray` annotation entirely outside `CARD_TARGETS = {"browser", "metadata"}`.             | `codex/views/browser/annotate/card.py`  |
+| **5.3** | New `comic_filter_uses_m2m` cached property. Skip `.distinct()` on Comic querysets that don't cross an m2m / m2m-through. | `codex/views/browser/filters/filter.py` |
+| **5.5** | Tie `search_score`'s `group_by("id")` to the same flag — only emit when there's actually fan-out to dedupe.               | `codex/views/browser/annotate/order.py` |
+
+### Why "scalar Max" for 5.2 became "skip entirely"
+
+The replan note proposed swapping the JsonGroupArray for a scalar
+`Max(updated_at)` on non-browser targets. Once the consumers were traced, "skip
+entirely" landed cleaner: `obj.updated_ats` is read in exactly one place
+(`codex.serializers.browser.mixins.BrowserAggregateSerializerMixin.get_mtime`,
+which iterates the aggregate as a list of datetime strings) and that mixin is
+only used by `BrowserCardSerializer` and `MetadataSerializer`. OPDS feeds
+compute their own `mtime` from the `bookmark_updated_at` aggregate; cover and
+download paths never touch it. A scalar Max would just be ignored.
+
+### Why 5.4 didn't ship
+
+The replan called for memoizing `get_acl_filter(model, user)` on `self`.
+`codex/views/auth.py` already caches the three scalar inputs
+(`_cached_visible_library_pks`, `_cached_max_idx`, `_cached_default_fits`) on
+`GroupACLMixin` per request. The remaining cost on `get_acl_filter` is composing
+two trivial `Q` objects from those cached scalars — microseconds, not queries.
+Wrapping a `cached_property` keyed on `(model, user_id)` would be cosmetic.
+
+### m2m detection table
+
+`comic_filter_uses_m2m` is a pure-Python check on `self.kwargs` + `self.params`
+— no DB hit, no SQL inspection. It returns True iff:
+
+- `kwargs.group == STORY_ARC_GROUP` with non-zero `pks` (m2m-through), or
+- `kwargs.group == FOLDER_GROUP` with non-zero `pks` and
+  `TARGET in {"cover", "choices", "bookmark", "download"}` — these targets
+  resolve folder filtering through `folders` / `comic__folders` (m2m) instead of
+  `parent_folder` (FK), per `GroupFilterView._get_rel_for_pks`, or
+- any active filter key is in
+  `{characters, credits, genres, identifier_source, locations, series_groups, stories, story_arcs, tags, teams, universes}`
+  — the BROWSER_FILTER_KEYS that resolve to m2m / m2m-through rels in
+  `_FILTER_REL_MAP`.
+
+20 tabletop cases pass (default-target browses across all groups, all four
+m2m-folder TARGETs, every BROWSER_FILTER_KEY by category, mixed filters,
+`pks=(0,)` early-out).
+
+### Result
+
+`stage5b-after.json` vs. `stage5a-after.json`:
+
+| Flow                    | Cold q / ms (5a) | Cold q / ms (5b) | Warm q / ms (5a) | Warm q / ms (5b) |
+| ----------------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| A — root browse         | 15 / 181         | 15 / 185         | 0 / 1.9          | 0 / 1.8          |
+| B — filtered search     | 16 / 1068        | 16 / 1062        | 0 / 2.0          | 0 / 1.9          |
+| C — series metadata     | 28 / 165         | 28 / 161         | 0 / 1.8          | 0 / 1.9          |
+| C2 — comic metadata     | 47 / 125         | 47 / 126         | 0 / 2.2          | 0 / 1.9          |
+| D — browse + 100 covers | 815 / 1362       | 815 / 1349       | 0 / 266          | 0 / 245          |
+| E — search + 46 covers  | 384 / 1545       | 384 / 1552       | 232 / 331        | 232 / 317        |
+
+Query counts identical (expected — `.distinct()` and `group_by` change SQL
+shape, not query count). Wall-time deltas are within run-to-run noise on the
+existing flow set.
+
+### Where 5b actually wins (not measured by current flows)
+
+The harness flows happen to land on cases the changes don't touch — root browse
+on Publisher (non-Comic; ACL through `comic__` always needs distinct), search on
+Publisher (same), single-row metadata lookups (one row, distinct is a no-op).
+The real wins are on cold paths the harness doesn't currently exercise:
+
+- **Browsing a Series's comic books** (`/api/v3/s/<pk>/<page>` returning Comic
+  cards): Comic queryset, no m2m filter → skips `.distinct()` + skips
+  `group_by("id")` on search.
+- **Folder browse with default browser TARGET**: Comic queryset, group=f, rel is
+  `parent_folder` (FK, not `folders` m2m) → skips `.distinct()`.
+- **OPDS feeds**: skip the `updated_ats` JsonGroupArray entirely.
+
+A follow-up patch should add a "browse a Series" flow to
+`tests/perf/run_baseline.py` to make these gains visible in the artifact.
+
+### Items 5.6 onward
+
+5.6 (choices endpoint) and 5.7 (cleanup bundle) remain open. 5.8 (R3 serializer
+audit) is still investigation-only.

--- a/tasks/browser-views-perf/stage5b-after.json
+++ b/tasks/browser-views-perf/stage5b-after.json
@@ -1,0 +1,106 @@
+{
+  "series_pk_used": 325,
+  "comic_pk_used": 10785,
+  "flows": [
+    {
+      "name": "flow_a_root_browse",
+      "description": "Root browse, no filters, no search.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 15,
+        "time_taken_ms": 184.98899999999998
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.795
+      }
+    },
+    {
+      "name": "flow_b_filtered_search",
+      "description": "Root browse with a search term.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 16,
+        "time_taken_ms": 1062.0629999999999
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.909
+      }
+    },
+    {
+      "name": "flow_c_series_metadata",
+      "description": "Metadata detail for the largest series.",
+      "kind": "url",
+      "url": "/api/v3/s/325/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 28,
+        "time_taken_ms": 161.315
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.907
+      }
+    },
+    {
+      "name": "flow_c2_comic_metadata",
+      "description": "Metadata detail for a single rich comic (exercises FK + M2M hydration).",
+      "kind": "url",
+      "url": "/api/v3/c/10785/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 47,
+        "time_taken_ms": 126.287
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.85
+      }
+    },
+    {
+      "name": "flow_d_browse_plus_covers",
+      "description": "Root browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 815,
+        "total_time_ms": 1349.32
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 0,
+        "total_time_ms": 244.643
+      }
+    },
+    {
+      "name": "flow_e_search_plus_covers",
+      "description": "Search browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 384,
+        "total_time_ms": 1552.058
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 232,
+        "total_time_ms": 316.99
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Stage 5b of the browser-views perf pass. Three small, behavior-preserving gates that strip work from the cold ORM pipeline when the query shape doesn't actually need it:

- **5.2 — `updated_ats` JsonGroupArray gated to browser/metadata.**
  `obj.updated_ats` is read only by `BrowserAggregateSerializerMixin.get_mtime`, which only the browser card and metadata serializers use. OPDS feeds compute their own mtime from the bookmark aggregate; cover/download paths never read it. Skipping the `JsonGroupArray(updated_at, distinct=True, ...)` annotation on those targets removes one DISTINCT scalar aggregate per group row in the cold path.

- **5.3 — m2m-aware `.distinct()`.**
  Comic querysets only need `.distinct()` when the filter pipeline forces an actual m2m / m2m-through join. New `BrowserFilterView.comic_filter_uses_m2m` cached_property detects that case (story_arc browse, folder browse on cover/choices/bookmark/download targets, or any of 11 m2m field filters) and `get_filtered_queryset` only attaches `.distinct()` when it'll actually do work. Non-Comic models still always distinct because ACL traverses `comic__` (one-to-many).

- **5.5a — `search_score` `group_by(\"id\")` gated on the same flag.**
  Same logic: the GROUP BY only dedupes rows on m2m fan-out. Without an m2m join there's nothing to dedupe and SQLite materializes a needless aggregate. The `for_cover` skip (subquery-aliasing edge case) is preserved.

**Why no 5.4 (ACL cache bundle).** `GroupACLMixin.init_group_acl` already caches `_cached_visible_library_pks`, `_cached_max_idx`, and `_cached_default_fits` on the view instance, and `get_acl_filter` composes the `Q` from those scalars. There's no scope per-request work left to bundle. Verified by reading `codex/views/auth.py`.

## Verification

- `make lint-python`: clean.
- `make test-python`: 20/20 pass.
- Standalone m2m-detection harness: 20/20 cases pass (story_arc / folder-target / m2m-filter / FK-only / non-Comic combinations).
- Perf capture: `tasks/browser-views-perf/stage5b-after.json` vs `stage5a-after.json`. Cold query counts identical, wall times within noise.

| flow | 5a cold queries → ms | 5b cold queries → ms |
|---|---|---|
| flow_a_root_browse | 15 → 181.1 | 15 → 184.9 |
| flow_b_filtered_search | 16 → 1068.0 | 16 → 1062.1 |
| flow_c_series_metadata | 28 → 165.5 | 28 → 161.3 |
| flow_c2_comic_metadata | 47 → 124.7 | 47 → 126.3 |
| flow_d_browse_plus_covers | 815 → 1362.7 | 815 → 1349.3 |
| flow_e_search_plus_covers | 384 → 1544.8 | 384 → 1552.1 |

**Where 5b actually wins (and why the harness flows don't show it).** The current flows hit non-Comic root browses (Publisher), single-row metadata, and cover paths that go through `cover_subquery` — none of those exercise `get_filtered_queryset` on a Comic queryset with an m2m-free filter. The wins land on:

- Series-comic browse (Comic queryset, no m2m unless a tag/character/etc. filter is set) — drops `.distinct()` and the `search_score` GROUP BY.
- Default-target folder browse (Comic via `parent_folder` FK, not `folders` m2m) — same.
- OPDS feed responses for those same shapes — also drops the `updated_ats` JsonGroupArray.

A follow-up should extend `tests/perf/run_baseline.py` with a Series-comic browse flow to make these gains visible. Tracked in `tasks/browser-views-perf/05-replan.md` Section 8.

## Test plan

- [x] `make lint-python` clean
- [x] `make test-python` 20/20
- [x] Standalone m2m-detection cases 20/20
- [x] Perf capture before/after on the existing harness flows
- [ ] Follow-up: add a Series-comic browse perf flow to actually measure 5b's gains

🤖 Generated with [Claude Code](https://claude.com/claude-code)