### PR TITLE
Browser views perf: Stage 5c — batched choices_available

### DIFF
--- a/codex/views/browser/choices.py
+++ b/codex/views/browser/choices.py
@@ -5,7 +5,7 @@ from types import MappingProxyType
 from typing import Any, override
 
 from caseconverter import snakecase
-from django.db.models import F, QuerySet
+from django.db.models import Exists, F, QuerySet
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
@@ -74,6 +74,9 @@ _BACK_REL_MAP = MappingProxyType(
 )
 _NULL_NAMED_ROW = MappingProxyType({"pk": VUETIFY_NULL_CODE, "name": DUMMY_NULL_NAME})
 _NULL_NAMED_ROW_ITERABLE = (_NULL_NAMED_ROW,)
+# We only need to know whether an m2m relation has two or more distinct
+# non-null values; ``[:2]`` is enough to distinguish 0/1/>=2 cases.
+_M2M_DISTINCT_PROBE_LIMIT = 2
 
 
 class BrowserChoicesViewBase(BrowserFilterView):
@@ -133,55 +136,117 @@ class BrowserChoicesAvailableView(BrowserChoicesViewBase):
 
     serializer_class: type[BaseSerializer] | None = BrowserFilterChoicesSerializer
 
-    @classmethod
-    def _is_field_choices_exists(cls, comic_qs, field_name) -> bool:
-        """Create a pk:name object for fields without tables."""
-        qs = cls.get_field_choices_query(comic_qs, field_name)
-        return qs.exists()
+    @staticmethod
+    def _has_two_distinct_m2m_values(comic_qs: QuerySet, rel: str) -> bool:
+        """
+        Return True iff ``rel`` resolves to >= 2 distinct non-null values.
 
-    def _is_m2m_field_choices_exists(self, model, comic_qs, rel) -> bool:
-        """Get choices with nulls where there are nulls."""
-        qs = self.get_m2m_field_query(model, comic_qs)
-        qs = qs[:2]
-        count = qs.count()
-        if count > 1:
-            # There are choices
-            return True
-        if count == 1:
-            # There are only choices if a null exists
-            return self.does_m2m_null_exist(comic_qs, rel)
-        # There is only one or no choices.
-        return False
+        The natural ``EXISTS(SELECT DISTINCT rel ... LIMIT 1 OFFSET 1)`` form
+        is broken on SQLite: ``EXISTS`` short-circuits on the first row from
+        the underlying join, before ``DISTINCT`` collapses or ``OFFSET``
+        skips. Materializing the first two distinct values via Python and
+        checking length sidesteps the bug while still capping work at two
+        rows scanned.
+        """
+        first_two = list(
+            comic_qs.filter(**{f"{rel}__isnull": False})
+            .values_list(rel, flat=True)
+            .distinct()[:_M2M_DISTINCT_PROBE_LIMIT]
+        )
+        return len(first_two) >= _M2M_DISTINCT_PROBE_LIMIT
 
-    def _is_filter_field_choices_exists(self, qs: QuerySet, field_name: str) -> bool:
-        rel, m2m_model = self.get_rel_and_model(field_name)
+    def _build_field_probes(
+        self, qs: QuerySet
+    ) -> tuple[dict[str, bool], dict[str, Exists], dict[str, str]]:
+        """
+        Walk the dynamic filter fields and partition them into probe groups.
 
-        if m2m_model:
-            exists = self._is_m2m_field_choices_exists(m2m_model, qs, rel)
-        else:
-            exists = self._is_field_choices_exists(qs, field_name)
-        try:
-            flag = exists
-        except TypeError:
-            flag = False
-        return flag
+        Returns ``(early_data, aggregates, m2m_specs)``:
 
-    @override
-    def get_object(self) -> dict[str, Any]:  # pyright: ignore[reportIncompatibleMethodOverride], # ty: ignore[invalid-method-override]
-        """Get choice counts."""
-        qs = super().get_object()
-        filters = self.params.get("filters", {})
-        data = {}
+        * ``early_data`` — fields whose availability is decided without SQL
+          (story-arc browse skip, active filter shortcuts).
+        * ``aggregates`` — kwargs for the batched ``EXISTS`` annotate call.
+          FK fields use their public ``field_name``; m2m fields contribute
+          ``_has_<name>`` and ``_null_<name>`` underscored keys.
+        * ``m2m_specs`` — ``field_name -> rel`` for fields that need the
+          post-aggregate resolve step.
+        """
+        filters = self.params.get("filters") or {}
+        early_data: dict[str, bool] = {}
+        aggregates: dict[str, Exists] = {}
+        m2m_specs: dict[str, str] = {}
         serializer: BrowserFilterChoicesSerializer = self.serializer_class()  # pyright: ignore[reportOptionalCall, reportAssignmentType], # ty: ignore[call-non-callable, invalid-assignment]
         for field_name in serializer.get_fields():
             if field_name == "story_arcs" and qs.model is StoryArc:
                 # don't allow filtering on story arc in story arc view.
                 continue
             if bool(filters.get(field_name)):
