### PR TITLE
Reader views perf plan

### DIFF
--- a/tasks/reader-views-perf/00-meta-plan.md
+++ b/tasks/reader-views-perf/00-meta-plan.md
@@ -1,0 +1,156 @@
+# Codex `codex/views/reader/` — Performance Plan: Methodology
+
+How this analysis is organized. Mirrors the structure of the
+[`tasks/opds-views-perf/`](../opds-views-perf/) plan; the goal is to
+produce a comparable ranked backlog for the reader subsystem.
+
+## Scope
+
+Everything under `codex/views/reader/` (6 source files,
+~850 LOC), plus the URL configuration in `codex/urls/api/reader.py`.
+The cover endpoint mounted under that URL conf
+(`<pk>/cover.webp`) routes to `codex.views.browser.cover.CoverView`
+and was already optimized in the browser-views perf project; not
+re-analyzed here.
+
+Out of scope (matches OPDS plan):
+
+- Browser views, OPDS views, admin views, librarian daemon.
+- Frontend (`/frontend/` — reader UI).
+- Comicbox internals, archive parsing, page extraction.
+- Schema changes (denormalization, indexes, PRAGMA tuning).
+
+## Why now
+
+The browser-views perf project (Stage 0 → 5e) closed the bulk of the
+ACL / annotation / FTS hotspots. The OPDS perf project (Stages 0
+through 5) closed the OPDS-specific batching + caching wins. The
+reader is the last large feature view family that hasn't been
+audited for performance.
+
+Reader matters because the user's comic-reading hot path goes
+through it:
+
+1. User clicks a comic in the browser → `c/<pk>` (`ReaderView`) is
+   hit. Returns the comic + the prev/curr/next book window + the
+   arc context + reader settings.
+2. User reads → `c/<pk>/<page>/page.jpg` (`ReaderPageView`) is hit
+   per page turn. The hottest endpoint in the codex.
+3. User changes per-comic settings → `c/<pk>/settings`
+   (`ReaderSettingsView`) is hit on every adjustment.
+
+Latency on (1) is felt as "click-to-open"; latency on (2) is felt
+as "page-turn lag." Both deserve scrutiny.
+
+## Surface map
+
+| File | LOC | Class | Role |
+| ---- | --- | ----- | ---- |
+| `params.py` | 70 | `ReaderParamsView` | Base class — input validation + memoized params dict + arc kwarg shape. |
+| `arcs.py` | 134 | `ReaderArcsView` | Build the arc context (series / volume / folder / story_arc list for the comic). |
+| `books.py` | 181 | `ReaderBooksView` | Build the prev / current / next book window inside the selected arc. |
+| `reader.py` | 49 | `ReaderView` | Top-level view — assembles arcs + books + close_route into the `c/<pk>` GET response. |
+| `page.py` | 106 | `ReaderPageView` | Streams the page image bytes for `c/<pk>/<page>/page.jpg`. |
+| `settings.py` | 309 | `ReaderSettingsBaseView`, `ReaderSettingsView` | Per-scope (global / comic / series / folder / story_arc) settings CRUD. |
+| __init__.py | 1 | — | — |
+
+Inheritance chain for the main view:
+
+```
+SettingsBaseView
+└── ReaderSettingsBaseView (settings.py)
+    └── ReaderParamsView (params.py)
+        └── ReaderArcsView (arcs.py)
+            └── ReaderBooksView (books.py) + SharedAnnotationsMixin + BookmarkAuthMixin
+                └── ReaderView (reader.py)
+```
+
+Side branches:
+
+- `ReaderSettingsView(ReaderSettingsBaseView)` — settings CRUD endpoint.
+- `ReaderPageView(BookmarkAuthMixin, AuthFilterAPIView)` — page binary.
+
+URL routes (`codex/urls/api/reader.py`):
+
+| Route | View | Cache |
+| ----- | ---- | ----- |
+| `c/<pk>` | `ReaderView` | **none** |
+| `c/<pk>/<page>/page.jpg` | `ReaderPageView` | `cache_control` only (HTTP cache headers; no server-side `cache_page`) |
+| `c/<pk>/cover.webp` | `CoverView` (browser) | `cache_page(COVER_MAX_AGE)` + `vary_on_cookie` (already optimal) |
+| `c/settings` and `c/<pk>/settings` | `ReaderSettingsView` | none |
+| `c/<pk>/download/<filename>` | `DownloadView` (browser) | none — download is single-shot |
+
+The reader and settings endpoints are uncached server-side. Page is
+client-cache only.
+
+## Plan structure
+
+Three sub-plans plus the summary:
+
+- [`01-reader-view-chain.md`](01-reader-view-chain.md) — `ReaderView`
+  + the params/arcs/books inheritance chain. The main reader request
+  (`c/<pk>`).
+- [`02-reader-settings.md`](02-reader-settings.md) — settings CRUD
+  (`c/settings`, `c/<pk>/settings`).
+- [`03-reader-page.md`](03-reader-page.md) — page binary
+  (`c/<pk>/<page>/page.jpg`).
+- [`99-summary.md`](99-summary.md) — ranked backlog with severity,
+  effort, risk, and a suggested landing order.
+
+The reader surface is small enough that this 3-plan + summary shape
+is adequate. The OPDS plan's 6-sub-plan decomposition would be
+over-engineered here.
+
+## Methodology (mirrors OPDS / browser plans)
+
+For each view family the analysis answers four questions:
+
+1. **What's the per-request cost shape?** — Lines fired in the hot
+   path: SQL queries, Comicbox opens, `reverse()` calls,
+   serialization passes.
+2. **What's the per-row / per-page fan-out?** — Where the cost
+   scales with N. (Pre-fix OPDS had `9 × N entries` for v1
+   acquisition feeds; the reader has analogous patterns.)
+3. **What's batchable / cacheable?** — Whether the cost is fixed
+   per-request or amortizable across a tab refresh / page sequence.
+4. **What's the risk profile of fixing it?** — Pure refactor (low),
+   query reshape (medium), behavior change (high).
+
+Where possible, link sub-plan items into a single ranked backlog in
+[`99-summary.md`](99-summary.md). Status starts ⏳ Open until items
+land; mirrors the OPDS plan's status column convention.
+
+## What this plan does NOT address
+
+Same posture as the OPDS plan:
+
+- Serializer-layer audit. `codex/serializers/reader.py` has its own
+  N+1 risks worth checking, but the audit belongs to a separate
+  serializer-perf handoff (mirror of
+  `tasks/browser-views-perf/stage5e-handoff-serializer-audit.md`).
+- Reader UI / frontend.
+- Schema changes.
+- Comicbox internals — page extraction, archive parsing, PDF
+  rendering.
+- Librarian / scribe perf.
+
+## What's worth measuring before scheduling
+
+1. **Reader endpoint cold latency.** Single hit on `c/<pk>` —
+   how many SQL queries, how much wall time.
+2. **Page endpoint cold latency.** Single hit on
+   `c/<pk>/<page>/page.jpg` — how much of the wall time is
+   Comicbox vs. ACL filter.
+3. **Per-route hit distribution.** Reader endpoint volume vs. page
+   endpoint volume. Page is the hotter endpoint per session
+   (page turn count vs. comic open count); confirm with traffic
+   data before prioritizing.
+4. **Settings endpoint volume.** Settings are written on UI
+   adjustments; if low-volume, the get-or-create pattern doesn't
+   matter even if it's two queries.
+
+Build a reader perf harness analogous to
+`tests/perf/run_opds_baseline.py` covering at minimum: reader
+endpoint cold, page endpoint cold, settings GET multi-scope, page
+turn warm. Without baselines, the rankings in
+[`99-summary.md`](99-summary.md) are opinion-driven.

