### PR TITLE
Serializers perf 01: pycountry cache + ISO code hygiene

### DIFF
--- a/codex/migrations/0041_strip_pycountry_names.py
+++ b/codex/migrations/0041_strip_pycountry_names.py
@@ -1,0 +1,46 @@
+"""
+Strip outer whitespace from Country / Language name rows.
+
+Targeted clean-up for rows whose ``name`` field was written before
+``CleaningStringFieldMixin.get_prep_value`` learned to strip outer
+whitespace. Only ``Country`` and ``Language`` matter here: the
+serializer-side pycountry cache (``PyCountryField`` /
+``CountryField`` / ``LanguageField``) does an exact dict-key
+lookup against alpha_2 / alpha_3 codes, which a trailing space
+would silently miss.
+
+Other ``CleaningCharField`` consumers (description, summary,
+notes, …) are left alone — outer whitespace there is harmless
+display-side, and ``UPDATE … SET name = trim(name)`` would touch
+every row in the table for no functional gain.
+"""
+
+from django.db import migrations
+from django.db.models.functions import Trim
+
+
+def _strip_pycountry_names(apps, _schema_editor) -> None:
+    """Trim outer whitespace from Country.name and Language.name rows."""
+    # Country / Language are tiny lookup tables (< 250 rows each at
+    # the upper bound of pycountry's data), so the no-op cost of
+    # ``Trim`` over every row is negligible — cheaper than a regex
+    # pre-filter on SQLite.
+    for model_name in ("Country", "Language"):
+        model = apps.get_model("codex", model_name)
+        model.objects.update(name=Trim("name"))
+
+
+def _noop_reverse(_apps, _schema_editor) -> None:
+    """Reverse is a no-op — stripping whitespace is not reversible."""
+
+
+class Migration(migrations.Migration):
+    """Trim Country.name / Language.name."""
+
+    dependencies = [
+        ("codex", "0040_librarianstatus_codex_libstat_active_idx"),
+    ]
+
+    operations = [
+        migrations.RunPython(_strip_pycountry_names, _noop_reverse),
+    ]

--- a/codex/models/fields.py
+++ b/codex/models/fields.py
@@ -18,11 +18,18 @@ class CleaningStringFieldMixin:
     """Sanitizing Mixin for CharField & TextField."""
 
     def get_prep_value(self, value):
-        """Truncate, sanitize and unescape."""
+        """Truncate, sanitize, unescape, and strip outer whitespace."""
         if value := super().get_prep_value(value):  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
             value = value[: self.max_length]  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
             value = clean(value)
             value = unescape(value)
+            # Strip outer whitespace last so trailing spaces left over
+            # from upstream parsers don't poison FK keys
+            # (Country.name / Language.name are the motivating case —
+            # the serializer-side pycountry cache lookup relies on
+            # exact alpha_2 matches; see
+            # ``codex/serializers/fields/browser.py``).
+            value = value.strip()
         return value
 
 

--- a/codex/serializers/fields/browser.py
+++ b/codex/serializers/fields/browser.py
@@ -1,11 +1,12 @@
 """Custom fields."""
 
 from abc import ABC
-from typing import override
+from typing import ClassVar, override
 
 import pycountry
 from loguru import logger
 from pycountry.db import Database
