### PR TITLE
Serializers perf 03: OPDS v2 batching + link/unused cleanup

### DIFF
--- a/codex/serializers/opds/v2/links.py
+++ b/codex/serializers/opds/v2/links.py
@@ -6,8 +6,8 @@ from rest_framework.fields import (
     BooleanField,
     CharField,
     IntegerField,
+    JSONField,
     ListField,
-    SerializerMethodField,
 )
 from rest_framework.serializers import Serializer
 
@@ -16,25 +16,21 @@ class OPDS2LinkBaseSerializer(Serializer):
     """Minimal Link Serializer for Authenticate."""
 
     href = CharField(read_only=True)
-    rel = SerializerMethodField(read_only=True, required=False)
+    # ``rel`` is per OPDS spec a string OR an array of strings. Pass
+    # through whatever shape upstream ``LinkData.rel`` provides — DRF's
+    # ``JSONField`` returns the raw Python value without coercion.
+    # Replaces a per-link ``SerializerMethodField`` that ran an
+    # ``isinstance`` guard per dispatch (~5 links x N publications per
+    # OPDS feed).
+    rel = JSONField(read_only=True, required=False)
     type = CharField(read_only=True, required=False)
-
-    def get_rel(self, obj) -> str | list[str]:
-        """Allow for SanitizedCharField or CharListField types."""
-        rel: str | list[str] = obj.get("rel", "")
-        if rel and not isinstance(rel, list | str):
-            reason = "OPDS2LinkSerializer.rel is not a list or a string."
-            raise TypeError(reason)
-        return rel
 
     @override
     def to_representation(self, instance) -> dict:
-        """Clean complex rel field if None."""
+        """Drop the rel key if it serializes empty."""
         ret = super().to_representation(instance)
-
         if "rel" in ret and not ret["rel"]:
             del ret["rel"]
-
         return ret
 
 