--- a/tasks/reader-views-perf/01-reader-view-chain.md
+++ b/tasks/reader-views-perf/01-reader-view-chain.md
@@ -1,0 +1,357 @@
+# 01 — Reader view chain (`c/<pk>` GET)
+
+The main reader request. Returns:
+
+- `arc` — the selected arc (group + ids + index + count).
+- `arcs` — all arcs the comic belongs to (series / volume / folder
+  / story_arc).
+- `books` — the prev / current / next book window inside the
+  selected arc (1–3 books).
+- `close_route` — the `last_route` from `SettingsBrowser` for the
+  "back to browser" button.
+- `mtime` — the max `updated_at` across the comic's arcs.
+
+Hits the inheritance chain
+`ReaderSettingsBaseView → ReaderParamsView → ReaderArcsView →
+ReaderBooksView → ReaderView`.
+
+## Files in scope
+
+| File | LOC | Purpose |
+| ---- | --- | ------- |
+| `codex/views/reader/params.py` | 70 | Input validation, memoized `params` property, arc kwarg shape |
+| `codex/views/reader/arcs.py` | 134 | Build the arc context (series / volume / folder / story_arc) |
+| `codex/views/reader/books.py` | 181 | Build the prev / current / next book window |
+| `codex/views/reader/reader.py` | 49 | Top-level view — assembles the response |
+
+## Per-request cost shape
+
+`ReaderView.get_object()` runs in this order:
+
+```python
+arcs, mtime = self.get_arcs()          # arcs.py — 1 Comic FK fetch + 1 StoryArc query + per-arc work
+books = self.get_book_collection()     # books.py — 1 ACL+filter query + N rows materialized + per-book settings/bookmark
+arc = {...}                            # in-memory dict assembly
+close_route = self.get_last_route()    # 1 SettingsBrowser query (cached on view)
+```
+
+Estimated per-request query count:
+
+| Phase | Queries | Notes |
+| ----- | ------: | ----- |
+| Params validation | ~1 | `SettingsReader` + `SettingsBrowser` lookups (cached on view; first hit only) |
+| `_get_field_names` | 1 | `AdminFlag.objects.get(folder_view)` — see #2 |
+| `get_arcs.Comic.objects.get` | 1 | Comic + select_related FKs |
+| `_get_story_arcs` | 1–2 | `StoryArc.exists()` + main query |
+| `get_book_collection._get_comics_list` | 1 | Filtered comics queryset (count + iteration) — see #1 |
+| `comics.count()` | 1 | Separate COUNT query |
+| `_append_with_settings` × 1–3 | 2–6 | `SettingsReader.first()` + `Bookmark.first()` per book |
+| `get_last_route` | ~0–1 | Cached |
+
+Total: **~8–13 queries per reader open**, plus the materialization
+cost of the comics list (which scales with arc size — 100-issue
+series materializes 100 rows).
+
+## Hotspots
+
+### #1 — `get_book_collection` materializes the entire arc to find prev/curr/next
+
+`codex/views/reader/books.py:147-181`:
+
+```python
+def get_book_collection(self) -> dict:
+    comics = self._get_comics_list()
+    books = {}
+    prev_book = None
+    pk = self.kwargs.get("pk")
+    for index, book in enumerate(comics):
+        if books:
+            books["next"] = self._append_with_settings(book)
+            break
+        if book.pk == pk:
+            if prev_book:
+                books["prev"] = self._append_with_settings(prev_book)
+            book.filename = book.get_filename()
+            self._selected_arc_index = index + 1
+            self._selected_arc_count = comics.count()
+            books["current"] = self._append_with_settings(book)
+        else:
+            prev_book = book
+    ...
+```
+
+The docstring acknowledges the optimal SQL approach was rejected:
+
+> Uses iteration in python. There are some complicated ways of
+> doing this with `__gt[0]` & `__lt[0]` in the db, but I think they
+> might be even more expensive.
+
+Hand-waving aside, the actual cost shape:
+
+- `_get_comics_list` returns a queryset filtered by ACL + arc
+  membership + browser filters, with `prefetch_related` for
+  story_arc_numbers, ordered by `arc_index, date, pk` (story arc)
+  or `path, pk` (folder) or `sort_name, issue_number, ...`
+  (series/volume).
+- The `for index, book in enumerate(comics):` loop materializes
+  every row up to and including the row AFTER the current pk.
+- For a series with 100 issues, reading issue #5 materializes 6
+  rows; reading issue #95 materializes 96 rows. Average across the
+  series: 50 rows materialized per reader open.
+- `comics.count()` (line 173) **fires a separate COUNT(*) query**
+  even after iteration begins. The count is needed for the
+  `index/count` display in the UI ("Issue 5 of 100"); it's not
+  derivable from a partial iteration.
+
+Mitigations (in order of preference):
+
+- **Two targeted queries.** One LIMIT 1 query for the current comic
+  (already known by pk), one ORDER BY ... DESC LIMIT 1 query
+  filtered to "comics ordered before the current" (prev), and one
+  ORDER BY ... ASC LIMIT 1 query for "comics ordered after the
+  current" (next). Plus the existing `count()` for total. Three
+  queries, three rows materialized — independent of arc size.
+- **Window-function single query.** `Comic.objects.annotate(rank=Window(RowNumber(), order_by=...))` with a self-join to find the rank-of-current and pull the rank±1 rows. One query, but window functions on SQLite have edge cases with `partition_by` and SQL complexity. The two-targeted-queries approach is simpler.
+- **Separate `count` from `prev/curr/next` fetch.** Even with
+  the existing implementation, deferring `comics.count()` to a
+  second query that runs only after the current is found avoids a
+  scan when the user is on page 1.
+
+**Severity: high.** The hottest of the reader chain. Wall-time scales
+linearly with arc size. For a 100-issue series, dozens of rows
+materialized on every reader open with all annotations + ordering.
+
+### #2 — `AdminFlag.objects.get(folder_view)` fired per request
+
+`codex/views/reader/arcs.py:33-37`:
+
+```python
+for field_name in _COMIC_ARC_FIELD_NAMES:
+    if field_name == "parent_folder":
+        efv_flag = (
+            AdminFlag.objects.only("on")
+            .get(key=AdminFlagChoices.FOLDER_VIEW.value)
+            .on
+        )
+        if not efv_flag:
+            continue
+    ...
+```
+
+Same anti-pattern flagged in OPDS sub-plans 02 #6 and 04 #2. Reads
+the admin flag uncached even though the request-scoped
+`self.admin_flags` `MappingProxyType` (from
+`SearchFilterView.admin_flags`) exposes `folder_view` as a dict
+lookup.
+
+Inherited via the chain:
+
+```
+ReaderArcsView → ReaderParamsView → ReaderSettingsBaseView → SettingsBaseView → ...
+```
+
+Whether `SettingsBaseView` exposes `admin_flags` needs verification.
+If yes, the fix is `self.admin_flags.get("folder_view")`. If no,
+the fix is to either (a) inherit the right mixin path that does, or
+(b) wire the flag onto an instance-cached property at this level.
+
+Mitigation: use `self.admin_flags["folder_view"]`. Single edit,
+eliminates the query.
+
+**Severity: medium.** One query saved per reader open. Same
+cross-cutting pattern that ships through the perf project's other
+view families.
+
+### #3 — `_append_with_settings` fires 2 queries per book
+
+`codex/views/reader/books.py:49-59`:
+
+```python
+def _append_with_settings(self, book):
+    reader_auth = self._get_reader_settings_auth_filter()
+    book.settings = SettingsReader.objects.filter(**reader_auth, comic=book).first()
+    bookmark_auth = self.get_bookmark_auth_filter()
+    book.bookmark = (
+        Bookmark.objects.filter(**bookmark_auth, comic=book)
+        .only("page", "finished")
+        .first()
+    )
+    return book
+```
+
+For 1–3 books returned (prev / curr / next) that's 2–6 queries.
+
+Mitigations:
+
+- **Annotate per-book settings + bookmark on the comics queryset
+  once.** `Comic.objects.annotate(my_settings=FilteredRelation(...))`
+  + `select_related("my_settings")` would fold the per-book lookups
+  into the main query.
+- **Batch the 1–3 book pks into one query.** After
+  `get_book_collection` knows which pks to attach data for, fire
+  one `SettingsReader.objects.filter(comic_id__in=pks)` and one
+  `Bookmark.objects.filter(comic_id__in=pks)`, then partition in
+  Python. Drops 2–6 queries to 2 queries.
+
+The first option is more elegant but trickier to compose with the
+existing iteration-driven flow. The second is mechanical and clearly
+correct. Land #1 first; #3 becomes obvious once #1 lands because
+the prev/curr/next pks are known up front from the targeted queries.
+
+**Severity: medium.** Always fires 2–6 queries; mechanical fix.
+
+### #4 — `_get_story_arcs` parses datetime strings per row in Python
+
+`codex/views/reader/arcs.py:67-95`:
+
+```python
+qs = qs.annotate(
+    ids=JsonGroupArray("id", distinct=True, order_by="id"),
+    updated_ats=JsonGroupArray(
+        "updated_at", distinct=True, order_by="updated_at"
+    ),
+)
+...
+for sa in qs:
+    arc = {"name": sa.name}
+    ids = tuple(sorted(set(sa.ids)))
+    updated_ats = (
+        datetime.strptime(ua, _UPDATED_ATS_DATE_FORMAT_STR).replace(tzinfo=UTC)
+        for ua in sa.updated_ats
+    )
+    mtime = max_none(EPOCH_START, *updated_ats)
+    ...
+```
+
+`JsonGroupArray("updated_at", ...)` returns a JSON-encoded array of
+timestamp strings (SQLite doesn't have native datetime types, so
+the timestamps come back as ISO-ish strings). The Python code then
+`strptime`s every string per row.
+
+For a comic with N story arcs (typically 0–3), each having M
+related rows... this is small. But the strptime cost adds up if
+some users have heavily-tagged story-arc comics.
+
+Mitigations:
+
+- **Aggregate the max in SQL.** `Max("updated_at")` instead of
+  `JsonGroupArray("updated_at", ...)` returns a single datetime per
+  arc that Django converts to a Python datetime via the field's
+  `from_db_value`. No string parsing.
+- **Cache the format string `_UPDATED_ATS_DATE_FORMAT_STR`.** Already
+  module-level; no win.
+
+**Severity: low.** Cleanup-worthy; not a hotspot at typical
+story-arc counts.
+
+### #5 — `_get_field_names` checks the same admin flag inside a 3-iteration loop
+
+Related to #2 — the admin-flag lookup is *inside* the
+`for field_name in _COMIC_ARC_FIELD_NAMES:` loop (lines 30–47).
+With `_COMIC_ARC_FIELD_NAMES = ("series", "volume", "parent_folder")`,
+the AdminFlag query fires only when `field_name == "parent_folder"`
+(the third iteration), so it's actually 1 query per request, not 3.
+Still a candidate for hoisting once the cached lookup is in place
+(via #2).
+
+The other branch (`show.get(group)`) reads from
+`self.get_from_settings("show", browser=True)`. That's a per-request
+call but presumably memoized inside the settings layer. Confirm
+during the implementation pass.
+
+**Severity: trivial.** Closes with #2.
+
+### #6 — `_set_selected_arc` walks `all_arc_ids` for intersect
+
+`codex/views/reader/arcs.py:97-116`:
+
+```python
+def _set_selected_arc(self, arcs) -> None:
+    arc = self.params["arc"]
+    arc_group = arc["group"]
+    requested_arc_ids = arc.get("ids", ())
+    arc_id_infos = arcs.get(arc_group)
+    all_arc_ids: frozenset[tuple[int, ...]] = (
+        frozenset(arc_id_infos.keys()) if arc_id_infos else frozenset()
+    )
+    arc_ids = ()
+    if arc_group == STORY_ARC_GROUP:
+        if requested_arc_ids in all_arc_ids:
+            arc_ids = requested_arc_ids
+        else:
+            for arc_ids in all_arc_ids:
+                if requested_arc_ids.intersection(frozenset(arc_ids)):
+                    break
+    if not arc_ids:
+        arc_ids = next(iter(all_arc_ids))
+    ...
+```
+
+The `frozenset(arc_ids)` build inside the loop allocates per
+iteration. For a story-arc with many disjoint groupings this is
+O(N × M). N is small in practice (story-arc count per comic, usually
+0–3) so this isn't a real hotspot.
+
+Pre-build `frozenset(arc_ids)` per `all_arc_ids` entry once outside
+the loop if cleanup-required. Otherwise leave.
+
+**Severity: trivial.** Code health, not perf.
+
+### #7 — `_get_comics_list` annotation pyramid
+
+`codex/views/reader/books.py:99-145`:
+
+```python
+qs = qs.annotate(
+    volume_number_to=(F("volume__number_to")),
+    issue_count=F("volume__issue_count"),
+    arc_pk=F(arc_pk_rel),
+    arc_index=arc_index,
+    mtime=F("updated_at"),
+    has_metadata=ExpressionWrapper(
+        Q(metadata_mtime__isnull=False), output_field=BooleanField()
+    ),
+)
+```
+
+Plus `annotate_group_names` (from `SharedAnnotationsMixin`) and
+optional `sort_name_annotations` (from `_get_comics_annotation_and_ordering`).
+
+Each annotation appears in the SELECT clause and the `ORDER BY`
+clause. The query already runs against an indexed comic table so
+the per-row cost is bounded.
+
+The `arc_pk` and `arc_index` annotations are needed for the prev /
+curr / next ordering — they should remain. The
+`volume_number_to` / `issue_count` annotations are read in the
+serializer; verify whether the reader serializer needs them on
+prev/next (probably yes, for display).
+
+**Severity: low.** Inherited query shape; auditing for fields that
+prev/next entries don't actually need would slim the SELECT but
+gains are small.
+
+## Out of plan
+
+- **The `_get_comics_filter` ACL composition.** `get_acl_filter`
+  and `ComicFieldFilterView.get_all_comic_field_filters` come from
+  the browser-views perf project's filter pipeline. Already
+  audited; no reader-specific work.
+- **The `SharedAnnotationsMixin.get_sort_name_annotations`.** Same.
+- **`get_last_route`.** Trivial settings lookup, cached.
+- **`Comic.get_filename`.** Cheap string assembly off the comic row.
+
+## Open questions
+
+- **Does the reader endpoint cache key safely scope per-user?** It
+  serves per-user bookmarks/settings. A `cache_page(60)` wrap with
+  `vary_on_cookie` would amortize the cost across rapid tab
+  refreshes (e.g. mobile-app re-foreground). Same trade-off as
+  OPDS Stage 2: 60 s of staleness vs. zero re-render cost. Worth
+  scheduling as a separate item.
+- **What's the actual comic page count distribution?** Determines
+  how often the prev/curr/next iteration's worst-case (last comic
+  in arc) fires.
+- **What's the read-time hit pattern?** A single user opening one
+  comic vs. browsing through many is a different cost shape.
+  Production traffic data would clarify.

