### PR TITLE
Serializers perf 04: model serializer cleanup + invariant docs

### DIFF
--- a/codex/serializers/browser/metadata.py
+++ b/codex/serializers/browser/metadata.py
@@ -7,7 +7,7 @@ from codex.serializers.browser.mixins import BrowserAggregateSerializerMixin
 from codex.serializers.models.comic import ComicSerializer
 from codex.serializers.models.named import (
     CreditSerializer,
-    IdentifierSeralizer,
+    IdentifierSerializer,
     StoryArcNumberSerializer,
 )
 
@@ -61,7 +61,7 @@ class MetadataSerializer(BrowserAggregateSerializerMixin, ComicSerializer):
     credits = CreditSerializer(
         source=f"{PREFETCH_PREFIX}credits", many=True, allow_null=True
     )
-    identifiers = IdentifierSeralizer(
+    identifiers = IdentifierSerializer(
         source=f"{PREFETCH_PREFIX}identifiers", many=True, allow_null=True
     )
     story_arc_numbers = StoryArcNumberSerializer(

--- a/codex/serializers/models/comic.py
+++ b/codex/serializers/models/comic.py
@@ -17,7 +17,7 @@ from codex.serializers.models.named import (
     CharacterSerializer,
     CreditSerializer,
     GenreSerializer,
-    IdentifierSeralizer,
+    IdentifierSerializer,
     LocationSerializer,
     OriginalFormatSerializer,
     ScanInfoSerializer,
@@ -64,7 +64,7 @@ class ComicSerializer(BaseModelSerializer):
     characters = CharacterSerializer(many=True, allow_null=True)
     credits = CreditSerializer(many=True, allow_null=True)
     genres = GenreSerializer(many=True, allow_null=True)
-    identifiers = IdentifierSeralizer(many=True, allow_null=True)
+    identifiers = IdentifierSerializer(many=True, allow_null=True)
     locations = LocationSerializer(many=True, allow_null=True)
     series_groups = SeriesGroupSerializer(many=True, allow_null=True)
     stories = StorySerializer(many=True, allow_null=True)

--- a/codex/serializers/models/named.py
+++ b/codex/serializers/models/named.py
@@ -108,8 +108,24 @@ class IdentifierSourceSerializer(NamedModelSerializer):
         model = IdentifierSource
 
 
-class IdentifierSeralizer(BaseModelSerializer):
-    """Identifier model."""
+class IdentifierSerializer(BaseModelSerializer):
+    """
+    Identifier model.
+
+    ``Identifier.name`` is a model-side ``@property`` that reads
+    ``self.source`` (FK to ``IdentifierSource``) — accessing ``name``
+    triggers a DB hit unless ``source`` is preloaded. Today the only
+    consumer is the metadata pane via ``MetadataSerializer``'s
+    ``identifiers`` field, which is populated from
+    ``M2M_QUERY_OPTIMIZERS[Identifier]`` with ``select=("source",)``.
+    Other paths reach Identifier transitively (Credit.role.identifier,
+    StoryArcNumber.story_arc.identifier) but only read ``.url`` —
+    ``url`` is a column, not a property, so no FK fan-out.
+
+    Adding any field to this serializer that triggers further FK
+    access on ``Identifier`` (or the optimizer dropping ``source``)
+    breaks the invariant.
+    """
 
     name = CharField(read_only=True)
 


### PR DESCRIPTION
## Summary

Implementation of [`tasks/serializers-perf/04-models.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/serializers-perf/04-models.md).

One commit. Two findings landed; two findings deferred with notes.

### F7 — Rename `IdentifierSeralizer` → `IdentifierSerializer`

Long-standing typo. Five sites total: class definition in
`named.py`, import + field declaration in `comic.py`, import +
field declaration in `browser/metadata.py`.

### F4 — Document `Identifier.name` property invariant

`Identifier.name` is a model-side `@property` that reads
`self.source` (FK to `IdentifierSource`); accessing it without
`source` preloaded would N+1. Today only the metadata pane reads
`name` on top-level identifiers, and that path's
`M2M_QUERY_OPTIMIZERS[Identifier]` entry pre-selects `source` so
the invariant holds.

Other code paths reach Identifier transitively
(`Credit.role.identifier`, `StoryArcNumber.story_arc.identifier`)
but only read `.url` — a column, not a property — so no FK
fan-out. Document the invariant on the (newly-renamed)
serializer so a future contributor adding fields knows why the
optimizer matters.

### F1 deferred

The plan's headline finding was an audit of serializer-time
queries on `flow_c2_comic_metadata` — confirm zero queries fire
during `MetadataSerializer(obj).data`. That requires silk traces
against a populated dev DB; without one, the audit becomes a
documentation update rather than a regression test.

Defer to a follow-up PR with a populated test fixture (similar
shape to `tests/test_models.py`'s setup) and `CaptureQueriesContext`
assertions on the metadata path.

### F6 deferred (revised conclusion)

The plan claimed `Meta.depth = 1` on `ComicSerializer` is a no-op
because all Comic FKs are explicitly serialized. **That's wrong.**
`Comic` inherits `library` (FK to `Library`) from `WatchedPath`,
and `library` is neither explicitly declared in `ComicSerializer`
nor in the `Meta.exclude` tuple `("folders", "parent_folder", "stat")`.

With `depth=1`, DRF auto-nests `Comic.library` as a nested Library
object on the metadata response. Without `depth=1`, it'd serialize
as a bare pk integer.

Dropping `depth=1` is therefore a wire-format change, not a no-op
cleanup. Skip in this PR; revisit if the metadata response shape
ever needs a deliberate audit.

## Test plan

- [x] `make lint-python` clean.
- [x] `make test-python` clean (24 tests pass).
- [x] `grep -rn 'IdentifierSeralizer'` returns nothing across the
  codebase (rename complete).
- [ ] Hit `/api/v3/c/<pk>/metadata` on a populated DB; verify
  response shape unchanged (the rename is purely internal).

## References

- Plan: `tasks/serializers-perf/04-models.md`
- Meta plan: `tasks/serializers-perf/00-meta.md`
- Original handoff: `tasks/browser-views-perf/stage5e-handoff-serializer-audit.md`
- Previous PRs: #613 (01-fields), #614 (02-browser), #615 (03-opds)
- Next: `tasks/serializers-perf/05-auth-admin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)