-                flag = True
+                # Active filter on this dimension — the user is already
+                # filtering by it, so it must be available.
+                early_data[field_name] = True
+                continue
+            rel, m2m_model = self.get_rel_and_model(field_name)
+            if m2m_model is None:
+                # FK on Comic: legacy semantic is "any non-null value exists".
+                aggregates[field_name] = Exists(
+                    qs.filter(**{f"{field_name}__isnull": False}).values("pk")[:1]
+                )
             else:
-                flag = self._is_filter_field_choices_exists(qs, field_name)
-            data[field_name] = flag
+                # m2m / m2m-through: legacy semantic is "(distinct rels >= 2)
+                # OR (>= 1 rel AND a null sibling)". Decompose into two
+                # cheap EXISTS booleans; the rarer "1 rel, 0 null" case
+                # falls back to a per-field distinct-count probe below.
+                m2m_specs[field_name] = rel
+                aggregates[f"_has_{field_name}"] = Exists(
+                    qs.filter(**{f"{rel}__isnull": False}).values("pk")[:1]
+                )
+                aggregates[f"_null_{field_name}"] = Exists(
+                    qs.filter(**{f"{rel}__isnull": True}).values("pk")[:1]
+                )
+        return early_data, aggregates, m2m_specs
+
+    def _resolve_m2m_field(
+        self, qs: QuerySet, field_name: str, rel: str, row: dict[str, Any]
+    ) -> bool:
+        """Resolve one m2m field from the (has_rel, has_null) booleans."""
+        has_rel = bool(row.get(f"_has_{field_name}"))
+        if not has_rel:
+            return False
+        if bool(row.get(f"_null_{field_name}")):
+            return True
+        return self._has_two_distinct_m2m_values(qs, rel)
+
+    @override
+    def get_object(self) -> dict[str, Any]:  # pyright: ignore[reportIncompatibleMethodOverride], # ty: ignore[invalid-method-override]
+        """Get choice availability for all dynamic filter fields in one query."""
+        qs = super().get_object()
+        data, aggregates, m2m_specs = self._build_field_probes(qs)
+        if aggregates:
+            # One SQL round-trip: pin a 1-row anchor on Comic and let SQLite
+            # evaluate every EXISTS subquery in one shot. The anchor row's
+            # pk is irrelevant — only the subqueries' booleans matter, and
+            # the EXISTS clauses are uncorrelated to the outer row.
+            row = (
+                qs.model.objects.values("pk")
+                .annotate(**aggregates)
+                .values(*aggregates.keys())
+                .first()
+            ) or {}
+        else:
+            row = {}
+
+        # FK fields drop straight in by their public name.
+        data.update(
+            {
+                name: bool(row.get(name))
+                for name in aggregates
+                if not name.startswith("_")
+            }
+        )
+        # m2m fields fan out from the (has_rel, has_null) booleans, with a
+        # distinct-count probe only for the (has_rel, ¬has_null) corner.
+        for field_name, rel in m2m_specs.items():
+            data[field_name] = self._resolve_m2m_field(qs, field_name, rel, row)
         return data
 
 

--- a/tasks/browser-views-perf/05-replan.md
+++ b/tasks/browser-views-perf/05-replan.md
@@ -315,3 +315,79 @@ A follow-up patch should add a "browse a Series" flow to
 
 5.6 (choices endpoint) and 5.7 (cleanup bundle) remain open. 5.8 (R3 serializer
 audit) is still investigation-only.
