### PR TITLE
Hoist session-key validation to AuthMixin; cover bookmark + reader-settings paths

### DIFF
--- a/codex/views/auth.py
+++ b/codex/views/auth.py
@@ -1,9 +1,10 @@
 """Views authorization bases."""
 
 from collections.abc import Sequence
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.models import Session
 from django.db.models.query_utils import Q
 from loguru import logger
 from rest_framework.authtoken.models import Token
@@ -16,6 +17,9 @@ from rest_framework.views import APIView
 
 from codex.choices.admin import AdminFlagChoices
 from codex.models import AdminFlag, Comic, Folder, StoryArc
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 
 
 class IsAuthenticatedOrEnabledNonUsers(IsAuthenticated):
@@ -40,6 +44,24 @@ class AuthMixin:
     permission_classes: Sequence[type[BasePermission]] = (
         IsAuthenticatedOrEnabledNonUsers,
     )
+
+    def _ensure_session_key(self) -> str | None:
+        """Ensure a Django session row exists in the DB and return its key."""
+        # The cookie may carry a session_key for a row that has been removed
+        # from the DB (e.g. by sessions cleanup or expiry). The cached_db
+        # backend serves such sessions from cache without rechecking, so
+        # session.session_key alone is not safe to use as an FK target.
+        if TYPE_CHECKING:
+            self.request: Request  # pyright: ignore[reportUninitializedInstanceVariable]
+        session = self.request.session
+        if (
+            session.session_key
+            and not Session.objects.filter(session_key=session.session_key).exists()
+        ):
+            session.flush()
+        if not session.session_key:
+            session.save()
+        return session.session_key
 
 
 class AuthAPIView(AuthMixin, APIView):  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/codex/views/bookmark.py
+++ b/codex/views/bookmark.py
@@ -4,12 +4,11 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 from django.db.models.query_utils import Q
-from loguru import logger
 from rest_framework.response import Response
 
 from codex.librarian.bookmark.tasks import BookmarkUpdateTask
 from codex.librarian.mp_queue import LIBRARIAN_QUEUE
-from codex.views.auth import AuthAPIView, GroupACLMixin
+from codex.views.auth import AuthAPIView, AuthMixin, GroupACLMixin
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -46,23 +45,14 @@ class BookmarkFilterMixin(GroupACLMixin, ABC):
         return Q(**my_bookmarks_kwargs)
 
 
-class BookmarkAuthMixin:
+class BookmarkAuthMixin(AuthMixin):
     """Base class for Bookmark Views."""
 
     def get_bookmark_auth_filter(self) -> dict[str, int | str | None]:
         """Filter only the user's bookmarks."""
-        if TYPE_CHECKING:
-            self.request: Request  # pyright: ignore[reportUninitializedInstanceVariable]
         if self.request.user.is_authenticated:
-            key = "user_id"
-            value = self.request.user.pk
-        else:
-            if not self.request.session or not self.request.session.session_key:
-                logger.debug("no session, make one")
-                self.request.session.save()
-            key = "session_id"
-            value = self.request.session.session_key
-        return {key: value}
+            return {"user_id": self.request.user.pk}
+        return {"session_id": self._ensure_session_key()}
 
 
 class BookmarkPageMixin(BookmarkAuthMixin):

--- a/codex/views/opds/auth.py
+++ b/codex/views/opds/auth.py
@@ -23,5 +23,5 @@ class OPDSAuthMixin(AuthMixin):
     def user_agent_name(self) -> str:
         """Memoize user agent name."""
         if self._user_agent_name is None:  # pyright: ignore[reportUnnecessaryComparison]
-            self._user_agent_name = get_user_agent_name(self.request)  # pyright: ignore[reportAttributeAccessIssue,reportUninitializedInstanceVariable], # ty: ignore[unresolved-attribute]
+            self._user_agent_name = get_user_agent_name(self.request)  # pyright: ignore[reportUninitializedInstanceVariable]
         return self._user_agent_name

--- a/codex/views/reader/settings.py
+++ b/codex/views/reader/settings.py
@@ -1,10 +1,8 @@
 """Reader settings views."""
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING
 
 from drf_spectacular.utils import extend_schema