+from rest_framework.fields import CharField
 from rest_framework.serializers import ListField
 
 from codex.choices.browser import (
@@ -13,7 +14,6 @@ from codex.choices.browser import (
     DUMMY_NULL_NAME,
 )
 from codex.serializers.fields.base import CodexChoiceField
-from codex.serializers.fields.sanitized import SanitizedCharField
 from codex.serializers.route import RouteSerializer
 
 
@@ -23,44 +23,76 @@ class BookmarkFilterField(CodexChoiceField):
     class_choices = tuple(BROWSER_BOOKMARK_FILTER_CHOICES.keys())
 
 
-class PyCountryField(SanitizedCharField, ABC):
-    """Serialize to a long pycountry name."""
+class PyCountryField(CharField, ABC):
+    """
+    Serialize to a long pycountry name.
+
+    The hot path is alpha_2 input — a tiny ISO code (``"US"``,
+    ``"FR"``, ``"EN"``) that pycountry resolves into a long display
+    name. Build a ``{alpha_2: name}`` dict once per subclass on
+    first use and serve the lookup from memory; that drops a per-
+    field per-comic ``DB.get(alpha_2=...)`` round trip (~µs each)
+    to a single dict ``get`` (~ns).
+
+    pycountry data ships with the package and is immutable across
+    the process lifetime. A server restart picks up package
+    upgrades; in-process invalidation is unnecessary.
+
+    Inherits from plain ``CharField`` rather than
+    ``SanitizedCharField`` — ISO codes are alphanumeric by
+    definition, so nh3 HTML sanitization on every write is dead
+    work. Outer whitespace is stripped in
+    :class:`codex.models.fields.CleaningStringFieldMixin` before
+    a value ever reaches this field.
+    """
 
     DB: Database = pycountry.countries
     _ALPHA_2_LEN = 2
+    _alpha_2_map: ClassVar[dict[str, str] | None] = None
+
+    @classmethod
+    def _get_alpha_2_map(cls) -> dict[str, str]:
+        """Lazy-build the alpha_2 → name projection on first call."""
+        if cls._alpha_2_map is None:
+            cls._alpha_2_map = {
+                row.alpha_2: row.name for row in cls.DB if hasattr(row, "alpha_2")
+            }
+        return cls._alpha_2_map
 
     @override
     def to_representation(self, value) -> str:
-        """Lookup the name with pycountry, just copy the value on fail."""
+        """Look up the long name via the cached alpha_2 map."""
         if not value:
             return ""
         if value == DUMMY_NULL_NAME:
             return value
+        # Defensive ``.strip()``: belt-and-braces for the pycountry
+        # cache lookup even if a row predates migration 0041.
+        value = value.strip()
+        if len(value) == self._ALPHA_2_LEN:
+            return self._get_alpha_2_map().get(value, value)
+        # Non-alpha_2 fallback — rare, e.g. legacy ``"eng"`` (alpha_3)
+        # or a free-form name. Fuzzy ``DB.lookup`` covers both.
         try:
-            # fix for https://github.com/flyingcircusio/pycountry/issues/41
-            lookup_obj = (
-                self.DB.get(alpha_2=value)
-                if len(value) == self._ALPHA_2_LEN
-                else self.DB.lookup(value)
-            )
-            # If lookup fails, return the key as the name
-        except Exception:
+            row = self.DB.lookup(value)
+        except (LookupError, KeyError):
             logger.warning(f"Could not serialize name with pycountry {value}")
             return value
-        else:
-            return lookup_obj.name if lookup_obj else value
+        return row.name if row else value
 
 
 class CountryField(PyCountryField):
     """Serializer to long country name."""
 
     DB: Database = pycountry.countries
+    _alpha_2_map: ClassVar[dict[str, str] | None] = None
 
 
 class LanguageField(PyCountryField):
     """Serializer to long language name."""
 
     DB: Database = pycountry.languages
+    _alpha_2_map: ClassVar[dict[str, str] | None] = None
 
 
 class BreadcrumbsField(ListField):

--- a/codex/serializers/fields/stats.py
+++ b/codex/serializers/fields/stats.py
@@ -1,5 +1,6 @@
 """Custom Vuetify fields."""
 
+from functools import cache
 from typing import override
 
 from rest_framework.fields import DictField, IntegerField
@@ -17,6 +18,16 @@ class StringListMultipleChoiceField(MultipleChoiceField):
         return super().to_internal_value(data)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
 
 
+@cache
+def _serializer_field_names(serializer_cls: type) -> tuple[str, ...]:
+    """Return the field names of ``serializer_cls`` once per class."""
+    # ``serializer_cls()`` runs DRF's metaclass field walk; cache by
+    # serializer class so AdminStatsRequestSerializer's five
+    # ``SerializerChoicesField`` instances share a single instantiation
+    # per target serializer.
+    return tuple(serializer_cls().get_fields().keys())
+
+
 class SerializerChoicesField(StringListMultipleChoiceField):
     """A String List Multiple Choice Field limited to a specified serializer's fields."""
 
@@ -25,8 +36,7 @@ class SerializerChoicesField(StringListMultipleChoiceField):
         if not serializer:
             reason = "serializer required for this field."
             raise ValueError(reason)
-        choices = serializer().get_fields().keys()
-        super().__init__(choices=choices, **kwargs)
+        super().__init__(choices=_serializer_field_names(serializer), **kwargs)
 
 
 class CountDictField(DictField):


### PR DESCRIPTION
## Summary

Implementation of [`tasks/serializers-perf/01-fields.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/serializers-perf/01-fields.md).

Three commits, scoped to country/language code handling at the
field layer.

### F0 — Strip outer whitespace at write (`89f97611`)

`CleaningStringFieldMixin.get_prep_value` now strips outer
whitespace alongside its existing nh3-clean + unescape pipeline.
A trailing space on `Country.name = "US "` would have silently
missed the new pycountry cache lookup; closing this gap at the
field layer means every write is normalized before it reaches the
DB.

Migration `0041_strip_pycountry_names.py` runs `Trim()` over
existing `Country.name` / `Language.name` rows. Targeted to the
two FK lookup tables that feed the pycountry cache; leaves
description / summary / review text alone (outer whitespace there
is benign and wholesale `Trim()` would touch every row for no
functional gain).

### F1 + F2 — `PyCountryField` cache + drop `SanitizedCharField` (`c10bf316`)

`PyCountryField.to_representation` ran
`pycountry.countries.get(alpha_2=...)` per Comic per request. A
50-card browser list × (country + language) = ~100 pycountry
calls per response.

Build a `{alpha_2: name}` dict once per subclass on first use and
serve from memory. `CountryField` / `LanguageField` each get
their own cache slot via `ClassVar`; the parent's `None` stays
untouched and the runtime `setattr` lands on the actual subclass.

Microbench (100k iterations):

| | µs/call |
| --- | --- |
| `pycountry.countries.get(alpha_2)` | 0.393 |
| Cached `_alpha_2_map.get()` | 0.118 |
| **Speedup** | **≈ 3.3×** |

Per browser-list response: ~30–40 µs of Python time saved.
Modest but free, and the cost compounds across endpoints that
touch Comic metadata (browser, metadata pane, OPDS).

Drop `SanitizedCharField` from `PyCountryField`'s inheritance —
ISO 3166-1 alpha-2 / ISO 639 codes are alphanumeric by
construction, so nh3 HTML sanitization on every write was dead
work.

Replace bare `except Exception:` with `except (LookupError,
KeyError):` so real exceptions surface during the fuzzy-lookup
fallback. Defensive `.strip()` on input as belt-and-braces in
case any pre-migration row predates F0.

### F3 — `SerializerChoicesField` cache (`4a33bb7b`)

`SerializerChoicesField.__init__` ran `serializer().get_fields()`
per field instance. `AdminStatsRequestSerializer` has five
instances; each was instantiating its target serializer at app
start.

Lift the introspection into a module-level `@cache` helper keyed
by the serializer class. Cosmetic — per-app-start, not
per-request.

## Test plan

- [x] `make lint-python` clean (ruff + format + basedpyright +
  vulture + complexipy + codespell).
- [x] `make test-python` clean (24 tests pass on the new
  migration).
- [x] `make test-frontend` clean.
- [x] Microbench shows ~3.3× speedup on pycountry alpha_2 lookups
  (100k iterations).
- [ ] On a live install, hit `/api/v3/<group>/<pks>/<page>` with
  international metadata; verify `country` / `language` long
  names render correctly.
- [ ] `make migrate` against an existing dev DB applies 0041
  cleanly.

## References

- Plan: `tasks/serializers-perf/01-fields.md`
- Meta plan: `tasks/serializers-perf/00-meta.md`
- Next sub-plan: `tasks/serializers-perf/02-browser.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)