+
+---
+
+## 9. Stage 5c landed — choices_available batching
+
+### What shipped
+
+| Item    | Change                                                                                                                                                                                                       | File                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| **5.6** | Replace the per-field existence loop in `BrowserChoicesAvailableView.get_object` with a single batched `EXISTS` annotate. FK fields keep "any non-null exists" semantics; m2m fields decompose into (has_rel, has_null) booleans plus a lazy distinct-count probe for the rare `has_rel ∧ ¬has_null` corner. | `codex/views/browser/choices.py`      |
+| Harness | Add `flow_f_choices_available`, `flow_g_choices_field_m2m`, `flow_h_choices_field_fk` to make the changed code path visible in the artifact. | `tests/perf/run_baseline.py`          |
+
+### Why batched + lazy instead of pure single-query
+
+The natural `EXISTS(SELECT DISTINCT rel ... LIMIT 1 OFFSET 1)` formulation
+collapses on SQLite: `EXISTS` short-circuits on the first row produced by the
+join, before `DISTINCT` collapses or `OFFSET` skips. That made a "true single
+SQL probe per m2m field" form return wrong booleans (every m2m field reported
+True regardless of distinct count). The fix splits the m2m semantic into two
+cheap booleans:
+
+* `has_rel` — `EXISTS(qs.filter(rel__isnull=False))`
+* `has_null` — `EXISTS(qs.filter(rel__isnull=True))`
+
+These compose:
+
+* `¬has_rel` → False (no related rows at all).
+* `has_rel ∧ has_null` → True (≥ 1 rel + a null sibling = effective count ≥ 2).
+* `has_rel ∧ ¬has_null` → distinct-count probe (`values_list(rel)[:2]` capped
+  at two rows) decides between 1-and-only and ≥ 2 distinct rels.
+
+In practice the third branch fires rarely — most m2m relations on a real
+library have at least one comic without a related row, so the (has_rel,
+has_null) booleans alone resolve the field. On the dev DB none of the 12 m2m
+fields hit the distinct-count probe.
+
+### Why no batched ACL/setup elimination
+
+The 11-query cold-path floor on `choices_available` is the per-request setup
+the view shares with `BrowserView` (session read, AdminFlag, library
+visibility 4×, age-rating max, ACL filter pipeline 5.3-style). That's already
+amortized inside `AuthFilterAPIView`/`GroupACLMixin` and was scoped out of
+Stage 5b in §8. Stage 5d (cleanup bundle) is the next time those would
+plausibly come up.
+
+### Result
+
+`stage5c-after.json` vs. `stage5c-before.json`:
+
+| Flow                          | Cold q / ms (before)  | Cold q / ms (after)    |
+| ----------------------------- | --------------------- | ---------------------- |
+| **f — choices_available**     | **34 / 121.4**        | **11 / 53.5** (−68% q) |
+| g — choices/characters (m2m)  | 12 / 218.8            | 12 / 197.2             |
+| h — choices/year (FK)         | 11 / 26.0             | 11 / 52.7              |
+| a — root browse               | 15 / 179.9            | 15 / 181.7             |
+| b — filtered search           | 16 / 1046.3           | 16 / 1068.8            |
+| c — series metadata           | 28 / 158.3            | 28 / 167.3             |
+| c2 — comic metadata           | 47 / 124.7            | 47 / 137.1             |
+| d — browse + 100 covers       | 815 / 1353.1          | 815 / 1411.1           |
+| e — search + 46 covers        | 384 / 1520.5          | 384 / 1557.1           |
+
+Headline: `choices_available` cold path drops 23 queries (one per filter
+dimension folded into the batched `EXISTS` annotate). Wall time drops by
+~half. Single-field `choices/<field>` endpoints are unchanged because they
+weren't part of the batched fix; their per-call cost is already low (1 query
++ setup) and they're hit lazily as the user expands sidebar sections.
+
+The single-field `choices/year` wall-time went up (26 → 53 ms) — within
+run-to-run noise on a 26 ms baseline; query count is identical. Re-runs
+straddle the 30-50 ms range.
+
+### Items 5.7 onward
+
+5.7 (cleanup bundle) and 5.8 (R3 serializer audit) remain open. The
+"browse-a-Series" flow noted in §8 still hasn't shipped — should bundle with
+5.7 if it lands as a perf-harness-only patch.

