### PR TITLE
Browser views perf: Stage 5.9 — FTS demote-joins regression guard + 5e handoff

### DIFF
--- a/tasks/browser-views-perf/05-replan.md
+++ b/tasks/browser-views-perf/05-replan.md
@@ -150,8 +150,10 @@ serializer-layer perf work.
 - **Cross-request ACL cache with database mtime key (original #16)** — subsumed
   by the simpler per-request memoization in 5.4. Reconsider if profiling shows
   visible-library computation is a bottleneck across requests.
-- **R1 FTS demote test** — moves to a follow-up test-only PR, not blocking any
-  perf work.
+- **R1 FTS demote test** — moved to a follow-up test-only PR (Stage 5.9). Landed
+  in `tests/test_search_fts.py` as `FTSForceInnerJoinsTestCase`; locks in the
+  conditional `codex_comicfts` demote in `BrowserFilterView.force_inner_joins`
+  against future regressions.
 
 ## 6. Exit criteria
 
@@ -462,5 +464,18 @@ the win Stage 5b made possible — visible now that the harness covers the path.
 
 ### Items 5.8 onward
 
-Only **5.8** (R3 serializer audit) remains open from the Stage 5 backlog, and
-it's investigation-only.
+**5.8** (R3 serializer audit) remains open from the Stage 5 backlog, and it's
+investigation-only. The investigation has been deferred to a future session that
+will pair it with other serializer-layer perf work; scouting from this session
+is captured in `tasks/browser-views-perf/stage5e-handoff-serializer-audit.md` as
+the input for that session's `investigation-serializer.md` deliverable.
+
+### Stage 5.9 — R1 FTS-demote regression test
+
+Test-only PR. Locks in `BrowserFilterView.force_inner_joins`'s conditional
+`codex_comicfts` demote behind `FTSForceInnerJoinsTestCase` in
+`tests/test_search_fts.py`. Four checks: the canonical SQLite failure mode
+(LEFT-OUTER MATCH raises), the positive demote (`fts_mode=True` flips LEFT OUTER
+→ INNER on `codex_comicfts`), the negative skip (`fts_mode=False` leaves it
+alone), and the end-to-end repair (the same LEFT-OUTER carrier funneled through
+`force_inner_joins` returns the expected MATCH row).

--- a/tasks/browser-views-perf/stage5e-handoff-serializer-audit.md
+++ b/tasks/browser-views-perf/stage5e-handoff-serializer-audit.md
@@ -1,0 +1,342 @@
+# Stage 5e — Handoff: ComicSerializer N+1 audit
+
+This is a handoff doc, not the audit itself. The Stage 5e investigation has been
+moved into a future Claude session that will pair it with other serializer-layer
+perf work. This doc captures the scouting already done so the next session can
+land running.
+
+The deliverable named in `05-replan.md` §4 was
+`tasks/browser-views-perf/investigation-serializer.md` — that file does not
+exist yet, and this handoff is the input it should be written from.
+
+## Why this matters
+
+`flow_c2_comic_metadata` (`/api/v3/c/<pk>/metadata`) currently runs at **47 cold
+queries / 137 ms** (`stage5d-after.json`). Stages 1–4 already batched the
+visible offenders: M2M union hydration, FK intersection batching, group queries,
+value-field annotations. The 47 remaining cold queries include per-request setup
+(~8 queries), the intersection pipeline, and any **lazy FK access fired during
+DRF serialization itself**. The audit's job is to confirm which of those 47 are
+serializer-time and whether any are eliminable.
+
+`04-metadata.md` #9 is the entry that flagged this risk; this handoff is the
+scouting done to hand off that entry.
+
+## Scope confirmation
+
+`ComicSerializer` is consumed by **exactly one** caller:
+
+```
+$ grep -rn "ComicSerializer" codex/
+codex/serializers/models/comic.py:35:class ComicSerializer(BaseModelSerializer):
+codex/serializers/browser/metadata.py:7:from ...
+codex/serializers/browser/metadata.py:26:class MetadataSerializer(...)
+codex/serializers/browser/metadata.py:71:class Meta(ComicSerializer.Meta):
+codex/serializers/browser/metadata.py:75:        *ComicSerializer.Meta.exclude,
+```
+
+So the audit can stay focused on `MetadataSerializer` and its
+`MetadataView.get_object()` feed. `ReaderComicSerializer` is a plain
+`Serializer` with scalar fields only (`codex/serializers/reader.py:54-90`); it
+does not extend `ModelSerializer` and has no FK-access risk.
+`BrowserCardSerializer`'s cover `SerializerMethodField`s use
+`getattr(..., None)` fallback to `obj.pk` — safe.
+
+## ComicSerializer landscape
+
+`codex/serializers/models/comic.py:35-85`:
+
+- `Meta.model = Comic`, `Meta.exclude = ("folders", "parent_folder", "stat")`,
+  `Meta.depth = 1`. The `depth=1` alone causes DRF to auto-nest every FK on
+  Comic that isn't excluded.
+- 12 explicit nested-FK serializers (override the `depth=1` defaults):
+    - **Group FKs** (4): `publisher`, `imprint`, `series`, `volume` — but
+      `MetadataSerializer.Meta.exclude` strips these and replaces with `*_list`
+      GroupSerializer instances populated from
+      `MetadataCopyIntersectionsView._copy_groups`. **Not a serializer-time
+      risk** in the metadata path.
+    - **pycountry FKs** (2): `country`, `language` — `CountrySerializer` /
+      `LanguageSerializer` resolve at the Python level via pycountry; they
+      **don't hit the database** (`codex/serializers/models/pycountry.py`).
+    - **Other FKs** (6): `age_rating`, `original_format`, `scan_info`, `tagger`,
+      `main_character`, `main_team`. These hit the DB if the FK target row isn't
+      already loaded.
+- 11 explicit M2M serializers: `characters`, `credits`, `genres`, `identifiers`,
+  `locations`, `series_groups`, `stories`, `story_arc_numbers`, `tags`, `teams`,
+  `universes`. In `MetadataSerializer`, `credits`, `identifiers`, and
+  `story_arc_numbers` rebind to `attached_*` (PREFETCH_PREFIX) — populated by
+  `MetadataCopyIntersectionsView._copy_m2m_intersections`.
+
+## Risk hotspots from URL/property fields
+
+These are the access patterns that will fire extra queries during serialization
+unless the upstream queryset hydrates them:
+
+1. **`URLNamedModelSerializer.url`** `codex/serializers/models/named.py:43`:
+
+    ```python
+    url = URLField(read_only=True, source="identifier.url")
+    ```
+
+    One-hop FK access (`obj.identifier.url`). Subclasses:
+    `CreditPersonSerializer`, `CreditRoleSerializer`, `CharacterSerializer`,
+    `GenreSerializer`, `LocationSerializer`, `StorySerializer`,
+    `StoryArcSerializer`, `TagSerializer`, `TeamSerializer`,
+    `UniverseSerializer` (10 classes).
+
+2. **`StoryArcNumberSerializer.url`** `codex/serializers/models/named.py:164`:
+
+    ```python
+    url = URLField(read_only=True, source="story_arc.identifier.url")
+    ```
+
+    **Two-hop FK access** (`obj.story_arc.identifier.url`) — needs
+    `select_related("story_arc__identifier")`.
+
+3. **`IdentifierSeralizer.name`** `codex/serializers/models/named.py:111-121`
+   declares `name = CharField(read_only=True)`. `Identifier.name` is a
+   `@property` that reads `self.source` (FK) — every serialized Identifier
+   triggers `Identifier.source` access.
+
+4. **`AgeRatingSerializer.metron`** `codex/serializers/models/named.py:196`:
+    ```python
+    metron = AgeRatingMetronSerializer(allow_null=True, read_only=True)
+    ```
+    Nested FK from AgeRating → AgeRatingMetron. Needs `select_related("metron")`
+    on the AgeRating queryset.
+
+## Existing optimizer coverage
+
+`codex/views/browser/metadata/const.py:61-111` defines two MappingProxyType
+dispatch tables that `query_intersections.py` consults when building each
+intersection queryset:
+
+`FK_QUERY_OPTIMIZERS` (3 entries):
+
+| Model     | select       | only                                    |
+| --------- | ------------ | --------------------------------------- |
+| AgeRating | `metron`     | `name`, `metron__name`, `metron__index` |
+| Character | `identifier` | `name`, `identifier__url`               |
+| Team      | `identifier` | `name`, `identifier__url`               |
+
+`M2M_QUERY_OPTIMIZERS` (6 entries):
+
+| Model          | prefetch                                                   | select    | only                                |
+| -------------- | ---------------------------------------------------------- | --------- | ----------------------------------- |
+| Credit         | `role`, `person`, `role__identifier`, `person__identifier` | —         | `role`, `person`                    |
+| StoryArcNumber | `story_arc`, `story_arc__identifier`                       | —         | `story_arc`, `number`               |
+| Identifier     | —                                                          | `source`  | `source`, `key`, `url`              |
+| Universe       | —                                                          | (default) | `name`, `designation`, `identifier` |
+| SeriesGroup    | —                                                          | (none)    | `name`                              |
+| Folder         | —                                                          | (none)    | `path`                              |
+
+Defaults (`query_intersections.py:_get_optimized_fk_query` and
+`_get_optimized_m2m_query`):
+
+- FK default: `only=("name",)`. **No `select_related` by default** — so the six
+  "Other FKs" on Comic that aren't in the table get nothing.
+- M2M default: `select=("identifier",)`, `only=("name", "identifier")`. This is
+  exactly what `URLNamedModelSerializer` needs (one-hop `identifier.url`).
+
+## Coverage gaps the audit should verify
+
+These are the open questions that determine whether the audit produces a patch
+or just a "no-op confirmed clean" doc:
+
+### Gap 1 — M2M defaults already cover URLNamedModelSerializer subclasses
+
+`Genre`, `Location`, `Story`, `Tag` are URLNamedModelSerializer subclasses
+**not** in `M2M_QUERY_OPTIMIZERS`. They fall through to the default
+`select=("identifier",)` + `only=("name", "identifier")`. That happens to be
+correct for `url = URLField(source="identifier.url")` — confirm there's no
+hidden cost (e.g. `Identifier.source` property access, since
+`IdentifierSeralizer` is not in the M2M Identifier serializer chain for these
+models — `URLNamedModelSerializer.url` only reads `identifier.url` directly, not
+the Identifier's name).
+
+**Test:** capture queries during serialization of one comic that has
+genres/locations/stories/tags. Expected: 0 extra queries beyond the intersection
+hydration itself.
+
+### Gap 2 — FK_QUERY_OPTIMIZERS gaps for "Other FKs"
+
+The six Other FKs (`age_rating`, `original_format`, `scan_info`, `tagger`,
+`main_character`, `main_team`) are hydrated through `_query_fk_intersections` →
+`_copy_fks` (`fk_qs.first()`). `FK_QUERY_OPTIMIZERS` covers AgeRating, Character
+(= main_character path), Team (= main_team path). Missing: `OriginalFormat`,
+`ScanInfo`, `Tagger`.
+
+These three are simple `NamedModelSerializer` subclasses (just `pk`, `name`) —
+the default `only=("name",)` is correct. **Likely no work needed**, but worth a
+1-comic silk capture to confirm.
+
+### Gap 3 — Main queryset materialization on `model is Comic`
+
+`MetadataView.get_object()` (`codex/views/browser/metadata/__init__.py:71-106`)
+runs `qs[0]` on the annotated Comic queryset, then `_copy_fks` overwrites each
+FK attribute with an optimized intersection-fk queryset's `.first()`.
+
+**Question:** does `qs[0]` itself fire any additional queries due to attribute
+access on the resulting Comic instance during the rest of `get_object()`? In
+particular, the chain is:
+
+```
+qs[0] -> _aggregate_multi_pk_sums (only when len(pks) > 1)
+      -> query_intersections (drives 7 fk + 11 m2m queries)
+      -> copy_intersections_into_comic_fields
+          -> _path_security (reads obj.path)
+          -> _highlight_current_group (model-name based)
+          -> _copy_groups (sets *_list)
+          -> _copy_fks (fk_qs.first() per FK — 7 queries)
+          -> _copy_m2m_intersections (sets attached_* / m2m fields)
+```
+
+`_path_security` calls `obj.search_path()` only when admin_flag set; otherwise
+reads `obj.path` (already in `qs[0]`). No serializer-time risk here.
+
+The hand-off audit should still verify by running silk on flow_c2 and
+attributing each of the 47 cold queries to a stage.
+
+### Gap 4 — `Identifier.name` property on `IdentifierSeralizer`
+
+`Identifier.name` is a `@property` that reads `self.source` (FK to
+`IdentifierSource`). The `M2M_QUERY_OPTIMIZERS[Identifier]` entry includes
+`select=("source",)` — so the FK is loaded eagerly when the M2M intersection
+queryset is hydrated. **Looks safe**, but the audit should confirm the
+identifier prefetches on `Credit.role__identifier` and
+`StoryArcNumber.story_arc__identifier` paths similarly load `identifier.source`
+if `name` is read for those nested Identifiers (in this codebase,
+`IdentifierSeralizer` is only mounted on the top-level `identifiers` field of
+MetadataSerializer, so probably not a cross-cutting issue).
+
+### Gap 5 — `Meta.depth = 1` on ComicSerializer
+
+`depth=1` causes DRF to **auto-nest every Comic FK that isn't explicitly
+serialized or excluded**. The exclude list is
+`("folders", "parent_folder", "stat")` — but folders is M2M and parent_folder is
+the only "extra" FK. All other Comic FKs are explicitly serialized, which
+**overrides depth=1** for that field. Effective: depth=1 changes nothing — it's
+belt-and-braces. The audit could note this (and possibly drop `depth=1` for
+clarity), but it's not a perf win.
+
+## MetadataView.get_object() flow (reference map)
+
+```
+codex/views/browser/metadata/__init__.py:72-106
+  filter -> annotate_order/card/cover/values_and_fks/group_by/inner_joins
+  qs[0]  ->  obj
+  query_intersections(filtered_qs)
+    -> _query_groups()                    [N queries, N = group depth]
+    -> _get_comic_pks(filtered_qs)        [1 query, distinct values_list]
+    -> _query_fk_intersections(comic_pks) [7 lazy querysets,
+                                           hydrated by _copy_fks below]
+    -> _query_m2m_intersections(comic_pks)[1 UNION + 11 hydration querysets]
+  copy_intersections_into_comic_fields(obj, ...)
+    -> _copy_fks: fk_qs.first() x 7 fields
+    -> _copy_m2m_intersections: setattr or .set(qs, clear=True)
+serializer.data
+  -> walks ComicSerializer fields, then MetadataSerializer fields
+  -> THIS IS WHERE ANY MISSED select_related FIRES EXTRA QUERIES
+```
+
+## Files to read (with the relevant line ranges)
+
+Serializers:
+
+- `codex/serializers/models/comic.py:35-85` — `ComicSerializer`
+- `codex/serializers/browser/metadata.py:14-81` — `MetadataSerializer`
+- `codex/serializers/models/named.py:30-249` — full `URLNamedModelSerializer`
+  family + `IdentifierSeralizer` + `StoryArcNumberSerializer` +
+  `AgeRatingSerializer`
+- `codex/serializers/browser/mixins.py:21-71` —
+  `BrowserAggregateSerializerMixin` (`get_mtime` reads only annotations; safe)
+- `codex/serializers/models/groups.py` — group serializers (pk + name; safe)
+- `codex/serializers/models/pycountry.py` — Country/Language (Python-side
+  resolution; safe)
+- `codex/serializers/reader.py:54-90` — `ReaderComicSerializer` (plain
+  Serializer, scalar fields only; safe)
+
+Views:
+
+- `codex/views/browser/metadata/__init__.py:21-119` — `MetadataView`
+  (`get_object` flow)
+- `codex/views/browser/metadata/const.py:61-111` — `FK_QUERY_OPTIMIZERS` +
+  `M2M_QUERY_OPTIMIZERS`
+- `codex/views/browser/metadata/query_intersections.py:55-160` —
+  `_get_optimized_fk_query`, `_get_optimized_m2m_query`,
+  `_query_fk_intersections`, `_query_m2m_intersections`
+- `codex/views/browser/metadata/copy_intersections.py` — `_copy_fks`,
+  `_copy_m2m_intersections`
+
+Models (for property-access risk):
+
+- `codex/models/identifier.py` — `Identifier.name` is a `@property` reading
+  `self.source`
+
+Background:
+
+- `tasks/browser-views-perf/04-metadata.md:219-232` — original #9 entry
+- `tasks/browser-views-perf/04-metadata.md:273-292` — Stage-1 query-count
+  baseline
+- `tasks/browser-views-perf/05-replan.md` §10 — Stage 5d landing notes
+
+## Suggested verification approach
+
+1. **Silk capture on `flow_c2_comic_metadata` cold path.** The harness in
+   `tests/perf/run_baseline.py` already wires silk via the `--with-silk` flag.
+   Run with silk enabled and attribute each of the 47 cold queries to a stage:
+    - per-request setup (~8: session, AdminFlag, library visibility ×4,
+      age-rating max, ACL filter)
+    - `qs[0]` materialization (~1)
+    - `_query_groups` (depth-dependent, 0-4)
+    - `_get_comic_pks` distinct values_list (~1)
+    - `_query_fk_intersections` lazy querysets evaluated by `_copy_fks.first()`
+      (~7)
+    - `_query_m2m_intersections` UNION + hydrations (~12)
+    - serializer-time queries (target: 0; **anything > 0 here is the audit's
+      yield**)
+
+2. **Per-field `connection.queries` diff.** For each of the 11 M2M fields and 6
+   Other FKs, wrap `serializer.data` in a `CaptureQueriesContext` and isolate
+   the per-field cost.
+
+3. **Confirm Gap 1 by toggling defaults.** Temporarily change
+   `_get_optimized_m2m_query`'s default `select=("identifier",)` to `()` —
+   verify the genres/locations/stories/tags fields fire one extra query per row.
+   Restore default and confirm zero. This validates the existing default is
+   doing real work and shouldn't be loosened.
+
+4. **No-op confirmation is a valid outcome.** If silk shows zero serializer-time
+   queries, the audit's deliverable is the `investigation-serializer.md` doc
+   with that conclusion + the test methodology, so a future regression can be
+   caught.
+
+## Already audited and clean (do not re-audit)
+
+- `BrowserCardSerializer` cover `SerializerMethodField`s — `getattr(..., None)`
+  fallback to `obj.pk`.
+- `BrowserAggregateSerializerMixin.get_mtime` — reads `obj.updated_ats` /
+  `obj.bookmark_updated_ats` annotations (lists of strings).
+- `ReaderComicSerializer` — plain `Serializer`, scalar fields only.
+- Group `*_list` GroupSerializer in MetadataSerializer — populated from
+  `_query_groups` materialized querysets, `name` + `ids` only.
+- Country/Language via pycountry — Python-level resolution, no DB.
+
+## Out of scope for the audit
+
+- The 8-query per-request setup (session + ACL pipeline). Scoped out of Stage 5b
+  in `05-replan.md` §8 ("Why 5.4 didn't ship").
+- Cross-request caching of metadata responses. `cache_page` already applies;
+  in-app caching was deferred in `04-metadata.md` §D.
+- M2M UNION + hydration query architecture. Already optimized in Stages 1–4.
+
+## Done state
+
+The audit is "done" when `tasks/browser-views-perf/investigation-serializer.md`
+exists and contains:
+
+1. A silk-attributed breakdown of `flow_c2_comic_metadata`'s 47 cold queries.
+2. For each gap above (Gap 1–5), either "confirmed clean" with the reproduction
+   command, or a patch landed in the same PR.
+3. An updated `99-summary.md` row for R3 with status set to either
+   `verified-clean` or `landed`.

--- a/tests/test_search_fts.py
+++ b/tests/test_search_fts.py
@@ -1,0 +1,222 @@
+"""
+FTS5 ``demote_joins`` regression guard.
+
+The browser filter pipeline calls
+:meth:`codex.views.browser.filters.filter.BrowserFilterView.force_inner_joins`
+on every queryset that participates in search. That helper unconditionally
+demotes ``codex_library`` (and ``codex_comic`` when the model isn't Comic),
+and **conditionally** demotes ``codex_comicfts`` only when ``self.fts_mode``
+is True.
+
+The conditional ``codex_comicfts`` demotion exists because SQLite's FTS5
+``MATCH`` operator only works when the FTS5 virtual table is INNER-joined to
+the rest of the query. A LEFT OUTER JOIN raises::
+
+    sqlite3.OperationalError: unable to use function MATCH in the requested context
+
+Stage-5 backlog item R1 (`tasks/browser-views-perf/05-replan.md` §3, sub-plan
+`03-filters.md` #5) flagged ``force_inner_joins`` as a candidate for
+conditional demotion. This test locks the contract in as a hard regression
+guard before any future perf work tries to skip the demote on the FTS5 table.
+
+Why the carrier queries here look unusual:
+
+* ``Comic.objects.values("comicfts__pk")`` puts ``codex_comicfts`` in the
+  alias map as ``LEFT OUTER JOIN`` without any non-null filter through the
+  join chain — so Django's optimizer leaves it alone, and the demote in
+  ``force_inner_joins`` is observably load-bearing.
+* The failure-mode tests use ``qs.query.promote_joins({"codex_comicfts"})``
+  to flip the FTS join from INNER back to LEFT OUTER. ``promote_joins`` is
+  the documented inverse of ``demote_joins`` (both live on
+  :class:`django.db.models.sql.query.Query`), so it's the cleanest way to
+  reconstruct the exact alias-map state the demote exists to prevent —
+  no contrived OR/IS NULL clauses that themselves trip FTS5's context
+  rules.
+
+Filtering through ``comic__comicfts__match`` directly — the shape used by
+the production filter pipeline — is intentionally **not** the assertion
+target for the demote, because Django's optimizer auto-promotes that join
+to INNER before ``force_inner_joins`` ever runs.
+"""
+
+import shutil
+from pathlib import Path
+from typing import override
+
+import pytest
+from django.db import OperationalError, connection
+from django.test import TestCase
+
+from codex.models import Comic, Imprint, Library, Publisher, Series, Volume
+from codex.views.browser.filters.filter import BrowserFilterView
+
+TMP_DIR = Path("/tmp/codex.tests.fts")  # noqa: S108
+
+
+class _FTSCallableView:
+    """
+    Minimal stand-in exposing only the attribute ``force_inner_joins`` reads.
+
+    ``BrowserFilterView.force_inner_joins`` is an unbound method on the
+    view class but only ever touches ``self.fts_mode`` and the queryset's
+    own ``model`` / ``demote_joins`` helpers. Instantiating the full DRF
+    view stack just to flip a single boolean would obscure what the test
+    is actually asserting.
+    """
+
+    force_inner_joins = BrowserFilterView.force_inner_joins
+
+    def __init__(self, *, fts_mode: bool) -> None:
+        self.fts_mode = fts_mode
+
+
+class FTSForceInnerJoinsTestCase(TestCase):
+    """Regression guard for the FTS5 demote-joins contract."""
+
+    @override
+    def setUp(self) -> None:
+        """Seed two comics + two FTS rows with distinguishable tokens."""
+        TMP_DIR.mkdir(exist_ok=True, parents=True)
+        library = Library.objects.create(path=str(TMP_DIR))
+        publisher = Publisher.objects.create(name="Pub")
+        imprint = Imprint.objects.create(name="Imp", publisher=publisher)
+        self.series = Series.objects.create(  # pyright: ignore[reportUninitializedInstanceVariable]
+            name="Ser", imprint=imprint, publisher=publisher
+        )
+        volume = Volume.objects.create(
+            name="2024", series=self.series, imprint=imprint, publisher=publisher
+        )
+
+        def _make_comic(slug: str, issue: int) -> Comic:
+            path = TMP_DIR / f"{slug}.cbz"
+            path.touch()
+            return Comic.objects.create(
+                library=library,
+                path=path,
+                issue_number=issue,
+                name=slug,
+                publisher=publisher,
+                imprint=imprint,
+                series=self.series,
+                volume=volume,
+                size=1,
+            )
+
+        self.comic_wonder = _make_comic("wonder", 1)  # pyright: ignore[reportUninitializedInstanceVariable]
+        self.comic_phoenix = _make_comic("phoenix", 2)  # pyright: ignore[reportUninitializedInstanceVariable]
+
+        # ``ComicFTS`` is ``managed=False`` and its column list is
+        # rewritten by SQL-level migrations (most recently 0039), so the
+        # Django field set drifts from the live schema. Insert via raw
+        # SQL using only the columns that have been stable since 0029
+        # (``comic_id`` + ``name``) — FTS5 fills the unspecified columns
+        # with empty strings.
+        with connection.cursor() as cur:
+            cur.execute(
+                "INSERT INTO codex_comicfts (comic_id, name) VALUES (?, ?), (?, ?)",
+                [
+                    self.comic_wonder.pk,
+                    "wonder",
+                    self.comic_phoenix.pk,
+                    "phoenix",
+                ],
+            )
+
+    @override
+    def tearDown(self) -> None:
+        """Clear the FTS table and the temp comic tree."""
+        with connection.cursor() as cur:
+            cur.execute("DELETE FROM codex_comicfts")
+        shutil.rmtree(TMP_DIR, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _comicfts_join_type(qs) -> str:
+        """Return the SQL join type Django assigned to ``codex_comicfts``."""
+        for join in qs.query.alias_map.values():
+            if getattr(join, "table_name", None) == "codex_comicfts":
+                return getattr(join, "join_type", "")
+        msg = "codex_comicfts not in alias_map"
+        raise AssertionError(msg)
+
+    @staticmethod
+    def _left_outer_match_qs():
+        """
+        Return a queryset with ``codex_comicfts`` joined LEFT OUTER + MATCH.
+
+        Django auto-promotes the FTS join to INNER as soon as ``MATCH`` is
+        added to the WHERE. ``Query.promote_joins`` (the documented
+        inverse of ``demote_joins``) flips it back to LEFT OUTER — the
+        exact alias-map state ``force_inner_joins`` exists to prevent.
+        """
+        qs = Comic.objects.filter(comicfts__match="wonder")
+        qs.query.promote_joins({"codex_comicfts"})
+        return qs
+
+    # ------------------------------------------------------------------
+    # The contract under test
+    # ------------------------------------------------------------------
+
+    def test_left_joined_fts_match_raises_operational_error(self) -> None:
+        """
+        SQLite refuses ``MATCH`` against a LEFT-joined FTS5 table.
+
+        Stripping the ``codex_comicfts`` demote re-introduces this error
+        path on every FTS-enabled browse — exactly the failure mode that
+        ``force_inner_joins`` exists to prevent.
+        """
+        qs = self._left_outer_match_qs()
+        # Confirm the carrier query really does keep the join LEFT OUTER —
+        # otherwise Django's auto-promotion would mask the regression we
+        # care about.
+        assert self._comicfts_join_type(qs) == "LEFT OUTER JOIN"
+        with pytest.raises(OperationalError):
+            list(qs.values_list("id", flat=True))
+
+    def test_force_inner_joins_demotes_comicfts_when_fts_mode_true(self) -> None:
+        """
+        ``codex_comicfts`` is demoted to INNER JOIN when ``fts_mode`` is True.
+
+        Carrier query: ``Comic.objects.values("comicfts__pk")`` puts the
+        FTS table in the alias map as LEFT OUTER without any non-null
+        filter — Django leaves it alone, so the demote is observable.
+        """
+        view = _FTSCallableView(fts_mode=True)
+        qs = Comic.objects.values("comicfts__pk")
+        assert self._comicfts_join_type(qs) == "LEFT OUTER JOIN"
+        out = view.force_inner_joins(qs)
+        assert self._comicfts_join_type(out) == "INNER JOIN"
+
+    def test_force_inner_joins_skips_comicfts_when_fts_mode_false(self) -> None:
+        """
+        ``codex_comicfts`` stays LEFT OUTER when ``fts_mode`` is False.
+
+        The non-FTS branch still demotes ``codex_library`` (and
+        ``codex_comic`` for non-Comic models) — only the FTS table stays
+        on the default LEFT OUTER JOIN, because no MATCH is being issued.
+        """
+        view = _FTSCallableView(fts_mode=False)
+        qs = Comic.objects.values("comicfts__pk")
+        assert self._comicfts_join_type(qs) == "LEFT OUTER JOIN"
+        out = view.force_inner_joins(qs)
+        assert self._comicfts_join_type(out) == "LEFT OUTER JOIN"
+
+    def test_force_inner_joins_unblocks_match_on_left_joined_query(self) -> None:
+        """
+        End-to-end: ``force_inner_joins`` flips LEFT OUTER -> INNER and MATCH runs.
+
+        Same carrier query as
+        ``test_left_joined_fts_match_raises_operational_error``, but
+        funneled through ``force_inner_joins(fts_mode=True)``. After the
+        demote, ``codex_comicfts`` is INNER, MATCH succeeds, and the
+        ``wonder`` token narrows the result to a single comic.
+        """
+        view = _FTSCallableView(fts_mode=True)
+        qs = self._left_outer_match_qs()
+        out = view.force_inner_joins(qs)
+        assert self._comicfts_join_type(out) == "INNER JOIN"
+        ids = list(out.values_list("id", flat=True))
+        assert ids == [self.comic_wonder.pk], ids


### PR DESCRIPTION
## Summary

- **Stage 5.9 (R1) lands as a test-only PR.** Adds `tests/test_search_fts.py` to lock in the conditional `codex_comicfts` demote inside `BrowserFilterView.force_inner_joins`. Future perf work that strips the FTS table from the demote set now fails loudly instead of silently re-introducing `OperationalError: unable to use function MATCH in the requested context` on every FTS-enabled browse.
- **Stage 5e handoff doc** — adds `tasks/browser-views-perf/stage5e-handoff-serializer-audit.md` scoping the deferred R3 serializer N+1 audit, and updates `05-replan.md` §5 / §10 to record both the 5.9 landing and the 5.8 deferral.

## Why a test-only PR

R1 (`tasks/browser-views-perf/05-replan.md` §3, sub-plan `03-filters.md` #5) flagged `force_inner_joins` as a candidate for conditional demotion. The conditional `codex_comicfts` demote exists because SQLite's FTS5 `MATCH` operator only works when the FTS5 virtual table is INNER-joined. A LEFT OUTER JOIN raises:

    sqlite3.OperationalError: unable to use function MATCH in the requested context

Without a hard regression guard, the demote looks like dead code to anyone unfamiliar with FTS5's context rules — exactly the kind of "harmless" cleanup that breaks search.

## What got tested

| Test | What it locks in |
| ---- | ---------------- |
| `test_left_joined_fts_match_raises_operational_error` | Canonical failure mode. Uses `Query.promote_joins` (the documented inverse of `demote_joins`) to flip the auto-promoted FTS join back to LEFT OUTER, then proves SQLite refuses the MATCH. |
| `test_force_inner_joins_demotes_comicfts_when_fts_mode_true` | Positive contract. Carrier query `Comic.objects.values("comicfts__pk")` joins `codex_comicfts` LEFT OUTER without any non-null filter — Django's optimizer leaves it alone, and `force_inner_joins(fts_mode=True)` flips it to INNER. |
| `test_force_inner_joins_skips_comicfts_when_fts_mode_false` | Negative contract. Same carrier, `fts_mode=False` leaves the join LEFT OUTER. |
| `test_force_inner_joins_unblocks_match_on_left_joined_query` | End-to-end repair. The promoted-LEFT-OUTER MATCH carrier funneled through `force_inner_joins(fts_mode=True)` returns the matching comic exactly once. |

## Reviewer notes

- The carrier queries look unusual on purpose. Filtering through `comic__comicfts__match` directly — the production filter shape — auto-promotes the join to INNER before `force_inner_joins` ever runs, which would make the demote untestable. The two carriers (`values("comicfts__pk")` for the LEFT-OUTER-without-MATCH case, and `Query.promote_joins({"codex_comicfts"})` for the LEFT-OUTER-plus-MATCH case) are the cleanest constructions I could find that actually exercise the contract. The module docstring explains the choice.
- `ComicFTS` is `managed=False` and its column list is rewritten by SQL-level migrations (most recently 0039), so the Django field set drifts from the live schema. The setup inserts via raw SQL using only the columns stable since 0029 (`comic_id` + `name`) — FTS5 fills the rest with empty strings.
- No production code changes. `force_inner_joins` itself is untouched.

## Stage 5 status after this PR

Only **5.8** (R3 serializer audit) remains, and it's investigation-only. The handoff doc in this PR scopes it for a future session that pairs it with broader serializer-layer perf work.

## Test plan

- [x] `uv run --group test pytest tests/test_search_fts.py` — 4/4 passed.
- [x] `uv run --group test pytest tests/` — 24/24 passed.
- [x] `uv run --group lint ruff check tests/test_search_fts.py` — clean.
- [x] `uv run --group lint --group test --group build basedpyright tests/test_search_fts.py` — 0 errors.
- [x] `bun x prettier --check` — clean on touched markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)