### PR TITLE
Fix OPDS FK constraint failure on stale or cleaned-up sessions

### DIFF
--- a/codex/librarian/scribe/janitor/cleanup.py
+++ b/codex/librarian/scribe/janitor/cleanup.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import MappingProxyType
 
 from django.contrib.sessions.models import Session
+from django.core import signing
 from django.db.models.functions.datetime import Now
 
 from codex.librarian.scribe.janitor.failed_imports import JanitorUpdateFailedImports
@@ -172,7 +173,7 @@ class JanitorCleanup(JanitorUpdateFailedImports):
             self.status_controller.finish(status)
 
     def cleanup_sessions(self) -> None:
-        """Delete corrupt sessions."""
+        """Delete expired and corrupt sessions."""
         status = JanitorCleanupSessionsStatus()
         try:
             self.status_controller.start(status)
@@ -181,9 +182,22 @@ class JanitorCleanup(JanitorUpdateFailedImports):
             if count:
                 self.log.info(f"Deleted {count} expired sessions.")
             bad_session_keys = set()
+            store = Session.get_session_store_class()()
+            salt = store.key_salt  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+            serializer = store.serializer
             for encoded_session in Session.objects.all():
-                session = encoded_session.get_decoded()
-                if not session:
+                # Session.get_decoded() swallows decode errors and returns
+                # an empty dict, which is also the legitimate state for an
+                # anonymous session with no stored data — so we can't use
+                # it to detect corruption. Call signing.loads directly so a
+                # genuine signature/decode failure raises.
+                try:
+                    signing.loads(
+                        encoded_session.session_data,
+                        salt=salt,
+                        serializer=serializer,
+                    )
+                except Exception:
                     bad_session_keys.add(encoded_session.session_key)
 
             if bad_session_keys:

--- a/codex/views/settings.py
+++ b/codex/views/settings.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from types import MappingProxyType
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.contrib.sessions.models import Session
 from loguru import logger
 
 from codex.choices.browser import DEFAULT_BROWSER_ROUTE
@@ -56,10 +57,20 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
     # ── Session / user helpers ──────────────────────────────────────
 
     def _ensure_session_key(self) -> str | None:
-        """Ensure the Django session is saved and return its key."""
-        if not self.request.session.session_key:
-            self.request.session.save()
-        return self.request.session.session_key
+        """Ensure a Django session row exists in the DB and return its key."""
+        # The cookie may carry a session_key for a row that has been removed
+        # from the DB (e.g. by sessions cleanup or expiry). The cached_db
+        # backend serves such sessions from cache without rechecking, so
+        # session.session_key alone is not safe to use as an FK target.
+        session = self.request.session
+        if (
+            session.session_key
+            and not Session.objects.filter(session_key=session.session_key).exists()
+        ):
+            session.flush()
+        if not session.session_key:
+            session.save()
+        return session.session_key
 
     def _get_request_user(self):
         """Return the authenticated user or None."""


### PR DESCRIPTION
## Summary

Fixes intermittent `sqlite3.IntegrityError: FOREIGN KEY constraint failed` errors reported by users running iOS Panels against Codex over OPDS. Symptoms were three errors logged together (`Getting OPDS v1 namespace`, `Loading settings data from model`, `Internal Server Error: /opds/v1.2/...`) that worked again after a container restart and recurred a while later.

## Root cause

Two interacting bugs:

1. **`cleanup_sessions` over-deletes** ([codex/librarian/scribe/janitor/cleanup.py](codex/librarian/scribe/janitor/cleanup.py)). The nightly janitor used `if not encoded_session.get_decoded():` to flag "corrupt" sessions. But `get_decoded()` returns `{}` for both genuinely-broken sessions *and* legitimate anonymous sessions with no stored data — exactly what HTTP Basic Auth clients (Panels) produce. Every nightly run silently wiped those valid rows.

2. **`_ensure_session_key` trusts the cookie** ([codex/views/settings.py](codex/views/settings.py)). It returned `request.session.session_key` without checking whether the row still existed. With `SESSION_ENGINE = cached_db`, the session is served from cache after the DB row is gone, so a stale cookie key slipped through and was used as `SettingsBrowser.session_id` / `SettingsReader.session_id`, violating the FK on insert and on update.

## Fix

- Replace the buggy "corrupt detection" with a direct `signing.loads()` call so only real `BadSignature` / decode failures are flagged. Legitimate empty sessions are preserved.
- In `_ensure_session_key`, verify the `Session` row exists; if not, `session.flush()` (clears the stale cache entry) then `save()` to mint a fresh key before returning.

Either fix alone closes the user-visible error; together they also stop the churn that creates the bad state.

## Verification

- Reproduced the FK error end-to-end against a fresh DB before the patch (insert + update both failed with `IntegrityError: FOREIGN KEY constraint failed`).
- After the patch: anonymous empty sessions survive cleanup, genuinely-corrupt sessions are still detected, stale-cookie scenario cycles cleanly, and follow-up `SettingsBrowser` writes succeed.
- `ruff check`, `ruff format`, `basedpyright`, `ty`, `codespell` clean. `pytest tests/` — 5 passed.

## Test plan

- [ ] Have an iOS Panels user reconnect after the next nightly cleanup and confirm OPDS keeps working without a restart.
- [ ] Check janitor logs after a nightly run — "Deleted N corrupt sessions" should report 0 in normal operation.