### PR TITLE
Stats: fix user_registered_count / auth_group_count always-zero bug

### DIFF
--- a/codex/librarian/telemeter/stats.py
+++ b/codex/librarian/telemeter/stats.py
@@ -153,8 +153,13 @@ class CodexStats:
             return
         config = self._get_model_counts("config")
         sessions, config["user_anonymous_count"] = self._get_session_stats()
-        config["user_registered_count"] = config.pop("users_count", 0)
-        config["auth_group_count"] = config.pop("groups_count", 0)
+        # ``_get_model_counts`` keys off ``snakecase(model.__name__) + "_count"``
+        # — for ``django.contrib.auth.models.User`` / ``Group`` that is
+        # ``user_count`` / ``group_count`` (singular). The previous pop()s
+        # used ``users_count`` / ``groups_count`` which never existed,
+        # so both fields silently fell back to the default ``0``.
+        config["user_registered_count"] = config.pop("user_count", 0)
+        config["auth_group_count"] = config.pop("group_count", 0)
         obj["config"] = config
         obj["sessions"] = sessions
 


### PR DESCRIPTION
## Summary

Follow-up to #610. The Stats tab in the admin UI showed 0 registered
users / 0 auth groups even on installs with multiple accounts. Bug
predates #610 — long-standing since at least Sep 2024 — but surfaced
when verifying the perf cleanups landed correctly.

## Root cause

`_add_config` in `codex/librarian/telemeter/stats.py` tried to
rename the per-model count keys produced by `_get_model_counts`:

```python
config["user_registered_count"] = config.pop("users_count", 0)
config["auth_group_count"]      = config.pop("groups_count", 0)
```

But `_get_model_counts` builds keys as
`snakecase(model.__name__) + "_count"`. For Django's
`django.contrib.auth.models.User` / `Group` that produces
`user_count` and `group_count` (**singular**). The `pop()`s with the
plural names never matched, so the default `0` won every time. The
actual `user_count` / `group_count` keys were left orphaned in the
dict and then silently dropped by `StatsConfigSerializer`, which
only declares the renamed fields.

## Fix

Pop `user_count` / `group_count` (singular). One-line change plus a
comment explaining the source key shape so the next reader doesn't
re-introduce the typo.

## Test plan

- [ ] Hit `/api/v3/admin/stats` on an install with > 0 users —
  `user_registered_count` and `auth_group_count` reflect the real
  counts.
- [ ] If running locally with the #610 stats cache, restart the
  server (or wait 60s for TTL) so the cached zero response evicts.
- [x] `make lint-python` / `make test-python` clean against
  `v1.11-performance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)