--- a/codex/serializers/opds/v2/unused.py
+++ b/codex/serializers/opds/v2/unused.py
@@ -1,101 +1,112 @@
-"""Unused OPDS v2 Serializers."""
+"""
+Reference scaffolds for future OPDS v2 endpoints.
 
-from typing import Any, override
+These serializer shapes are NOT registered or imported anywhere;
+they exist as starting points for endpoints like the navigation
+feed, group feed, and library feed that the OPDS v2 spec allows
+but Codex does not yet expose. When wiring one of these
+endpoints, copy the relevant class out of the example block,
+move it into the appropriate module
+(``feed.py`` / ``publication.py`` / etc.), and import it from the
+view.
 
-from rest_framework.fields import CharField, DateTimeField, DecimalField, IntegerField
-from rest_framework.serializers import ChoiceField, Serializer
+Example::
 
-from codex.serializers.opds.v2.links import OPDS2LinkListField
+    from typing import Any, override
 
-
-class RecursiveField(Serializer):
-    """
-    A recursive field type.
-
-    There is a more comprehensive solution at
-    https://pypi.org/project/djangorestframework-recursive/
-    """
-
-    @override
-    def to_representation(self, instance) -> Any:
-        """Represent with own class."""
-        parent = self.parent
-        # Should not be ignored but is currently unused
-        serializer = parent.parent.__class__(instance, context=self.context)
-        return serializer.data
-
-
-class OPDS2PriceSerializer(Serializer):
-    """
-    Prices.
-
-    https://drafts.opds.io/schema/properties.schema.json
-    """
-
-    value = DecimalField(read_only=True, max_digits=10, decimal_places=2)
-    # by schema this should be a choices for allowed currencies.
-    currency = CharField(read_only=True, max_length=3)
-
-
-class OPDS2HoldsSerializer(Serializer):
-    """
-    Holds.
-
-    https://drafts.opds.io/schema/properties.schema.json
-    """
-
-    total = IntegerField(read_only=True)
-    position = IntegerField(read_only=True)
-
-
-class OPDS2CopiesSerializer(Serializer):
-    """
-    Copies.
-
-    https://drafts.opds.io/schema/properties.schema.json
-    """
-
-    total = IntegerField(read_only=True)
-    available = IntegerField(read_only=True)
-
-
-class OPDS2AcquisitionObjectSerializer(Serializer):
-    """
-    Acquisition Object.
-
-    https://drafts.opds.io/schema/acquisition-object.schema.json
-    """
-
-    type = CharField(read_only=True)
-    child = RecursiveField(many=True, required=False)
-
-
-class OPDS2ProfileSerializer(Serializer):
-    """
-    Profile.
-
-    https://drafts.opds.io/schema/profile.schema.json
-    """
-
-    name = CharField(read_only=True)
-    email = CharField(read_only=True)
-    links = OPDS2LinkListField(read_only=True, required=False)
-    loans = OPDS2CopiesSerializer(read_only=True)
-    holds = OPDS2HoldsSerializer(read_only=True)
-
-
-class OPDS2AvailabilitySerializer(Serializer):
-    """
-    Availability.
-
-    https://drafts.opds.io/schema/properties.schema.json
-    """
-
-    CHOICES = ("available", "unavailable", "reserved", "ready")
-
-    state = ChoiceField(
-        choices=CHOICES,
-        read_only=True,
+    from rest_framework.fields import (
+        CharField,
+        DateTimeField,
+        DecimalField,
+        IntegerField,
     )
-    since = DateTimeField(read_only=True, required=False)
-    until = DateTimeField(read_only=True, required=False)
+    from rest_framework.serializers import ChoiceField, Serializer
+
+    from codex.serializers.opds.v2.links import OPDS2LinkListField
+
+
+    class RecursiveField(Serializer):
+        '''A recursive field type.
+
+        There is a more comprehensive solution at
+        https://pypi.org/project/djangorestframework-recursive/
+        '''
+
+        @override
+        def to_representation(self, instance) -> Any:
+            '''Represent with own class.'''
+            parent = self.parent
+            # Should not be ignored but is currently unused
+            serializer = parent.parent.__class__(instance, context=self.context)
+            return serializer.data
+
+
+    class OPDS2PriceSerializer(Serializer):
+        '''Prices.
+
+        https://drafts.opds.io/schema/properties.schema.json
+        '''
+
+        value = DecimalField(read_only=True, max_digits=10, decimal_places=2)
+        # by schema this should be a choices for allowed currencies.
+        currency = CharField(read_only=True, max_length=3)
+
+
+    class OPDS2HoldsSerializer(Serializer):
+        '''Holds.
+
+        https://drafts.opds.io/schema/properties.schema.json
+        '''
+
+        total = IntegerField(read_only=True)
+        position = IntegerField(read_only=True)
+
+
+    class OPDS2CopiesSerializer(Serializer):
+        '''Copies.
+
+        https://drafts.opds.io/schema/properties.schema.json
+        '''
+
+        total = IntegerField(read_only=True)
+        available = IntegerField(read_only=True)
+
+
+    class OPDS2AcquisitionObjectSerializer(Serializer):
+        '''Acquisition Object.
+
+        https://drafts.opds.io/schema/acquisition-object.schema.json
+        '''
+
+        type = CharField(read_only=True)
+        child = RecursiveField(many=True, required=False)
+
+
+    class OPDS2ProfileSerializer(Serializer):
+        '''Profile.
+
+        https://drafts.opds.io/schema/profile.schema.json
+        '''
+
+        name = CharField(read_only=True)
+        email = CharField(read_only=True)
+        links = OPDS2LinkListField(read_only=True, required=False)
+        loans = OPDS2CopiesSerializer(read_only=True)
+        holds = OPDS2HoldsSerializer(read_only=True)
+
+
+    class OPDS2AvailabilitySerializer(Serializer):
+        '''Availability.
+
+        https://drafts.opds.io/schema/properties.schema.json
+        '''
+
+        CHOICES = ("available", "unavailable", "reserved", "ready")
+
+        state = ChoiceField(
+            choices=CHOICES,
+            read_only=True,
+        )
+        since = DateTimeField(read_only=True, required=False)
+        until = DateTimeField(read_only=True, required=False)
+"""

--- a/codex/views/opds/v2/feed/publications.py
+++ b/codex/views/opds/v2/feed/publications.py
@@ -1,25 +1,62 @@
 """Publication Methods for OPDS v2.0 feed."""
 
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from datetime import datetime
 from math import floor
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from typing import Final, override
 from urllib.parse import quote_plus
 
 from caseconverter import snakecase