--- a/tasks/browser-views-perf/stage5c-after.json
+++ b/tasks/browser-views-perf/stage5c-after.json
@@ -1,0 +1,154 @@
+{
+  "series_pk_used": 325,
+  "comic_pk_used": 10785,
+  "flows": [
+    {
+      "name": "flow_a_root_browse",
+      "description": "Root browse, no filters, no search.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 15,
+        "time_taken_ms": 181.675
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.906
+      }
+    },
+    {
+      "name": "flow_b_filtered_search",
+      "description": "Root browse with a search term.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 16,
+        "time_taken_ms": 1068.7530000000002
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.661
+      }
+    },
+    {
+      "name": "flow_c_series_metadata",
+      "description": "Metadata detail for the largest series.",
+      "kind": "url",
+      "url": "/api/v3/s/325/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 28,
+        "time_taken_ms": 167.25
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 2.07
+      }
+    },
+    {
+      "name": "flow_c2_comic_metadata",
+      "description": "Metadata detail for a single rich comic (exercises FK + M2M hydration).",
+      "kind": "url",
+      "url": "/api/v3/c/10785/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 47,
+        "time_taken_ms": 137.055
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.767
+      }
+    },
+    {
+      "name": "flow_d_browse_plus_covers",
+      "description": "Root browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 815,
+        "total_time_ms": 1411.097
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 0,
+        "total_time_ms": 264.986
+      }
+    },
+    {
+      "name": "flow_e_search_plus_covers",
+      "description": "Search browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 384,
+        "total_time_ms": 1557.1129999999998
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 232,
+        "total_time_ms": 312.664
+      }
+    },
+    {
+      "name": "flow_f_choices_available",
+      "description": "Filter sidebar open: which dynamic filter fields have >1 choice.",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices_available",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 11,
+        "time_taken_ms": 53.511
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.7309999999999999
+      }
+    },
+    {
+      "name": "flow_g_choices_field_m2m",
+      "description": "Filter sidebar expand: m2m field with many choices (characters).",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices/characters",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 12,
+        "time_taken_ms": 197.159
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 4.968
+      }
+    },
+    {
+      "name": "flow_h_choices_field_fk",
+      "description": "Filter sidebar expand: FK field on Comic (year).",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices/year",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 11,
+        "time_taken_ms": 52.649
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.8370000000000002
+      }
+    }
+  ]
+}

--- a/tasks/browser-views-perf/stage5c-before.json
+++ b/tasks/browser-views-perf/stage5c-before.json
@@ -1,0 +1,154 @@
+{
+  "series_pk_used": 325,
+  "comic_pk_used": 10785,
+  "flows": [
+    {
+      "name": "flow_a_root_browse",
+      "description": "Root browse, no filters, no search.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 15,
+        "time_taken_ms": 179.87
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 2.127
+      }
+    },
+    {
+      "name": "flow_b_filtered_search",
+      "description": "Root browse with a search term.",
+      "kind": "url",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 16,
+        "time_taken_ms": 1046.314
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 2.145
+      }
+    },
+    {
+      "name": "flow_c_series_metadata",
+      "description": "Metadata detail for the largest series.",
+      "kind": "url",
+      "url": "/api/v3/s/325/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 28,
+        "time_taken_ms": 158.271
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.949
+      }
+    },
+    {
+      "name": "flow_c2_comic_metadata",
+      "description": "Metadata detail for a single rich comic (exercises FK + M2M hydration).",
+      "kind": "url",
+      "url": "/api/v3/c/10785/metadata",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 47,
+        "time_taken_ms": 124.658
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.714
+      }
+    },
+    {
+      "name": "flow_d_browse_plus_covers",
+      "description": "Root browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 815,
+        "total_time_ms": 1353.075
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 101,
+        "total_sql_queries": 0,
+        "total_time_ms": 239.724
+      }
+    },
+    {
+      "name": "flow_e_search_plus_covers",
+      "description": "Search browse then fetch every returned cover.",
+      "kind": "browse_plus_covers",
+      "url": "/api/v3/r/0/1?q=man",
+      "cold": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 384,
+        "total_time_ms": 1520.489
+      },
+      "warm": {
+        "status_code": 200,
+        "num_requests": 47,
+        "total_sql_queries": 232,
+        "total_time_ms": 311.493
+      }
+    },
+    {
+      "name": "flow_f_choices_available",
+      "description": "Filter sidebar open: which dynamic filter fields have >1 choice.",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices_available",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 34,
+        "time_taken_ms": 121.35700000000001
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.9559999999999997
+      }
+    },
+    {
+      "name": "flow_g_choices_field_m2m",
+      "description": "Filter sidebar expand: m2m field with many choices (characters).",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices/characters",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 12,
+        "time_taken_ms": 218.822
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 5.361000000000001
+      }
+    },
+    {
+      "name": "flow_h_choices_field_fk",
+      "description": "Filter sidebar expand: FK field on Comic (year).",
+      "kind": "url",
+      "url": "/api/v3/r/0/choices/year",
+      "cold": {
+        "status_code": 200,
+        "num_sql_queries": 11,
+        "time_taken_ms": 26.032
+      },
+      "warm": {
+        "status_code": 200,
+        "num_sql_queries": 0,
+        "time_taken_ms": 1.5230000000000001
+      }
+    }
+  ]
+}

--- a/tests/perf/run_baseline.py
+++ b/tests/perf/run_baseline.py
@@ -151,6 +151,24 @@ def _build_flows(series_pk: int, comic_pk: int) -> list[dict[str, Any]]:
             "kind": "browse_plus_covers",
             "url": f"{_BROWSE_PLUS_COVERS_URL}?q=man",
         },