--- a/tasks/reader-views-perf/02-reader-settings.md
+++ b/tasks/reader-views-perf/02-reader-settings.md
@@ -1,0 +1,266 @@
+# 02 — Reader settings (`c/settings`, `c/<pk>/settings`)
+
+Per-scope settings CRUD. Settings can live at five scope levels:
+
+- **`g`** (global) — one row per user, no FK.
+- **`c`** (comic) — one row per (user, comic).
+- **`s`** / `p` / `i` / `v` (series, all canonicalized to `s`) —
+  one row per (user, series).
+- **`f`** (folder) — one row per (user, folder).
+- **`a`** (story_arc) — one row per (user, story_arc).
+
+Three HTTP methods:
+
+- `GET ?scopes=g,s,c` — return settings for the requested scopes.
+- `PATCH` — update a single scope (with optional `scope_pk`).
+- `DELETE` — reset / drop the scope.
+
+## Files in scope
+
+| File | LOC | Purpose |
+| ---- | --- | ------- |
+| `codex/views/reader/settings.py` | 309 | `ReaderSettingsBaseView` + `ReaderSettingsView`. Two classes; the base is also inherited by the reader view chain (sub-plan 01). |
+
+## Per-request cost shape
+
+### GET — `?scopes=g,s,c` (typical multi-scope read)
+
+```python
+# Pre-fetch comic if any non-g/c scope needs it
+if needed_comic_fks and comic_pk:
+    comic = Comic.objects.only(*needed_comic_fks).get(pk=comic_pk)
+# Per scope
+for scope in requested:
+    self._get_scope(scope, scopes_out, comic, scope_info)
+```
+
+Per-scope work:
+
+- **`g` (global):** `_get_global_settings` does `filter().first()`
+  → if hit, return; if miss, `objects.create(...)` → 1 or 2
+  queries.
+- **`c` (comic):** `_get_scoped_settings("comic_id", comic.pk)` →
+  1 query.
+- **`s` (series), `f` (folder), `a` (story_arc):**
+  `_get_scoped_settings(fk_field, scope_pk)` → 1 query, plus a
+  follow-up `Model.objects.filter(pk=scope_pk).values_list("name").first()`
+  → 1 query for the scope's display name. **2 queries per
+  intermediate scope.**
+
+For `?scopes=g,s,c` typical: 1 (comic prefetch) + 1 (global) + 2
+(series settings + name) + 1 (comic settings) = **5 queries per GET**.
+
+For `?scopes=g,s,f,a,c` (all five): 1 + 1 + 2 + 2 + 2 + 1 = **9
+queries**.
+
+### PATCH
+
+- Validate input via serializer.
+- For non-global: `_get_or_create_scoped_settings(fk_field,
+  scope_pk)` → 1 (filter().first()) + 0–1 (create if missing) → 1–2
+  queries.
+- For global: `_get_global_settings()` → 1–2 queries.
+- `instance.save()` → 1 query.
+- Total: **2–3 queries per PATCH**.
+
+### DELETE
+
+- For global: `_get_global_settings()` + `instance.save()` → 2–3
+  queries.
+- For non-global: `SettingsReader.objects.filter(...).delete()` →
+  1 query.
+
+## Hotspots
+
+### #1 — Per-scope name lookup fires its own query
+
+`codex/views/reader/settings.py:198-207`:
+
+```python
+name = (
+    (
+        model.objects.filter(pk=scope_pk)
+        .values_list("name", flat=True)
+        .first()
+        or ""
+    )
+    if model
+    else ""
+)
+```
+
+For each non-global, non-comic scope (`s`, `f`, `a`) the GET
+handler fires a separate query just to fetch the name string for
+the scope display. With `?scopes=g,s,c` that's one extra query;
+with `?scopes=g,s,f,a,c` it's three.
+
+Mitigations:
+
+- **Fold into the comic prefetch.** When the comic is prefetched
+  for FK resolution (line 227), pull the scope display names from
+  the same comic row via `.select_related("series__name",
+  "parent_folder__path")`. Story-arcs aren't on the comic FK
+  pyramid; one extra query for them stays.
+- **Batch into a single query.** Collect all the `(model, pk)`
+  pairs, fire one query per model with `pk__in=[...]`, partition
+  by pk in Python. With at most 3 scope types this is 0–3 queries
+  vs. the current 0–3.
+- **Drop the name on the response.** If the frontend already
+  knows the display name (it has the scope_pk to PATCH against —
+  it presumably knows what it's editing), `scope_info` may be
+  unnecessary. Audit frontend usage first.
+
+**Severity: low.** 1–3 extra queries per GET; only fires on
+multi-scope GETs.
+
+### #2 — Two-query get-or-create pattern
+
+`codex/views/reader/settings.py:114-117` (global):
+
+```python
+instance = SettingsReader.objects.filter(**filter_kwargs).first()
+if instance is not None:
+    return instance
+return SettingsReader.objects.create(**base_lookup, **self.CREATE_ARGS)
+```
+
+Same shape at `_get_or_create_scoped_settings` (lines 124-132).
+Two queries on the create path, one on the hit path.
+
+Mitigations:
+
+- **`get_or_create`.** The Django ORM's
+  `Model.objects.get_or_create(defaults={}, **lookup)` does the
+  same logic in a single query (or two, with a race-condition
+  fallback). Mechanically equivalent.
+- **`update_or_create`.** Useful if the caller follows the get
+  with a save; not the case here for GET.
+
+The trade-off is that `get_or_create` doesn't accept the
+`FILTER_ARGS` / `CREATE_ARGS` dict separation the current code
+uses (the lookup keys are the same for filter and create). For the
+`_get_global_settings` path, `FILTER_ARGS` adds
+`comic__isnull=True` / `series__isnull=True` / etc. on top of
+`base_lookup`, while `CREATE_ARGS` sets those FKs explicitly to
+None at creation. Django's `get_or_create` would do the right
+thing if `defaults` are supplied — but the asymmetry is worth
+preserving review attention during the conversion.
+
+**Severity: low.** Saves 1 query per cold GET on global. Rare.
+
+### #3 — `_resolve_scope_pk` calls `getattr(comic, comic_fk, None)` per scope
+
+`codex/views/reader/settings.py:156-168`:
+
+```python
+def _resolve_scope_pk(
+    self,
+    scope: str,
+    comic_fk: str | None,
+    comic: Comic | None,
+) -> int | None:
+    if scope == "a":
+        raw = self.request.GET.get("story_arc_pk")
+        return int(raw) if raw else None
+    if comic and comic_fk:
+        return getattr(comic, comic_fk, None)
+    return None
+```
+
+Pure attribute access; fine.
+
+The pre-fetch on line 227:
+
+```python
+needed_comic_fks = set()
+for scope in requested:
+    config = _SCOPE_MAP.get(scope)
+    if config and config[1]:
+        needed_comic_fks.add(config[1])
+if needed_comic_fks and comic_pk:
+    comic = Comic.objects.only(*needed_comic_fks).get(pk=comic_pk)
+```
+
+Already correctly batches the FK lookup into one query. No change
+needed.
+
+**Severity: none.** Already optimal.
+
+### #4 — `get_reader_default_params` rebuilds the defaults dict per call
+
+`codex/views/reader/settings.py:63-69`:
+
+```python
+@classmethod
+def get_reader_default_params(cls) -> dict:
+    return {
+        key: cls._get_field_default(SettingsReader, key)
+        for key in SettingsReader.DIRECT_KEYS
+    }
+```
+
+Called from `reset_reader_settings` (DELETE on global). Each call
+walks the model field list. The values are pure model metadata —
+they don't change at runtime.
+
+Mitigation: cache the dict at class load via a `Final` /
+`cached_classproperty` / lazy module-level cache. Trivial.
+
+**Severity: trivial.** Code health.
+
+### #5 — `_get_bookmark_auth_filter` is duplicated from `BookmarkAuthMixin`
+
+`codex/views/reader/settings.py:83-92`:
+
+```python
+def _get_bookmark_auth_filter(self) -> dict[str, int | str | None]:
+    """Filter only the current user's settings rows."""
+    if TYPE_CHECKING:
+        self.request: Request
+    if self.request.user.is_authenticated:
+        return {"user_id": self.request.user.pk}
+    if not self.request.session or not self.request.session.session_key:
+        logger.debug("no session, make one")
+        self.request.session.save()
+    return {"session_id": self.request.session.session_key}
+```
+
+The class docstring references "_ReaderSettingsAuthMixin /
+BookmarkAuthMixin" inlining; the duplicated copy here ensures the
+settings view doesn't depend on `BookmarkAuthMixin`. Functionally
+correct; mostly refactor opportunity.
+
+`books.py:43` (`ReaderBooksView`) uses
+`self.get_bookmark_auth_filter()` (from `BookmarkAuthMixin`), which
+returns a dict with `user_id` / `session_id` — same shape as this
+inline copy.
+
+Mitigations:
+
+- **De-dupe.** Have `ReaderSettingsBaseView` inherit
+  `BookmarkAuthMixin` and drop the local copy. Or move the helper
+  into a shared module.
+
+**Severity: code health.** Not perf.
+
+## Out of plan
+
+- **PATCH `instance.save()` cachalot churn.** Settings writes
+  invalidate `SettingsReader` rows in cachalot. Settings volume is
+  low (a few writes per session at most), so the churn doesn't
+  matter.
+- **`SettingsReader.DIRECT_KEYS` introspection.** Reflects the
+  model schema; not a perf concern.
+- **The `_canonical_scope` aliasing.** Pure dispatch, no DB.
+
+## Open questions
+
+- **What's the actual scope-GET volume?** If the frontend reads
+  multi-scope settings on every settings panel open and writes
+  per-field changes, the GET path is read-heavy and worth tuning;
+  the PATCH path isn't.
+- **Does the frontend already know scope display names?** If so,
+  `scope_info` is redundant and #1 closes by deletion.
+- **Could settings be cached per-user with a short TTL?** They're
+  user-state and rarely change; a 60 s cache with `vary_on_cookie`
+  would zero out the read path.

--- a/tasks/reader-views-perf/03-reader-page.md
+++ b/tasks/reader-views-perf/03-reader-page.md
@@ -1,0 +1,285 @@
+# 03 — Reader page binary (`c/<pk>/<page>/page.jpg`)
+
+The hottest endpoint in the codex. Returns a single page image
+extracted from the comic archive (CBZ / CBR / PDF). Hit on every
+page turn. Optionally records the bookmark.
+
+## Files in scope
+
+| File | LOC | Purpose |
+| ---- | --- | ------- |
+| `codex/views/reader/page.py` | 106 | `ReaderPageView`. Page extraction, content-type negotiation, async bookmark update. |
+| `codex/urls/api/reader.py:21` | — | URL: `c/<pk>/<page>/page.jpg`, wrapped in `cache_control(PAGE_MAX_AGE)` only (no server-side `cache_page`). |
+
+## Per-request cost shape
+
+```python
+def _get_page_image(self):
+    acl_filter = self.get_acl_filter(Comic, self.request.user)
+    qs = Comic.objects.filter(acl_filter).only("path", "file_type").distinct()
+    pk = self.kwargs.get("pk")
+    comic = qs.get(pk=pk)              # 1 SQL query
+
+    page = self.kwargs.get("page")
+    pdf_format = ...
+    with Comicbox(comic.path, ...) as cb:
+        page_image = cb.get_page_by_index(page, pdf_format=pdf_format)
+        # ↑ DISK I/O: opens the archive (zip/rar/pdf), seeks to page, extracts.
+    ...
+    return page_image, content_type
+```
+
+Then `_update_bookmark` queues an async task (no SQL on request
+thread). The page bytes come back via `HttpResponse(page_image,
+content_type=...)`.
+
+Per-request cost:
+
+- 1 SQL query for the comic ACL/filter.
+- 1 disk I/O to open the comic archive.
+- Page extraction (CPU + disk read for the page bytes).
+- `Vary: Cookie`-style HTTP cache headers via `cache_control`.
+
+The Comicbox open dominates. CBZ open is fast (zip TOC read +
+single-entry read); CBR open is slower (the `unrar` shell-out is
+~10 ms minimum); PDF open is slowest (libpoppler init).
+
+## Hotspots
+
+### #1 — Comicbox opens the archive on every page request
+
+`codex/views/reader/page.py:63-64`:
+
+```python
+with Comicbox(comic.path, config=COMICBOX_CONFIG, logger=logger) as cb:
+    page_image = cb.get_page_by_index(page, pdf_format=pdf_format)
+```
+
+A 200-page comic = 200 archive opens per read-through. The browser
+loads pages sequentially as the user scrolls; reader apps may
+prefetch the next 1–2 pages. Either way, every page hit pays the
+archive-open cost.
+
+Mitigations:
+
+- **Pool the open archive per (comic, request thread, short
+  TTL).** A request-scoped `Comicbox` cache keyed on `comic_path`,
+  with explicit close on cache eviction. The browser's page-turn
+  pattern is "page N → page N+1 → page N+2", so re-opening the
+  same archive 3 times in 3 seconds is wasted work. A 30-second
+  per-process cache (LRU bounded) would absorb this.
+  - **Risk:** memory + file-descriptor pressure if many comics
+    are open simultaneously. The LRU size needs care. Worker
+    pool implications: with multiple Granian workers the cache
+    is per-worker, so memory multiplies.
+- **Pre-extract pages in advance.** Background task generates page
+  images on import; the page endpoint returns a static file. Storage
+  cost. Already partly addressed by the cover pipeline; pages would
+  be similar but more numerous.
+- **Streaming the page from a long-lived archive handle.** Same
+  shape as the pool above but explicitly per-comic.
+
+**Severity: very high.** Page-turn perceived latency. The biggest
+single win for the reader subsystem if it can be done safely.
+Needs measurement of cold vs. warm archive open to scope.
+
+### #2 — `Comic.objects.filter(acl_filter).only("path", "file_type").distinct().get(pk=pk)`
+
+`codex/views/reader/page.py:51-54`:
+
+```python
+acl_filter = self.get_acl_filter(Comic, self.request.user)
+qs = Comic.objects.filter(acl_filter).only("path", "file_type").distinct()
+comic = qs.get(pk=pk)
+```
+
+The ACL filter on every page request includes the visible-libraries
+sub-query. For most users this is a fast index hit; for users with
+many libraries it's a join. The `.distinct()` is required because
+the ACL filter joins through `library_groups`.
+
+Mitigations:
+
+- **Cache the (user, comic_pk) ACL decision per-process.** A small
+  LRU keyed on `(user_id, comic_pk)` with a 60-second TTL would
+  skip the per-page ACL check during a single read-through. Risk:
+  ACL is sensitive (revoke-vs-cache); per-process caching with a
+  short TTL is generally safe but worth flagging.
+- **Inline the path lookup.** If the comic's `path` and `file_type`
+  are known from the prior reader endpoint hit, the page endpoint
+  could trust them via signed query parameters. More complexity,
+  not a real win unless the ACL query proves expensive.
+
+**Severity: low-medium.** Single fast query per page request; the
+cost is dominated by the Comicbox open (#1).
+
+### #3 — `_update_bookmark` queues a task per page hit
+
+`codex/views/reader/page.py:31-46`:
+
+```python
+def _update_bookmark(self) -> None:
+    do_bookmark = bool(
+        self.request.GET.get("bookmark")
+        and self.request.headers.get("X-moz") not in self.X_MOZ_PRE_HEADERS
+    )
+    if not do_bookmark:
+        return
+
+    auth_filter = self.get_bookmark_auth_filter()
+    comic_pks = (self.kwargs.get("pk"),)
+    page = self.kwargs.get("page")
+    updates = {"page": page}
+
+    task = BookmarkUpdateTask(auth_filter, comic_pks, updates)
+    LIBRARIAN_QUEUE.put(task)
+```
+
+Already async — request thread doesn't pay the bookmark write cost.
+Good shape.
+
+The frontend can suppress bookmarking via `?bookmark=0` (and Firefox
+prefetch hints are filtered). Reasonable.
+
+The librarian thread that processes `BookmarkUpdateTask` is shared;
+high-throughput page reads queue many tasks. Whether the librarian
+queue throttles or the librarian processes them serially is a
+separate concern. Browser-views perf project's #18 (bookmark write
+batching) was the analogous concern there.
+
+Mitigations:
+
+- **Coalesce page-bookmark updates.** A user reading at one page per
+  3 seconds enqueues ~20 tasks/minute. Each task does a single UPDATE.
+  Coalescing in the librarian queue (only the latest page-update
+  per `(user, comic)` matters) would reduce DB write volume to ~1/min.
+  - Out of scope for view perf; belongs to a librarian-perf project.
+
+**Severity: low for the request-thread.** Out of scope for this
+plan but worth flagging for librarian-perf.
+
+### #4 — PDF format negotiation per request
+
+`codex/views/reader/page.py:58-62`:
+
+```python
+pdf_format = (
+    PageFormat.PIXMAP.value
+    if self.request.GET.get("pixmap", "").lower() not in FALSY
+    else ""
+)
+```
+
+Cheap: dict lookup + string compare. Fine.
+
+`codex/views/reader/page.py:68-75`:
+
+```python
+if (
+    comic.file_type == FileTypeChoices.PDF.value
+    and pdf_format not in _PDF_FORMAT_NON_PDF_TYPES
+):
+    content_type = _PDF_MIME_TYPE
+else:
+    content_type = self.content_type
+```
+
+Cheap. Fine.
+
+**Severity: none.**
+
+### #5 — No server-side caching on the page endpoint
+
+`codex/urls/api/reader.py:20-24`:
+
+```python
+path(
+    "<int:pk>/<int:page>/page.jpg",
+    cache_control(max_age=PAGE_MAX_AGE, public=True)(ReaderPageView.as_view()),
+    name="page",
+),
+```
+
+Only `cache_control` is applied — sets HTTP cache headers so the
+client's browser caches the page bytes for `PAGE_MAX_AGE` (one
+week). The server doesn't cache the response body itself.
+
+For repeat page hits (e.g. user re-reads a comic; multiple
+sessions across a household) the server re-extracts every page
+even though the bytes are immutable.
+
+Mitigations:
+
+- **`cache_page(PAGE_MAX_AGE)` wrap.** Like the cover endpoint
+  (`codex/urls/opds/binary.py:34-38`), wrap with `cache_page` +
+  `vary_on_cookie` (or `vary_on_headers("Cookie", "Authorization")`
+  if Basic / Bearer auth applies). The page bytes are user-scoped
+  via ACL but identical across users with access to the same
+  library — the Vary header keys per user/auth scheme. Same
+  trade-off as OPDS Stage 2.
+  - **Concern:** page byte payloads are large (~100–500 KB per
+    page). A cache holding many pages × many comics × many users
+    fills disk fast. The default cache backend is filesystem-based
+    (see `codex/settings/__init__.py:512`) with `MAX_ENTRIES =
+    10000`. With 200-page comics × 100 users × shared-library
+    scenarios, the cache spills its bound quickly and evicts.
+    Bounded-cache effectiveness worth measuring before
+    scheduling.
+- **Hybrid client + server cache.** `cache_control(public=True)`
+  already lets clients cache. A reverse proxy (nginx, Caddy) in
+  front of Granian can also cache by URL — moves the cache layer
+  out of the Django process. Worth documenting as the
+  recommended deployment shape.
+
+**Severity: high if archive-open cost (#1) is high; low otherwise.**
+Caching response bytes only helps when the underlying extraction
+is expensive. With #1 fixed (or with archives that are cheap to
+re-open), this matters less.
+
+### #6 — Distinct on the comic queryset
+
+`codex/views/reader/page.py:52`:
+
+```python
+qs = Comic.objects.filter(acl_filter).only("path", "file_type").distinct()
+```
+
+The `.distinct()` is required because the ACL filter joins through
+`codex_library_groups` which can produce duplicate rows. Removing
+it would risk leaking comics that match multiple group memberships.
+Not a real perf concern at single-comic-pk granularity (the LIMIT 1
+implied by `.get(pk=...)` collapses duplicates anyway).
+
+The browser-views perf project verified `distinct` necessity for
+the multi-row queryset path; for single-row this is mechanical.
+Could drop, but the gain is invisible.
+
+**Severity: trivial.** Leave as-is.
+
+## Out of plan
+
+- **Comicbox internals** — page extraction performance, archive-open
+  cost variance across CBZ / CBR / PDF. Tuning belongs to the
+  comicbox project, not codex.
+- **Frontend prefetch behavior.** Whether the reader pre-fetches N+1
+  / N+2 / N+3 pages affects perceived latency and shapes #1's
+  caching strategy. Out of scope for view-side analysis.
+- **Librarian bookmark-task throttling** — see #3.
+
+## Open questions
+
+- **What's the actual archive-open cost distribution?** CBZ
+  (zip): typically <5 ms cold open. CBR (rar): 10–30 ms. PDF:
+  10–100 ms depending on pages and renderer. Production traffic
+  data on file_type distribution + per-type wall time would
+  prioritize #1 vs. #5.
+- **What fraction of page hits are repeat reads?** Determines
+  whether server-side caching (#5) is worth the disk pressure.
+- **Reader UI prefetch pattern?** If the frontend prefetches +1,
+  +2, +3 ahead, the archive-open cache (#1) windows naturally
+  to the next 3 pages. If it prefetches +20 (full chapter), the
+  cache strategy changes shape.
+- **Worker pool sizing.** Multi-worker Granian deployments
+  multiply per-worker caches. The archive-open cache (#1) needs to
+  be shared across workers (e.g. via a sidecar process) or the
+  win evaporates with worker count.

--- a/tasks/reader-views-perf/99-summary.md
+++ b/tasks/reader-views-perf/99-summary.md
@@ -1,0 +1,269 @@
+# Codex `codex/views/reader/` — Performance Plan
+
+A prioritized, sequenced plan for improving the performance of every
+view under `codex/views/reader/` while preserving existing behavior.
+Based on a file-by-file audit of ~850 LOC across 6 source files.
+Broken out into three sub-plans:
+
+- [`00-meta-plan.md`](00-meta-plan.md) — methodology, surface map,
+  inheritance chain.
+- [`01-reader-view-chain.md`](01-reader-view-chain.md) — `c/<pk>`
+  GET (params / arcs / books / reader inheritance chain).
+- [`02-reader-settings.md`](02-reader-settings.md) — `c/settings`
+  and `c/<pk>/settings` CRUD.
+- [`03-reader-page.md`](03-reader-page.md) — `c/<pk>/<page>/page.jpg`
+  page binary.
+
+This document rolls all sub-plan findings into one ordered backlog.
+Each item cites the sub-plan for the detailed "why" and code-level
+specifics.
+
+---
+
+## 1. Executive summary — where the time is going
+
+The reader inherits the full `BrowserView` filter / annotation
+pipeline. Browser-views perf and OPDS-views perf already closed the
+shared hotspots (ACL filter, search parse, m2m gating, caching).
+That leaves three categories of reader-specific cost:
+
+1. **Comicbox archive open on every page request.** The biggest
+   single hotspot in the reader subsystem. A 200-page comic =
+   200 archive opens per read-through. Sub-plan 03 #1.
+
+2. **`get_book_collection` materializes the entire arc to find
+   prev/curr/next.** A 100-issue series materializes up to 100 rows
+   per reader open. Two targeted SQL queries (`__lt`/`__gt` LIMIT 1)
+   would collapse to 3 rows. Sub-plan 01 #1.
+
+3. **Caching at the route layer is disabled.** `c/<pk>` (reader),
+   `c/<pk>/<page>/page.jpg` (page server-side), and
+   `c/<pk>/settings` (settings) all run the full pipeline on every
+   request. Adding `cache_page` + `vary_on_cookie` (mirroring OPDS
+   Stage 2 / browser cover route) would amortize cold cost across
+   tab refreshes.
+
+Secondary cost centers (see ranked backlog):
+
+4. **Per-book settings/bookmark queries.** `_append_with_settings`
+   fires 2 queries × 1–3 books per reader open. Sub-plan 01 #3.
+5. **Uncached `AdminFlag.objects.get(folder_view)` in
+   `_get_field_names`.** Same anti-pattern as OPDS sub-plan 02 #6;
+   needs `self.admin_flags["folder_view"]`. Sub-plan 01 #2.
+6. **Per-scope name-lookup query in settings GET.** 1 extra query
+   per non-trivial scope. Sub-plan 02 #1.
+7. **Two-query get-or-create in settings.** Sub-plan 02 #2.
+
+---
+
+## 2. Ranked backlog
+
+Each row includes severity, estimated effort, risk, and a link to the
+sub-plan with the code-level analysis. Status is **all-open** at
+this point — no implementation has started. Use ⏳ Open until items
+land.
+
+### Tier 1 — critical latency wins
+
+| #   | Change | Sub-plan | Impact | Effort | Risk | Status |
+| --- | ------ | -------- | ------ | ------ | ---- | ------ |
+| 1   | **Pool / cache the open Comicbox archive per (comic, process, short TTL).** Reader page-turn pattern hits the same archive repeatedly within seconds; per-request open is wasted I/O. LRU bounded by file-descriptor / memory budget. Worker pool implications. | 03 #1 | **Very high** (page-turn perceived latency) | M-L | M | ⏳ Open |
+| 2   | **Replace `get_book_collection` whole-arc iteration with two targeted LIMIT-1 queries.** One query for `prev` (`< current.order_by_value` ORDER BY ... DESC LIMIT 1), one for `next` (`> current.order_by_value` ASC LIMIT 1). The current is already known by pk. Plus the existing `count()` for the arc index. | 01 #1 | **High** (linear → constant w.r.t. arc size; saves dozens of rows per reader open on large series) | M | M | ⏳ Open |
+| 3   | **Re-enable route caching on `c/<pk>` (`ReaderView`).** Wrap with `cache_page(60)` + `vary_on_cookie`. Mirrors OPDS Stage 2. Reader endpoint serves per-user state — Vary on Cookie scopes the cache key correctly. | 00 / 01 | **High** (every reader open currently re-runs the full pipeline) | S | M | ⏳ Open |
+
+### Tier 2 — redundant work on every request
+
+| #   | Change | Sub-plan | Impact | Effort | Risk | Status |
+| --- | ------ | -------- | ------ | ------ | ---- | ------ |
+| 4   | **Batch `_append_with_settings` queries.** After #2 lands, the prev/curr/next pks are known up front. One `SettingsReader.objects.filter(comic_id__in=pks)` + one `Bookmark.objects.filter(comic_id__in=pks)`, partition in Python. Drops 2–6 queries to 2. | 01 #3 | Medium (saves 0–4 queries per reader open) | S | L | ⏳ Open |
+| 5   | **Replace `AdminFlag.objects.get(folder_view)` with `self.admin_flags["folder_view"]` in `_get_field_names`.** Same anti-pattern as OPDS sub-plan 02 #6. Eliminates 1 query per reader open. Verify `admin_flags` is exposed on the reader inheritance chain. | 01 #2 | Low (1 query per reader open; cumulative cross-cutting) | S | L | ⏳ Open |
+| 6   | **Add server-side caching to the page endpoint** (`cache_page(PAGE_MAX_AGE)` + `vary_on_cookie`). Mirrors the cover endpoint. Trade-off: page bytes are large (~100–500 KB per page); cache disk pressure is real. Measure first. Less critical once #1 lands. | 03 #5 | High if #1 doesn't land; Low if #1 does | S | M | ⏳ Open |
+| 7   | **Fold the per-scope name lookup into the comic prefetch.** `_get_scope` for `s` / `f` scopes fires a separate `Model.objects.filter(pk).values_list("name")` query. `select_related("series__name", "parent_folder__path")` on the comic prefetch covers `s` and `f`; story_arcs need a separate one-shot query. | 02 #1 | Low (1–3 queries saved per multi-scope GET) | S | L | ⏳ Open |
+
+### Tier 3 — batch-shaped redundancies
+
+| #   | Change | Sub-plan | Impact | Effort | Risk | Status |
+| --- | ------ | -------- | ------ | ------ | ---- | ------ |
+| 8   | **Replace `JsonGroupArray("updated_at")` + Python strptime loop with `Max("updated_at")`.** Story-arc mtime computation parses datetime strings per row in Python. SQL aggregation returns a single datetime per arc that Django converts via the field's `from_db_value`. | 01 #4 | Low (cleanup; small wins on heavily-tagged story-arc comics) | S | L | ⏳ Open |
+| 9   | **Convert two-query get-or-create to `Model.objects.get_or_create`.** `_get_global_settings` and `_get_or_create_scoped_settings` both filter-then-create. Django ORM has the atomic primitive. | 02 #2 | Low (saves 1 query on cold-create paths) | S | L | ⏳ Open |
+| 10  | **Cache `get_reader_default_params` at class load.** Pure model metadata; doesn't change at runtime. | 02 #4 | Trivial | XS | L | ⏳ Open |
+| 11  | **Audit `_get_comics_list` annotation pyramid for prev/next dead fields.** Annotations applied to every row in the iteration — but prev/next entries don't need the same level of detail as current. Slimming the SELECT shrinks per-row I/O. | 01 #7 | Low | S | M | ⏳ Open |
+
+### Tier 4 — clean-ups / small wins
+
+| #   | Change | Sub-plan | Impact | Effort | Risk | Status |
+| --- | ------ | -------- | ------ | ------ | ---- | ------ |
+| 12  | **De-duplicate `_get_bookmark_auth_filter` between `ReaderSettingsBaseView` and `BookmarkAuthMixin`.** Currently inlined in two places. | 02 #5 | Code health | S | L | ⏳ Open |
+| 13  | **Pre-build `frozenset(arc_ids)` in `_set_selected_arc` once outside the loop.** Sub-plan 01 #6. Trivial. | 01 #6 | Trivial | XS | L | ⏳ Open |
+| 14  | **Drop redundant `.distinct()` on the page-endpoint comic queryset.** `.get(pk=pk)` LIMIT 1 collapses duplicates anyway. | 03 #6 | Trivial | XS | L | ⏳ Open |
+| 15  | **Cache the (user, comic_pk) ACL decision** for the page endpoint. Per-process LRU keyed on the pair, 60-second TTL. Skips the per-page ACL check during a single read-through. | 03 #2 | Low-Medium (depends on ACL filter cost in profile) | S-M | M | ⏳ Open |
+
+### Tier 5 — high-risk / needs investigation before scheduling
+
+| #   | Item | Sub-plan | Status |
+| --- | ---- | -------- | ------ |
+| R1  | **Reader perf harness.** No baseline data exists for reader endpoints. Build one analogous to `tests/perf/run_opds_baseline.py` covering at minimum: reader endpoint cold, page endpoint cold (+ per file_type), settings GET multi-scope, page-turn warm. Without this, every Tier 1–2 item is opinion-driven. | 00 (meta) | ⏳ Open |
+| R2  | **Per-route hit distribution.** Reader `c/<pk>` is hit once per comic-open; page `c/<pk>/<page>/page.jpg` is hit per page turn. Need production traffic data to scope #1's cache window and #6's disk pressure. | 03 (open) | ⏳ Open |
+| R3  | **Archive-open cost distribution.** CBZ vs. CBR vs. PDF. Determines whether #1 (archive cache) or #6 (response cache) is the higher-impact item, and whether each is worth landing. | 03 (open) | ⏳ Open |
+| R4  | **Reader frontend prefetch behavior.** Whether the reader pre-fetches +1, +2, +3 ahead — or +N for chapter-view — shapes #1's cache strategy and TTL. | 03 (open) | ⏳ Open |
+| R5  | **Worker pool implications for the archive cache.** Multi-worker Granian deployments multiply per-worker caches. Either the cache is shared across workers (sidecar / Redis / shared-memory) or the per-worker cache effectiveness drops linearly with worker count. | 03 (open) | ⏳ Open |
+
+---
+
+## 3. Suggested landing order
+
+Mirrors the OPDS phasing: measure first, then land independent
+low-risk wins, then tackle structural items.
+
+### Phase A — "measure before you cut" (required prep)
+
+- [ ] Build the reader perf harness (R1). Mirror the structure of
+      `tests/perf/run_opds_baseline.py` — JSON-output flows that
+      record cold + warm timings + query counts.
+- [ ] Record baseline timings for: reader endpoint cold, page
+      endpoint cold (CBZ + CBR + PDF; small + large), settings GET
+      multi-scope.
+- [ ] Sample production traffic distribution if possible (R2 / R3 /
+      R4).
+
+Without baselines, Tier 1 #1 (archive cache) is blocked because
+the size and TTL of the cache depends on traffic shape. #2 and #3
+are safe to land without traffic data — they're per-request
+deterministic improvements.
+
+### Phase B — high-value, low-risk per-request wins
+
+Independent fixes that don't depend on Tier 1 #1 landing:
+
+- **#5** (replace AdminFlag.objects.get with admin_flags cache) —
+  single edit.
+- **#9** (`get_or_create` for settings) — mechanical.
+- **#10** (cache reader default params) — trivial.
+- **#13**, **#14** — trivial cleanups.
+
+Together: a handful of small PRs over 1–2 days. Verify with the
+Phase A harness.
+
+### Phase C — `get_book_collection` rewrite (Tier 1 #2 + Tier 2 #4)
+
+Land #2 (two targeted LIMIT-1 queries) first. Once the prev/curr/next
+pks are known up front, #4 (batch settings/bookmark queries) becomes
+mechanical. Together they make the reader endpoint cold cost
+constant w.r.t. arc size.
+
+### Phase D — caching (Tier 1 #3) + #7
+
+#3 is the highest-impact items in the reader plan after the page
+endpoint:
+
+1. Wrap `c/<pk>` with `cache_page(60)` + `vary_on_cookie`.
+2. Verify with the Phase A harness that response correctness holds
+   across users (no cross-user leakage; bookmark-position changes
+   visible within TTL).
+3. Land #7 (settings name-lookup batching) as a follow-on cleanup
+   in the same phase.
+
+### Phase E — page-endpoint optimization (Tier 1 #1 + Tier 2 #6 + Tier 4 #15)
+
+This is the biggest-impact phase but also the highest-risk:
+
+1. Confirm R3 / R4 / R5 are resolved.
+2. Decide between #1 (archive cache) and #6 (response cache) based
+   on archive-open cost vs. cache disk pressure measurements.
+3. Land #15 (ACL decision cache) as a small win regardless.
+
+### Phase F — clean-ups (Tier 3 + 4)
+
+Land in any order. Each is a small, isolated PR.
+
+---
+
+## 4. Cross-cutting guidance
+
+A few patterns surfaced in multiple sub-plans; addressing them at
+the architectural level prevents recurrence.
+
+### A. Uncached `AdminFlag.objects.get` is the wrong shape
+
+`arcs.py:33-37`'s pattern is the same anti-pattern flagged in
+the OPDS plan (sub-plan 02 #6, 04 #2) and fixed in OPDS Stage 0
+Phase B #6. Any check that reads an `AdminFlag` must go through
+`self.admin_flags`, the request-scoped `MappingProxyType` populated
+by `codex/views/browser/filters/search/parse.py:197-211`. Never
+query `AdminFlag` directly in a view body.
+
+### B. Per-row Python parsing of SQL aggregate strings
+
+`arcs.py:67-95`'s `JsonGroupArray("updated_at") +
+strptime per row` is a SQLite-specific anti-pattern. SQLite stores
+datetimes as ISO strings, but Django's ORM normally handles the
+conversion via the field's `from_db_value`. Aggregations that
+return raw strings bypass that hook. Prefer `Max(field)` /
+`Min(field)` / similar SQL aggregates that yield typed Python
+values directly.
+
+### C. `get_or_create` over filter().first() + create()
+
+`settings.py:114-117` and `:124-132` use the manual pattern. Django
+ORM has `Model.objects.get_or_create(defaults={}, **lookup)` which
+is atomic + race-condition aware. Use it.
+
+### D. Whole-result-set materialization to find a window
+
+`books.py:get_book_collection` materializes the entire arc just to
+find the row with `pk == kwargs.pk`. The optimal pattern for
+"window around a known row" in SQL is two targeted queries
+(`__lt LIMIT 1` + `__gt LIMIT 1`) or a window function. The
+docstring's "I think they might be even more expensive" argument is
+backwards — materializing 100 rows is always more expensive than 3
+LIMIT-1 lookups.
+
+### E. Comicbox open is the dominant page-turn cost
+
+`page.py:_get_page_image` opens the archive on every request. Any
+real win on page-turn latency requires keeping the archive open
+across requests within a session. The trade-offs (memory, file
+descriptors, multi-worker deployment) make this a structural
+investment rather than a localized refactor.
+
+---
+
+## 5. What this plan does NOT address
+
+Out of scope for this pass:
+
+- Views outside `codex/views/reader/` (browser, OPDS, admin, auth,
+  etc.).
+- Serializer-layer N+1 audit. The browser plan deferred its
+  serializer audit to a separate handoff
+  (`tasks/browser-views-perf/stage5e-handoff-serializer-audit.md`).
+  When that audit lands, repeat for reader serializers in
+  `codex/serializers/reader.py`.
+- Frontend reader.
+- Comicbox internals — page extraction, archive parsing, PDF
+  rendering. Tuning belongs to the comicbox project.
+- Schema changes (denormalization, new indexes, PRAGMA tuning).
+- Librarian / scribe perf — including the bookmark-update task
+  coalescing flagged in sub-plan 03 #3.
+
+---
+
+## 6. Quick-reference: hotspot → sub-plan index
+
+| Code location | Hotspot | Sub-plan |
+| ------------- | ------- | -------- |
+| `codex/views/reader/page.py:63-64` | Comicbox open per page request | 03 #1 |
+| `codex/views/reader/books.py:147-181` | Whole-arc iteration | 01 #1 |
+| `codex/views/reader/arcs.py:33-37` | Uncached AdminFlag.get | 01 #2 |
+| `codex/views/reader/books.py:49-59` | Per-book settings/bookmark queries | 01 #3 |
+| `codex/views/reader/arcs.py:67-95` | Per-row strptime on `updated_ats` | 01 #4 |
+| `codex/views/reader/settings.py:198-207` | Per-scope name lookup | 02 #1 |
+| `codex/views/reader/settings.py:114-117` + `:124-132` | filter().first() + create() | 02 #2 |
+| `codex/views/reader/settings.py:63-69` | `get_reader_default_params` rebuilt per call | 02 #4 |
+| `codex/views/reader/settings.py:83-92` | Duplicated `_get_bookmark_auth_filter` | 02 #5 |
+| `codex/views/reader/page.py:51-54` | ACL filter on every page request | 03 #2 |
+| `codex/views/reader/page.py:31-46` | Async bookmark task per page hit | 03 #3 |
+| `codex/views/reader/page.py:52` | `.distinct()` on single-row queryset | 03 #6 |
+| `codex/urls/api/reader.py:19` | No `cache_page` on reader endpoint | 00 / 01 |
+| `codex/urls/api/reader.py:20-24` | No server-side `cache_page` on page endpoint | 03 #5 |
+| `codex/urls/api/reader.py:41-46` | No cache on settings endpoint | 02 (open) |


### PR DESCRIPTION
## Summary

Audit of `codex/views/reader/` (~850 LOC across 6 source files) mirroring the [OPDS perf plan](tasks/opds-views-perf/99-summary.md) structure. Five documents:

- [`00-meta-plan.md`](tasks/reader-views-perf/00-meta-plan.md) — methodology, surface map, inheritance chain.
- [`01-reader-view-chain.md`](tasks/reader-views-perf/01-reader-view-chain.md) — `c/<pk>` GET (params / arcs / books / reader chain).
- [`02-reader-settings.md`](tasks/reader-views-perf/02-reader-settings.md) — `c/settings` + `c/<pk>/settings` CRUD.
- [`03-reader-page.md`](tasks/reader-views-perf/03-reader-page.md) — `c/<pk>/<page>/page.jpg` page binary.
- [`99-summary.md`](tasks/reader-views-perf/99-summary.md) — ranked backlog + suggested landing order.

15 ranked items + 5 research questions. Top three findings:

1. **Comicbox archive open on every page request** (sub-plan 03 #1) — 200-page comic = 200 archive opens per read-through. The biggest single hotspot; needs an LRU process-cache of open archives.
2. **`get_book_collection` materializes the entire arc to find prev/curr/next** (sub-plan 01 #1) — 100-issue series = up to 100 rows materialized per reader open. Two targeted LIMIT-1 queries collapse to 3 rows independent of arc size.
3. **No server-side caching on the reader / page / settings routes** — every request re-runs the full pipeline. Mirrors the OPDS Stage 2 fix.

## Suggested phasing

Mirrors OPDS / browser:

- **Phase A** — measure first. Build a reader perf harness mirroring `tests/perf/run_opds_baseline.py`.
- **Phase B** — low-risk per-request wins (admin-flag cache pattern, `get_or_create`, trivial cleanups).
- **Phase C** — `get_book_collection` rewrite + per-book settings/bookmark batching.
- **Phase D** — route caching on `c/<pk>` + settings name-lookup batching.
- **Phase E** — page endpoint (Comicbox cache + response cache; blocked on production traffic data).
- **Phase F** — cleanups.

## Test plan

- [x] `make fix` clean
- [x] `make lint` (Python) clean
- [ ] No code changes; planning-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)