### PR TITLE
Cover cleanup: render missing covers unblurred

### DIFF
--- a/frontend/src/components/book-cover.vue
+++ b/frontend/src/components/book-cover.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="bookCover">
     <v-img
-      :src="coverSrc"
-      :lazy-src="placeholderSrc"
+      :src="imgSrc"
+      :lazy-src="imgLazySrc"
       class="coverImg"
       :class="multiPkClasses"
       position="top"
@@ -51,6 +51,7 @@ export default {
     return {
       retry: 0,
       abort: null,
+      missing: false,
     };
   },
   computed: {
@@ -67,6 +68,21 @@ export default {
     },
     placeholderSrc() {
       return getPlaceholderSrc(this.group);
+    },
+    imgSrc() {
+      /*
+       * 404 → render the placeholder directly so it shows unblurred.
+       * Otherwise use the cover URL; v-img shows the blurred lazy-src
+       * until the real cover bytes arrive.
+       */
+      return this.missing ? this.placeholderSrc : this.coverSrc;
+    },
+    imgLazySrc() {
+      /*
+       * Skip lazy-src when missing so v-img doesn't apply its loading
+       * blur to the static fallback.
+       */
+      return this.missing ? undefined : this.placeholderSrc;
     },
     multiPkClasses() {
       const len = this.pks.length;
@@ -109,7 +125,13 @@ export default {
           return;
         }
         if (resp.status !== 202) {
-          if (sawPending) {
+          /*
+           * 404 = no cover ever; switch to the unblurred placeholder.
+           * Anything else (200, 5xx) leaves missing=false so v-img keeps
+           * its lazy-blur loading state for src.
+           */
+          this.missing = resp.status === 404;
+          if (sawPending && !this.missing) {
             this.retry = attempt + 1;
           }
           return;


### PR DESCRIPTION
## Summary

Follow-up to #605. When the cover endpoint returns 404 (no cover ever),
the per-type SVG placeholder should render **unblurred** — the
Vuetify `lazy-src` blur is meant for "still loading," not "doesn't exist."

Track a `missing` flag set by the polling loop on 404 and switch the
`<v-img>` to render `placeholderSrc` directly as `src` (with no
`lazy-src`) so the loading blur doesn't apply.

| State | `imgSrc` | `imgLazySrc` | Result |
| ----- | -------- | ------------ | ------ |
| Cover loading (initial) | `coverSrc` | `placeholderSrc` | Blurred SVG → real cover |
| Cover queued (202 polling) | `coverSrc` | `placeholderSrc` | Blurred SVG, swaps to real cover when poll bumps `retry` |
| **Cover 404** | `placeholderSrc` | `undefined` | **Unblurred SVG** |
| Cover 200 (real) | `coverSrc` | `placeholderSrc` | Real cover (lazy-src already faded out) |

## Test plan

- [ ] Hard-refresh a browser page with cards that have real covers —
  initial paint shows blurred per-type SVG, transitions to real cover.
- [ ] Hit a comic with no cover (cover endpoint 404s) — card shows the
  per-type SVG **unblurred**.
- [ ] Hit a comic whose cover is freshly enqueued (202 polling) — card
  shows blurred SVG, transitions to real cover when the cover thread
  finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)