### PR TITLE
Serializers perf 02: browser get_mtime + choices cache

### DIFF
--- a/codex/serializers/browser/choices.py
+++ b/codex/serializers/browser/choices.py
@@ -138,6 +138,18 @@ _CHOICES_NAME_SERIALIZER_MAP = MappingProxyType(
     }
 )
 _LIST_FIELDS = frozenset({"decade", "monochrome", "reading_direction", "year"})
+# ``BrowserSettingsFilterSerializer().get_fields()`` walks DRF's
+# metaclass and instantiates a serializer just to look up four field
+# representations. The fields are class-level definitions, so resolve
+# them once at module load and serve from a frozen dict on every
+# choices request.
+_LIST_FIELD_REPRESENTATIONS = MappingProxyType(
+    {
+        name: field
+        for name, field in BrowserSettingsFilterSerializer().get_fields().items()
+        if name in _LIST_FIELDS
+    }
+)
 
 
 class BrowserChoicesFilterSerializer(Serializer):
@@ -149,12 +161,8 @@ class BrowserChoicesFilterSerializer(Serializer):
         """Dynamic Serializer response by field type."""
         field_name = obj.get("field_name", "")
         choices = obj.get("choices", [])
-        serializer_class = _CHOICES_NAME_SERIALIZER_MAP.get(field_name)
-        if serializer_class:
-            value = serializer_class(choices, many=True).data
-        elif not serializer_class and field_name in _LIST_FIELDS:
-            field = BrowserSettingsFilterSerializer().get_fields().get(field_name)
-            value = field.to_representation(choices)  #  pyright: ignore[reportOptionalMemberAccess],# ty: ignore[unresolved-attribute]
-        else:
-            value = BrowserChoicesIntegerPkSerializer(choices, many=True).data
-        return value
+        if serializer_class := _CHOICES_NAME_SERIALIZER_MAP.get(field_name):
+            return serializer_class(choices, many=True).data
+        if field := _LIST_FIELD_REPRESENTATIONS.get(field_name):
+            return field.to_representation(choices)
+        return BrowserChoicesIntegerPkSerializer(choices, many=True).data

--- a/codex/serializers/browser/mixins.py
+++ b/codex/serializers/browser/mixins.py
@@ -42,9 +42,12 @@ class BrowserAggregateSerializerMixin(metaclass=SerializerMetaclass):
             if not dt_str:
                 continue
             try:
-                dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S.%f").replace(
-                    tzinfo=UTC
-                )
+                # ``fromisoformat`` accepts the SQLite GROUP_CONCAT
+                # output shape (``2024-01-15 10:30:45.123456``) since
+                # Python 3.11 and is ~20x faster than ``strptime`` —
+                # measurable savings on browser-list responses where
+                # this loop runs ~50 cards x ~50 timestamps.
+                dt = datetime.fromisoformat(dt_str).replace(tzinfo=UTC)
             except ValueError:
                 logger.warning(
                     f"computing group mtime: {dt_str} is not a valid datetime string."


### PR DESCRIPTION
## Summary

Implementation of [`tasks/serializers-perf/02-browser.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/serializers-perf/02-browser.md).

Two commits, scoped to browser-list and filter-menu hot paths.

### F1 — `get_mtime` `fromisoformat` (`2d085556`)

`BrowserAggregateSerializerMixin._get_max_updated_at` parsed every
SQLite `GROUP_CONCAT`'d timestamp string with `datetime.strptime`.
Per browser-list response: ~50 cards × ~50 timestamps each =
~2,500 invocations.

`fromisoformat` accepts the same `2024-01-15 10:30:45.123456`
shape since Python 3.11 and is dramatically faster:

| | µs/call |
| --- | --- |
| `strptime` | 3.199 |
| `fromisoformat` | 0.156 |
| **Speedup** | **≈ 20×** |

≈ 7–8 ms wall time saved on a 50-card response. Compounds with
the pycountry cache from PR #613 across the same hot path.

### F2 — `BrowserChoicesFilterSerializer` field cache (`73ee6045`)

`BrowserChoicesFilterSerializer.get_choices` instantiated
`BrowserSettingsFilterSerializer()` and walked `.get_fields()` per
request, just to look up the field representation for one of four
list fields (`decade`, `monochrome`, `reading_direction`, `year`).
These are class-level definitions independent of request state.

Resolve once at module load into a frozen
`_LIST_FIELD_REPRESENTATIONS` map; the per-request path becomes a
single dict get. Tighten the dispatch flow to early-return per
branch.

`/choices` is a filter-menu open path — low-volume but the win is
essentially free.

## Test plan

- [x] `make lint-python` clean.
- [x] `make test-python` clean (24 tests pass).
- [x] Microbench shows ~20× speedup on `fromisoformat` vs
  `strptime`.
- [ ] Hit `/api/v3/<group>/<pks>/<page>` on a populated DB; verify
  card mtime values match cold + warm.
- [ ] Hit `/api/v3/<group>/<pks>/choices/decade`,
  `.../choices/year`, etc. — output identical to pre-PR.

## References

- Plan: `tasks/serializers-perf/02-browser.md`
- Meta plan: `tasks/serializers-perf/00-meta.md`
- Previous: PR #613 (01-fields)
- Next: `tasks/serializers-perf/03-opds.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)