+from django.db.models import CharField, F, Value
 
 from codex.librarian.covers.create import THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH
 from codex.models import Comic
 from codex.models.groups import BrowserGroupModel, Folder
+from codex.models.named import Credit
 from codex.settings import BROWSER_MAX_OBJ_PER_PAGE
-from codex.views.opds.const import MimeType, Rel
+from codex.views.auth import GroupACLMixin
+from codex.views.opds.const import (
+    AUTHOR_ROLES,
+    OPDS_M2M_MODELS,
+    MimeType,
+    Rel,
+)
 from codex.views.opds.v2.const import HrefData, Link, LinkData
 from codex.views.opds.v2.feed.feed_links import OPDS2FeedLinksView
 
 _PUBLICATION_PREVIEW_LIMIT: Final = 5
 _PREVIEW_SHOW_PARAMS: Final[MappingProxyType[str, bool]] = MappingProxyType(
     {"p": True, "s": True}
+)
+# Direct ``Comic`` attribute → metadata key mapping. Mirrors the
+# manifest-side map in ``codex/views/opds/v2/manifest.py``; kept
+# in-module here because the publications feed shouldn't import view
+# code from the manifest path (sibling branches).
+_PUBLICATION_DIRECT_FIELDS: Final[MappingProxyType[str, str]] = MappingProxyType(
+    {
+        "description": "summary",
+        "publisher": "publisher_name",
+        "imprint": "imprint_name",
+    }
+)
+# Role-name → metadata-key partition for OPDS2 contributor fields.
+# The metadata serializer declares 11 contributor categories; rows
+# with a role-name not in any bucket are dropped.
+_MD_CREDIT_MAP: Final[MappingProxyType[str, frozenset[str]]] = MappingProxyType(
+    {
+        "author": frozenset(AUTHOR_ROLES),
+        "translator": frozenset({"Translator"}),
+        "editor": frozenset({"Editor"}),
+        "artist": frozenset({"CoverArtist", "Cover", "Artist"}),
+        "illustrator": frozenset({"Illustrator"}),
+        "letterer": frozenset({"Letterer"}),
+        "penciller": frozenset({"Penciller"}),
+        "colorist": frozenset({"Colorist", "Colors"}),
+        "inker": frozenset({"Inker", "Inks"}),
+        "contributor": frozenset({"Contributor"}),
+        "narrator": frozenset({"Narrator"}),
+    }
 )
 
 
@@ -182,6 +219,128 @@ class OPDS2PublicationBaseView(OPDS2FeedLinksView):
 class OPDS2PublicationsView(OPDS2PublicationBaseView):
     """Publication Methods for OPDS 2.0 feed."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize per-feed batch caches."""