-from loguru import logger
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
@@ -17,9 +15,6 @@ from codex.serializers.reader import (
     ReaderSettingsSerializer,
 )
 from codex.views.settings import NULL_VALUES, SettingsBaseView
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
 
 # scope letter → (SettingsReader FK field, Comic FK for auto-resolve, Model for name)
 # "g" = global (no FK).  "c" = comic.
@@ -82,14 +77,9 @@ class ReaderSettingsBaseView(SettingsBaseView):
 
     def _get_bookmark_auth_filter(self) -> dict[str, int | str | None]:
         """Filter only the current user's settings rows."""
-        if TYPE_CHECKING:
-            self.request: Request
         if self.request.user.is_authenticated:
             return {"user_id": self.request.user.pk}
-        if not self.request.session or not self.request.session.session_key:
-            logger.debug("no session, make one")
-            self.request.session.save()
-        return {"session_id": self.request.session.session_key}
+        return {"session_id": self._ensure_session_key()}
 
     def _get_settings_lookup(self, **extra):
         """Build the base lookup for a SettingsReader query."""

--- a/codex/views/settings.py
+++ b/codex/views/settings.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from types import MappingProxyType
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
-from django.contrib.sessions.models import Session
 from loguru import logger
 
 from codex.choices.browser import DEFAULT_BROWSER_ROUTE
@@ -55,22 +54,6 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
     BROWSER_CLIENT: ClientChoices = ClientChoices.API
 
     # ── Session / user helpers ──────────────────────────────────────
-
-    def _ensure_session_key(self) -> str | None:
-        """Ensure a Django session row exists in the DB and return its key."""
-        # The cookie may carry a session_key for a row that has been removed
-        # from the DB (e.g. by sessions cleanup or expiry). The cached_db
-        # backend serves such sessions from cache without rechecking, so
-        # session.session_key alone is not safe to use as an FK target.
-        session = self.request.session
-        if (
-            session.session_key
-            and not Session.objects.filter(session_key=session.session_key).exists()
-        ):
-            session.flush()
-        if not session.session_key:
-            session.save()
-        return session.session_key
 
     def _get_request_user(self):
         """Return the authenticated user or None."""


### PR DESCRIPTION
## Summary

Follow-up to #607. The same stale-`session_key` pattern that caused the OPDS FK error existed in two more write paths that #607 didn't touch:

- `BookmarkAuthMixin.get_bookmark_auth_filter` — fed `session_id` into `Bookmark.objects.bulk_create` / `bulk_update`.
- `ReaderSettingsBaseView._get_bookmark_auth_filter` — fed `session_id` into `SettingsReader.objects.create`.

Both used the old `if not session.session_key: save()` pattern that trusts whatever the cookie says.

## Change

Hoisted the validated `_ensure_session_key` helper from `SettingsBaseView` up to `AuthMixin` so every auth-aware view shares one implementation, then switched both call sites to use it. `BookmarkAuthMixin` now extends `AuthMixin` to inherit the helper.

`BookmarkFilterMixin.get_my_bookmark_filter` is intentionally unchanged — it's read-only (a `Q(...)` filter) and a missing/stale session correctly returns no rows there. Adding `AuthMixin` to it also creates MRO conflicts in views that combine both bookmark mixins.

Net: -44 / +29 lines, three duplicate copies of the session-key dance collapse to one.

## Verification

- End-to-end repro against a fresh DB: stale cookie → `BookmarkAuthMixin.get_bookmark_auth_filter` and `ReaderSettingsBaseView._get_bookmark_auth_filter` both return a filter dict with a freshly minted, DB-backed `session_id`. Authenticated user path returns `user_id` unchanged.
- `ruff check`, `ruff format`, `basedpyright`, `ty`, `codespell` clean. `pytest tests/` — 5 passed.

## Test plan

- [ ] Sanity-check that an anonymous OPDS bookmark PUT still creates a `Bookmark` row instead of FK-erroring after the next nightly cleanup window.
- [ ] Same for an anonymous reader-settings save.