### PR TITLE
Serializers perf 05: auth dead code + admin regression tests

### DIFF
--- a/codex/serializers/auth.py
+++ b/codex/serializers/auth.py
@@ -1,53 +1,12 @@
 """Codex Auth Serializers."""
 
-from django.contrib.auth.models import User
 from rest_framework.fields import BooleanField, CharField
 from rest_framework.serializers import (
     Serializer,
     SerializerMetaclass,
-    SerializerMethodField,
 )
 
-from codex.choices.admin import AdminFlagChoices
-from codex.models.admin import AdminFlag
 from codex.serializers.fields.auth import TimezoneField
-from codex.serializers.fields.sanitized import SanitizedCharField
-from codex.serializers.models.base import BaseModelSerializer
-
-
-class UserSerializer(BaseModelSerializer):
-    """Serialize User model for UI."""
-
-    _ADMIN_FLAG_KEYS = (
-        AdminFlagChoices.NON_USERS.value,
-        AdminFlagChoices.REGISTRATION.value,
-    )
-
-    admin_flags = SerializerMethodField()
-
-    def get_admin_flags(self, *_args) -> dict:
-        """Piggyback admin flags on the user object."""
-        flags = AdminFlag.objects.filter(key__in=self._ADMIN_FLAG_KEYS).values(
-            "name", "on"
-        )
-        admin_flags = {}
-        for flag in flags:
-            name = flag["name"]
-            key = name[0].lower() + name[1:].replace(" ", "")
-            admin_flags[key] = flag["on"]
-        return admin_flags
-
-    class Meta(BaseModelSerializer.Meta):
-        """Model spec."""
-
-        model = User
-        fields = (
-            "pk",
-            "username",
-            "is_staff",
-            "admin_flags",
-        )
-        read_only_fields = fields
 
 
 class TimezoneSerializerMixin(metaclass=SerializerMetaclass):
@@ -58,27 +17,6 @@ class TimezoneSerializerMixin(metaclass=SerializerMetaclass):
 
 class TimezoneSerializer(TimezoneSerializerMixin, Serializer):
     """Serialize Timezone submission from front end."""
-
-
-class UserCreateSerializer(BaseModelSerializer, TimezoneSerializerMixin):
-    """Serialize registration input for creating users."""
-
-    class Meta(BaseModelSerializer.Meta):
-        """Model spec."""
-
-        model = User
-        fields = ("username", "password", "timezone")
-        extra_kwargs = {"password": {"write_only": True}}  # noqa: RUF012
-
-
-class UserLoginSerializer(UserCreateSerializer):
-    """Serialize user login input."""
-
-    # specify this so it doesn't trigger the username unique constraint.
-    username = SanitizedCharField(min_length=2)
-
-    class Meta(UserCreateSerializer.Meta):
-        """Explicit meta inheritance required."""
 
 
 class AuthAdminFlagsSerializer(Serializer):