+        {
+            "name": "flow_f_choices_available",
+            "description": "Filter sidebar open: which dynamic filter fields have >1 choice.",
+            "kind": "url",
+            "url": "/api/v3/r/0/choices_available",
+        },
+        {
+            "name": "flow_g_choices_field_m2m",
+            "description": "Filter sidebar expand: m2m field with many choices (characters).",
+            "kind": "url",
+            "url": "/api/v3/r/0/choices/characters",
+        },
+        {
+            "name": "flow_h_choices_field_fk",
+            "description": "Filter sidebar expand: FK field on Comic (year).",
+            "kind": "url",
+            "url": "/api/v3/r/0/choices/year",
+        },
     ]
 
 


### PR DESCRIPTION
## Summary

Stage 5c of the browser-views perf pass. Collapses the per-field probe loop in `BrowserChoicesAvailableView` (the endpoint that decides which dynamic filter dimensions to show in the sidebar) into a single batched `EXISTS` annotate.

- **Existing shape**: 22 dynamic filter fields × {1 query for FK / `.exists()`, or 1–2 queries for m2m / `.count()` + null check} → ~22–34 round-trips per cold sidebar open.
- **New shape**: one `Comic.objects.values('pk').annotate(**aggregates).first()` round-trip with one `EXISTS` per FK field and two per m2m field (`_has_<name>` and `_null_<name>`). A Python-side distinct-count probe fires only for the rare `has_rel ∧ ¬has_null` corner — on the dev library no m2m field hits it.

### The SQLite gotcha

The natural single-probe form for m2m — `EXISTS(SELECT DISTINCT rel ... LIMIT 1 OFFSET 1)` — silently returns wrong booleans. SQLite's `EXISTS` short-circuits on the first row produced by the underlying join *before* `DISTINCT` collapses or `OFFSET` skips. A field with one distinct rel and no nulls (legacy: hide it) reported True. The fix decomposes the m2m semantic into two cheap booleans:

| `has_rel` | `has_null` | Field shown? |
|---|---|---|
| False | * | False |
| True | True | True (≥1 rel + null = ≥2 effective) |
| True | False | distinct-count probe (`values_list(rel).distinct()[:2]`) |

The third row is the only one that pays for a follow-up query; on the dev DB it never fires.

## Verification

- `make lint-python`: clean.
- `make test-python`: 20/20 pass.
- Direct comparison against legacy per-field code on the dev DB returns identical booleans for all 23 fields (3 False, 20 True; matches pre-change response shape exactly).
- Smoke test on `/api/v3/r/0/choices_available` returns the expected mixed-True/False payload.

| flow | before cold | after cold |
|---|---|---|
| **f — choices_available** | **34 q / 121.4 ms** | **11 q / 53.5 ms** (−68% q, −56% ms) |
| g — choices/characters (m2m) | 12 q / 218.8 ms | 12 q / 197.2 ms |
| h — choices/year (FK) | 11 q / 26.0 ms | 11 q / 52.7 ms (within run-to-run noise) |
| a — root browse | 15 q / 179.9 ms | 15 q / 181.7 ms |
| b — filtered search | 16 q / 1046.3 ms | 16 q / 1068.8 ms |
| c — series metadata | 28 q / 158.3 ms | 28 q / 167.3 ms |
| c2 — comic metadata | 47 q / 124.7 ms | 47 q / 137.1 ms |
| d — browse + 100 covers | 815 q / 1353.1 ms | 815 q / 1411.1 ms |
| e — search + 46 covers | 384 q / 1520.5 ms | 384 q / 1557.1 ms |

`tests/perf/run_baseline.py` picks up three new flows (`choices_available`, m2m field, FK field) so the changed code path is now visible in the artifact. The 11-query floor on flow_f is per-request setup that the view shares with `BrowserView` (session, AdminFlag, library visibility ×4, age-rating max, ACL setup) — same floor that 5b ruled out as not-worth-bundling.

The `BrowserChoicesView` (single-field detail) endpoint is untouched. Its per-call cost is already low (1 query + setup) and it's hit lazily as the user expands sidebar sections; flow_g/h are flat.

## Test plan

- [x] `make lint-python` clean
- [x] `make test-python` 20/20
- [x] Smoke-test endpoint returns identical payload to legacy
- [x] Perf capture: stage5c-before.json / stage5c-after.json
- [ ] Follow-up: bundle the deferred "browse-a-Series" perf flow in 5d

🤖 Generated with [Claude Code](https://claude.com/claude-code)