+        super().__init__(*args, **kwargs)
+        # Populated by ``get_publications`` before the per-publication
+        # loop. ``_publication_metadata`` reads them per ``obj.pk``.
+        self._credits_by_pk: dict[int, dict[str, list]] = {}
+        self._subjects_by_pk: dict[int, list] = {}
+
+    @staticmethod
+    def _build_credits_by_pk(comic_pks: Collection[int]) -> dict[int, dict[str, list]]:
+        """
+        Per-comic credit map keyed by metadata role bucket.
+
+        Single batched query against ``Credit`` joined with ``person``
+        and ``role``, partitioned in Python by ``_MD_CREDIT_MAP``. Rows
+        with a role-name not in any bucket are dropped. Replaces a
+        per-publication credit fan-out (the manifest path is still
+        per-comic via ``_publication_credits`` — fine for that endpoint
+        because it serves a single book per call).
+        """
+        if not comic_pks:
+            return {}
+        rows = (
+            Credit.objects.filter(comic__in=comic_pks)
+            .annotate(
+                _comic_id=F("comic"),
+                name=F("person__name"),
+                role_name=F("role__name"),
+            )
+            .values("pk", "name", "role_name", "_comic_id")
+            .order_by("_comic_id", "role_name", "name")
+        )
+        # Reverse-index role_name → bucket so the partition is O(1) per row.
+        role_to_bucket: dict[str, str] = {
+            role: bucket for bucket, roles in _MD_CREDIT_MAP.items() for role in roles
+        }
+        by_pk: dict[int, dict[str, list]] = {pk: {} for pk in comic_pks}
+        for row in rows:
+            bucket = role_to_bucket.get(row["role_name"])
+            if bucket is None:
+                continue
+            cid = row["_comic_id"]
+            if cid not in by_pk:
+                continue
+            credit = SimpleNamespace(
+                pk=row["pk"],
+                name=row["name"],
+                role_name=row["role_name"],
+                identifier="",
+                links=(),
+            )
+            by_pk[cid].setdefault(bucket, []).append(credit)
+        return by_pk
+
+    @staticmethod
+    def _build_subjects_by_pk(comic_pks: Collection[int]) -> dict[int, list]:
+        """
+        Per-comic subject (M2M) list as a flat union across model kinds.
+
+        Single ``UNION ALL`` over the seven ``OPDS_M2M_MODELS`` filtered
+        by comic pk. Mirrors the per-comic union in
+        ``OPDS2ManifestMetadataView._publication_subject`` but indexed
+        by comic pk for the feed path.
+        """
+        if not comic_pks or not OPDS_M2M_MODELS:
+            return {}
+        queries = []
+        for model in OPDS_M2M_MODELS:
+            rel = GroupACLMixin.get_rel_prefix(model)
+            kind = model.__name__.lower()
+            q = (
+                model.objects.filter(**{rel + "in": comic_pks})
+                .annotate(
+                    _kind=Value(kind, output_field=CharField()),
+                    _comic_id=F(rel + "id"),
+                )
+                .values("pk", "name", "_kind", "_comic_id")
+            )
+            queries.append(q)
+        rows = (
+            queries[0]
+            .union(*queries[1:], all=True)
+            .order_by("_comic_id", "_kind", "name")
+        )
+        by_pk: dict[int, list] = {pk: [] for pk in comic_pks}
+        seen: dict[tuple[int, str], set[int]] = {}
+        for row in rows:
+            cid = row["_comic_id"]
+            kind = row["_kind"]
+            ipk = row["pk"]
+            bucket_seen = seen.setdefault((cid, kind), set())
+            if ipk in bucket_seen or cid not in by_pk:
+                continue
+            bucket_seen.add(ipk)
+            by_pk[cid].append(SimpleNamespace(pk=ipk, name=row["name"], links=()))
+        return by_pk
+
+    @override
+    def _publication_metadata(self, obj, zero_pad) -> dict:
+        """Build feed-side metadata enriched with batched credits + subjects."""
+        md = super()._publication_metadata(obj, zero_pad)
+
+        # Direct attribute → metadata key passthrough.
+        for md_key, attr in _PUBLICATION_DIRECT_FIELDS.items():
+            if value := getattr(obj, attr, None):
+                md[md_key] = value
+
+        # Special-case transforms (mirror manifest semantics).
+        if lang := getattr(obj, "language", None):
+            md["language"] = lang.name
+        if layout := getattr(obj, "reading_direction", None):
+            md["layout"] = "scrolled" if layout == "ttb" else layout
+
+        # Pre-batched per-pk credit + subject hydration (set up by
+        # ``get_publications`` before the loop).
+        if credits_for_obj := self._credits_by_pk.get(obj.pk):
+            md.update(credits_for_obj)
+        if subjects_for_obj := self._subjects_by_pk.get(obj.pk):
+            md["subject"] = subjects_for_obj
+
+        return md
+
     @override
     def _publication(self, obj, zero_pad) -> dict:
         pub = super()._publication(obj, zero_pad)
@@ -228,8 +387,18 @@ class OPDS2PublicationsView(OPDS2PublicationBaseView):
         number_of_items: int | None = None,
     ) -> list:
         """Get publications section."""
+        # Materialize once so we can pre-fetch credits + subjects for
+        # the full pk slice before the per-publication loop. Without
+        # this the loop's ``_publication_metadata`` would fan out into
+        # 1 credit query + 7 m2m queries per book = 8N queries on a
+        # full feed page. The two batched UNION queries collapse that
+        # to 2 queries flat regardless of N.
+        book_list = list(book_qs)
+        pks = tuple(obj.pk for obj in book_list)
+        self._credits_by_pk = self._build_credits_by_pk(pks)
+        self._subjects_by_pk = self._build_subjects_by_pk(pks)
         publications = []