--- a/tests/test_admin_query_counts.py
+++ b/tests/test_admin_query_counts.py
@@ -1,0 +1,103 @@
+"""
+Regression tests for the admin user / group list endpoints.
+
+Both serializers depend on viewset-level ``select_related`` to avoid
+N+1 fan-out:
+
+- :class:`codex.serializers.admin.users.UserSerializer` reads
+  ``source="userauth.updated_at"`` and
+  ``source="userauth.age_rating_metron"`` per row. The viewset
+  must ``select_related("userauth__age_rating_metron")``.
+- :class:`codex.serializers.admin.groups.GroupSerializer` reads
+  ``source="groupauth.exclude"`` per row. The viewset must
+  ``select_related("groupauth")``.
+
+Without a regression test, a future refactor that splits the
+queryset (or reorders the prefetch chain) silently regresses to
+N+1. These tests pin the contract: query count for the list
+endpoint stays bounded as the row count grows.
+"""
+
+from typing import Final, override
+
+from django.contrib.auth.models import Group, User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+
+from codex.models.auth import GroupAuth, UserAuth
+
+# Test-only password — short, fixed, and never deployed. Hush
+# bandit's hardcoded-password warning at the call sites.
+_TEST_PASSWORD: Final = "test-pw-hush-S106"  # noqa: S105
+_HTTP_OK: Final = 200
+# Admin list endpoints prefetch their auth FK row per query. The
+# per-request setup (session + admin-flag fetches + ACL pipeline)
+# plus the list query plus its prefetch should comfortably sit
+# under this ceiling. A regression that drops ``select_related``
+# fans out N additional queries per row, tripping the assertion.
+_ADMIN_LIST_QUERY_CEILING: Final = 20
+
+
+class AdminListQueryCountTestCase(TestCase):
+    """Bound the per-row query count on /admin/user and /admin/group."""
+
+    @override
+    def setUp(self) -> None:
+        """Create an admin + a small fixture set of users / groups."""
+        self.admin = User.objects.create_user(  # pyright: ignore[reportUninitializedInstanceVariable]
+            username="admin_query_count_admin",
+            password=_TEST_PASSWORD,
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserAuth.objects.create(user=self.admin)
+        for i in range(3):
+            user = User.objects.create_user(
+                username=f"admin_query_count_user{i}", password=_TEST_PASSWORD
+            )
+            UserAuth.objects.create(user=user)
+        for i in range(3):
+            group = Group.objects.create(name=f"group{i}")
+            GroupAuth.objects.create(group=group)
+
+        self.client = Client()
+        self.client.force_login(self.admin)
+
+    def _query_count(self, url: str) -> int:
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
+        if response.status_code != _HTTP_OK:
+            reason = f"GET {url} returned {response.status_code}: {response.content!r}"
+            raise AssertionError(reason)
+        return len(ctx.captured_queries)
+
+    def test_admin_user_list_query_count(self) -> None:
+        """
+        Bound /admin/user list queries — fail-loud on N+1 regressions.
+
+        A regression that drops
+        ``select_related("userauth__age_rating_metron")`` would push
+        the count by 2 per row (one ``userauth`` SELECT + one
+        ``age_rating_metron`` SELECT), tripping the ceiling well
+        before becoming visible to users.
+        """
+        count = self._query_count("/api/v3/admin/user")
+        assert count <= _ADMIN_LIST_QUERY_CEILING, (
+            f"Expected <= {_ADMIN_LIST_QUERY_CEILING} queries on /admin/user, "
+            f"got {count}"
+        )
+
+    def test_admin_group_list_query_count(self) -> None:
+        """
+        Bound /admin/group list queries — fail-loud on N+1 regressions.
+
+        A regression that drops ``select_related("groupauth")`` would
+        add one query per group for the ``groupauth.exclude`` access,
+        tripping the ceiling.
+        """
+        count = self._query_count("/api/v3/admin/group")
+        assert count <= _ADMIN_LIST_QUERY_CEILING, (
+            f"Expected <= {_ADMIN_LIST_QUERY_CEILING} queries on /admin/group, "
+            f"got {count}"
+        )


### PR DESCRIPTION
## Summary

Implementation of [`tasks/serializers-perf/05-auth-admin.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/serializers-perf/05-auth-admin.md).
**Final sub-plan in the serializers-perf project.**

Two commits.

### F1 — `auth.py` dead code (`a7eff332`)

`codex/serializers/auth.py` had three serializers that were never
imported anywhere:

- `UserSerializer` (with a `get_admin_flags` SMF that fired
  `AdminFlag.objects.filter(...)` per call)
- `UserCreateSerializer`
- `UserLoginSerializer`

Confirmed dead:

```bash
$ grep -rn 'codex.serializers.auth' codex/ | grep -v __pycache__
codex/views/timezone.py:8:from codex.serializers.auth import TimezoneSerializer
codex/views/public.py:12:from codex.serializers.auth import AuthAdminFlagsSerializer
```

Only `AuthAdminFlagsSerializer` and `TimezoneSerializer` are live.
The actual `/auth/flags` endpoint uses the lightweight
`AuthAdminFlagsSerializer` (4 read-only scalar fields, no SMFs,
no DB).

Trim `auth.py` to its live exports. Drops 50 LOC and unused imports.

### F3 + F4 — Admin source-chain regression tests (`4b22cff5`)

`UserSerializer` and `GroupSerializer` both depend on per-row
`source="userauth.*"` / `source="groupauth.*"` chains.
`AdminUserViewSet` and `AdminGroupViewSet` apply the matching
`select_related` on their querysets — but no test enforces the
contract.

New `tests/test_admin_query_counts.py`:

- 3 users + 3 groups via `Django TestCase` with associated
  `UserAuth` + `GroupAuth` rows
- `force_login` as admin, hit `/api/v3/admin/user` and
  `/api/v3/admin/group` via the test client
- Capture queries via `CaptureQueriesContext`, assert ceiling of
  20 queries per list endpoint

The ceiling is deliberately generous — per-request setup
(session + admin-flag fetches + ACL pipeline) plus a single list
query plus prefetch joins comfortably sit under it. A regression
that drops `select_related("userauth__age_rating_metron")` would
add 2 queries per row (one `userauth` SELECT + one
`age_rating_metron` SELECT), tripping the ceiling.

## Test plan

- [x] `make lint-python` clean.
- [x] `make test-python` clean (26 tests pass = 24 existing + 2 new).
- [x] `grep -rn 'UserSerializer\|UserCreateSerializer\|UserLoginSerializer'
  codex/serializers/auth.py` returns nothing.
- [x] `from codex.serializers.auth import AuthAdminFlagsSerializer,
  TimezoneSerializer` still resolves at import time.
- [ ] Hit `/api/v3/admin/user` and `/api/v3/admin/group` on a
  populated install; verify response shape unchanged.

## Project completion

This wraps the serializers-perf project. Five PRs total against
`v1.11-performance`:

| PR | Sub-plan | Scope |
| --- | --- | --- |
| #613 | 01-fields | `PyCountryField` cache (~3.3×), drop `SanitizedCharField` from ISO codes, `SerializerChoicesField` cache, whitespace strip + migration 0041 |
| #614 | 02-browser | `get_mtime` `fromisoformat` (~20×), `BrowserChoicesFilterSerializer` field cache |
| #615 | 03-opds | OPDS v2 batched contributor + subject hydration, `get_rel` SMF removal, `unused.py` → docstring scaffolds |
| #616 | 04-models | `IdentifierSeralizer` typo fix, `Identifier.name` property invariant docstring |
| #617 | 05-auth-admin | `auth.py` dead code, admin source-chain regression tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)