-        for obj in book_qs:
+        for obj in book_list:
             pub = self._publication(obj, zero_pad)
             publications.append(pub)
 


### PR DESCRIPTION
## Summary

Implementation of [`tasks/serializers-perf/03-opds.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/serializers-perf/03-opds.md).

Three commits.

### F5 — `unused.py` → docstring scaffolds (`464a5023`)

`codex/serializers/opds/v2/unused.py` had 6 OPDS v2 serializer
classes that were never imported anywhere. Per the plan, preserve
them as documentation rather than deleting. The file becomes a
single module-level docstring with the class scaffolds in a `::`
example block; the module imports as a no-op (no exports). Future
contributors wiring a navigation / group / library feed copy the
relevant class out of the docstring.

### F3 — `get_rel` SMF → `JSONField` (`3e07723c`)

`OPDS2LinkBaseSerializer.rel` was a `SerializerMethodField` calling
`get_rel` per link dispatch (~5 links × N publications =
~500 SMF calls per feed). The method only ran a defensive
`isinstance(list | str)` guard against an `obj["rel"]` value that
— across all current `LinkData` call sites — is always a string
from the `Rel` constants class.

Replace with a plain `JSONField(read_only=True)`. DRF's JSONField
returns the raw Python value without coercion, so str-or-list rels
pass through unchanged (preserving spec future-proofing). The
`to_representation` override that drops empty rels stays.

### F2 — v2 batching + contributor / subject population (`94c0ae28`)

`OPDS2PublicationMetadataSerializer` declared 11 contributor
fields plus a subject array but the feed view's
`_publication_metadata` was thin (`title` / `subtitle` /
`published` / `modified` / `number_of_pages`). Anyone wiring those
fields without batching would have introduced an 8N N+1 (1 credits
query + 7 m2m queries per publication).

Per the plan (Option B), populate the fields — with batching:

- `_build_credits_by_pk(pks)` — one `Credit` query joined with
  `person` + `role`, partitioned in Python by `_MD_CREDIT_MAP`
  into the 11 contributor buckets. Reverse-indexed
  `role_name → bucket` so the partition is O(1) per row.
- `_build_subjects_by_pk(pks)` — `UNION ALL` across the seven
  `OPDS_M2M_MODELS`, partitioned by `(_comic_id, _kind)` with
  per-bucket dedup.

`get_publications` materializes `book_qs` once, pre-fetches both
maps for the full pk slice, then loops `_publication`. The new
`_publication_metadata` override reads its per-pk slices and adds
`language` / `publisher` / `imprint` / `layout` / `description`
from direct `Comic` attributes (mirrors the manifest view's
transforms).

Per-credit / per-subject `links` arrays are intentionally empty in
the feed path — opening the manifest endpoint surfaces the full
facet links. The feed is a summary; the manifest is detail.

**Query count**

| | per feed page |
| --- | --- |
| Before (if anyone populated) | `8N` (`1 + 7` per publication) |
| After | `2` (one credits UNION + one subjects UNION) |

## Wire-format change

- Previously-empty contributor / subject / `language` / `publisher` /
  `imprint` / `layout` / `description` fields on v2 feed
  publications now contain real data.
- Clients that ignored unknown / empty fields are unaffected.
- Roll out behind the existing OPDS-client testing gate from
  PR #606 (cover cleanup).

## Test plan

- [x] `make lint-python` clean.
- [x] `make test-python` clean (24 tests pass).
- [ ] Hit `/opds/v2.0/<group>/<pks>` with comics that have credits
  + m2m subject rows; verify response shape.
- [ ] OPDS v2 client (KyBook, Chunky, Stump) renders the feed
  identically or with new fields surfaced.
- [ ] Manifest endpoint `/opds/v2.0/<group>/<pks>/manifest`
  unchanged — F2 only touches `OPDS2PublicationsView`, manifest
  goes through `OPDS2ManifestView`.
- [ ] Verify `unused.py` import is a no-op:
  `python -c "import codex.serializers.opds.v2.unused"`.

## References

- Plan: `tasks/serializers-perf/03-opds.md`
- Meta plan: `tasks/serializers-perf/00-meta.md`
- Previous: PR #613 (01-fields), PR #614 (02-browser)
- Next: `tasks/serializers-perf/04-models.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)