### PR TITLE
Bookmark daemon perf: correctness + query reduction + network offload

### DIFF
--- a/codex/librarian/bookmark/bookmarkd.py
+++ b/codex/librarian/bookmark/bookmarkd.py
@@ -1,7 +1,7 @@
 """Sends notifications to connections, reading from a queue."""
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import override
 
 from loguru import logger
@@ -22,24 +22,62 @@ from codex.librarian.threads import AggregateMessageQueuedThread
 
 @dataclass
 class BookmarkKey:
-    """Bookmark queue item key."""
+    """
+    Bookmark queue item key.
+
+    Identity is field-equality on ``(auth_filter, comic_pks, user_pk)``.
+    The hash is computed once at construction and cached: ``__hash__``
+    is called per cache-key lookup, and rebuilding
+    ``tuple(auth_filter.items())`` per call wastes work on a hot path.
+    """
 
     auth_filter: Mapping[str, int | str | None] | None = None
     comic_pks: tuple = ()
     user_pk: int = 0
+    # Excluded from compare/init/repr — pure derived data populated in
+    # ``__post_init__``. Keeping it on the dataclass means the cache
+    # lives for the instance's lifetime without an extra dict.
+    _hash: int = field(default=0, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Cache a stable hash of the identity tuple."""
+        # ``sorted()`` makes the hash stable regardless of dict insertion
+        # order — defensive against ``{"user_id": 1}`` / ``{"session_id":
+        # ...}`` shape drift.
+        auth_filter_key = (
+            None
+            if self.auth_filter is None
+            else tuple(sorted(self.auth_filter.items()))
+        )
+        object.__setattr__(
+            self,
+            "_hash",
+            hash((auth_filter_key, self.comic_pks, self.user_pk)),
+        )
 
     @override
     def __hash__(self) -> int:
-        """Hash the dict as a tuple."""
-        auth_filters = (
-            None if self.auth_filter is None else tuple(self.auth_filter.items())
-        )
-        return hash((auth_filters, self.comic_pks, self.user_pk))
+        """Return the cached identity hash."""
+        return self._hash
 
     @override
     def __eq__(self, other) -> bool:
-        """Equal uses hashes."""
-        return self.__hash__() == other.__hash__()
+        """
+        Compare by identity fields, not by hash.
+
+        The previous implementation returned
+        ``self.__hash__() == other.__hash__()`` — collision-vulnerable.
+        Two distinct keys that hash-collide would compare equal and the
+        aggregator would merge one user's bookmark into another user's
+        cache entry, then write to that other user's DB row.
+        """
+        if not isinstance(other, BookmarkKey):
+            return NotImplemented
+        return (
+            self.auth_filter == other.auth_filter
+            and self.comic_pks == other.comic_pks
+            and self.user_pk == other.user_pk
+        )
 
 
 class BookmarkThread(

--- a/codex/librarian/bookmark/bookmarkd.py
+++ b/codex/librarian/bookmark/bookmarkd.py
@@ -1,6 +1,7 @@
 """Sends notifications to connections, reading from a queue."""
 
-from collections.abc import Mapping
+import threading
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import override
 
@@ -96,19 +97,47 @@ class BookmarkThread(
         self.init_group_acl()
         self.init_user_active()
 
+    def _spawn_offline(self, name: str, target: Callable[[], None]) -> None:
+        """
+        Run a long-running task on its own daemon thread.
+
+        ``CodexLatestVersionTask`` and ``TelemeterTask`` both make
+        outbound network calls with a 5-second timeout. Running them
+        inline inside the aggregator's process loop blocks every
+        queued ``BookmarkUpdateTask`` for the duration of the network
+        roundtrip — page-turn writes stall behind PyPI on a slow
+        connection. Daemon-thread offload returns control to the
+        aggregator immediately; both tasks are infrequent (telemetry
+        once per week, version check once per day) so unbounded thread
+        creation isn't a real risk.
+        """
+
+        def _run():
+            try:
+                target()
+            except Exception:
+                self.log.exception(f"Bookmark side-thread task {name} crashed")
+
+        threading.Thread(target=_run, name=f"bookmark-{name}", daemon=True).start()
+
     def _process_task_immediately(self, task) -> None:
         if self.db_write_lock.locked():
             self.log.warning(f"Database locked, not processing {task}")
         match task:
             case TelemeterTask():
-                send_telemetry(self.log)
+                self._spawn_offline("telemeter", lambda: send_telemetry(self.log))
             case ClearLibrarianStatusTask():
+                # Pure DB call (status_controller writes one row per
+                # known status). Cheap; no offload.
                 self.status_controller.finish_many([])
             case CodexLatestVersionTask():
                 worker = CodexLatestVersionUpdater(
                     self.log, self.librarian_queue, self.db_write_lock
                 )
-                worker.update_latest_version(force=task.force)
+                self._spawn_offline(
+                    "latest-version",
+                    lambda: worker.update_latest_version(force=task.force),
+                )
             case _:
                 self.log.warning(f"Unknown Bookmark task {task}")
 

--- a/codex/librarian/bookmark/update.py
+++ b/codex/librarian/bookmark/update.py
@@ -1,8 +1,11 @@
 """Sends notifications to connections, reading from a queue."""
 
+from collections.abc import Collection, Iterable
+from datetime import datetime
+
 from django.db.models.expressions import F
-from django.db.models.functions import Now
 from django.db.models.query import Q
+from django.utils import timezone as django_timezone
 
 from codex.choices.notifications import Notifications
 from codex.librarian.mp_queue import LIBRARIAN_QUEUE
@@ -23,9 +26,26 @@ class BookmarkUpdateMixin(GroupACLMixin):
 
     # Used by Bookmarkd and view.bookmark.
 
+    @staticmethod
+    def _normalize_comic_pks(comic_pks) -> tuple[int, ...]:
+        """
+        Coerce QuerySet / Iterable inputs to a tuple of pks.
+
+        Browser callers (``codex/views/browser/bookmark.py``) pass a
+        ``Comic`` ``QuerySet``; the bookmark thread passes a tuple
+        already. Forcing the QuerySet here costs one ``SELECT pk``
+        but lets the rest of the flow do set arithmetic without
+        re-evaluating Django expressions.
+        """
+        if isinstance(comic_pks, tuple):
+            return comic_pks
+        if hasattr(comic_pks, "values_list"):
+            return tuple(comic_pks.values_list("pk", flat=True))
+        return tuple(comic_pks)
+
     @classmethod
     def _get_existing_bookmarks_for_update(
-        cls, auth_filter, comic_pks, updates
+        cls, auth_filter, comic_pks: Collection[int], updates
     ) -> tuple:
         # Get existing bookmarks
         query_filter = Q(**auth_filter) & Q(comic__in=comic_pks)
@@ -36,22 +56,38 @@ class BookmarkUpdateMixin(GroupACLMixin):
             )
 
         update_fields = (set(updates.keys()) & _BOOKMARK_UPDATE_FIELDS) | {"updated_at"}
-        only_fields = (*update_fields, "pk")
+        # ``comic_id`` is loaded so the caller can build the
+        # covered-pk set without a second SELECT.
+        only_fields = (*update_fields, "pk", "comic_id")
 
         existing_bookmarks = existing_bookmarks.only(*only_fields)
         return existing_bookmarks, update_fields
 
     @classmethod
-    def _prepare_bookmark_updates(cls, existing_bookmarks, updates) -> list:
-        # Prepare updates
+    def _prepare_bookmark_updates(
+        cls, existing_bookmarks: Iterable, updates, now: datetime
+    ) -> tuple[list, set[int]]:
+        """
+        Build the bulk_update objects and track covered comic ids.
+
+        Returning the comic-id set lets the caller compute "missing"
+        without a second SELECT — the create-path query only fires when
+        phase 1 didn't already cover every input pk.
+        """
         update_bookmarks = []
+        covered_comic_ids: set[int] = set()
         for bm in existing_bookmarks:
             cls._update_bookmarks_validate_page(bm, updates)
             for key, value in updates.items():
                 setattr(bm, key, value)
-            bm.updated_at = Now()
+            # Single Python timestamp for the whole batch — bulk_update
+            # otherwise emits ``NOW()`` per row in the generated CASE
+            # WHEN, which is correct but redundant. A constant is also
+            # easier to reason about for tests / mocks.
+            bm.updated_at = now
             update_bookmarks.append(bm)
-        return update_bookmarks
+            covered_comic_ids.add(bm.comic_id)
+        return update_bookmarks, covered_comic_ids
 
     @staticmethod
     def _update_bookmarks_validate_page(bm, updates) -> None:
@@ -74,31 +110,31 @@ class BookmarkUpdateMixin(GroupACLMixin):
         LIBRARIAN_QUEUE.put(task)
 
     @classmethod
-    def _update_bookmarks(cls, auth_filter, comic_pks, updates) -> int:
-        """Update existing bookmarks."""
-        count = 0
+    def _update_bookmarks(
+        cls, auth_filter, comic_pks: Collection[int], updates, now: datetime
+    ) -> tuple[int, set[int]]:
+        """Update existing bookmarks; return (count, covered_comic_ids)."""
         if not updates:
-            return count
+            return 0, set()
 
         existing_bookmarks, update_fields = cls._get_existing_bookmarks_for_update(
             auth_filter, comic_pks, updates
         )
-        update_bookmarks = cls._prepare_bookmark_updates(existing_bookmarks, updates)
+        update_bookmarks, covered = cls._prepare_bookmark_updates(
+            existing_bookmarks, updates, now
+        )
         count = len(update_bookmarks)
-
-        # Bulk update
         if count:
             Bookmark.objects.bulk_update(update_bookmarks, tuple(update_fields))
-        return count
+        return count, covered
 
     @classmethod
-    def _get_comics_without_bookmarks(cls, auth_filter, comic_pks):
-        """Get comics without bookmarks."""
-        exclude = {}
-        for key, value in auth_filter.items():
-            exclude["bookmark__" + key] = value
-        query_filter = Q(pk__in=comic_pks) & ~Q(**exclude)
-        return Comic.objects.filter(query_filter).only("pk")
+    def _get_comics_without_bookmarks(cls, missing_comic_pks: Collection[int]):
+        """Pk-only Comic queryset for the create path."""
+        # Phase 1 already proved these pks have no matching bookmark
+        # for the auth_filter, so the previous ``~Q(bookmark__user_id=...)``
+        # subquery is redundant — one straight pk lookup suffices.
+        return Comic.objects.filter(pk__in=missing_comic_pks).only("pk")
 
     @classmethod
     def _prepare_bookmark_creates(
@@ -112,34 +148,55 @@ class BookmarkUpdateMixin(GroupACLMixin):
         return create_bookmarks
 
     @classmethod
-    def _create_bookmarks(cls, auth_filter, comic_pks, updates) -> int:
-        """Create new bookmarks for comics that don't exist yet."""
-        count = 0
-        if not updates:
-            return count
+    def _create_bookmarks(
+        cls, auth_filter, missing_comic_pks: Collection[int], updates
+    ) -> int:
+        """Create new bookmarks for comics that don't have one yet."""
+        if not updates or not missing_comic_pks:
+            return 0
 
-        create_bookmark_comics = cls._get_comics_without_bookmarks(
-            auth_filter, comic_pks
-        )
+        create_bookmark_comics = cls._get_comics_without_bookmarks(missing_comic_pks)
         create_bookmarks = cls._prepare_bookmark_creates(
             create_bookmark_comics, auth_filter, updates
         )
         count = len(create_bookmarks)
-
-        # Bulk create
         if count:
-            Bookmark.objects.bulk_create(
-                create_bookmarks,
-                update_fields=tuple(_BOOKMARK_UPDATE_FIELDS),
-                unique_fields=Bookmark._meta.unique_together[0],
-            )
+            # ``bulk_create`` here is a plain INSERT path; no UPSERT.
+            # Schema-side, ``Bookmark.unique_together = (user, session,
+            # comic)`` has nullable user/session, and SQLite (like ANSI
+            # SQL) treats NULLs in unique indexes as distinct — so an
+            # ``ON CONFLICT DO UPDATE`` target wouldn't fire for a row
+            # whose ``session_id`` is NULL on both sides. The two-pass
+            # design (filter existing first, only insert truly missing
+            # rows) sidesteps that gotcha.
+            Bookmark.objects.bulk_create(create_bookmarks)
         return count
 
     @classmethod
     def update_bookmarks(cls, auth_filter, comic_pks, updates) -> int:
         """Update a user bookmark."""
-        count = cls._update_bookmarks(auth_filter, comic_pks, updates)
-        count += cls._create_bookmarks(auth_filter, comic_pks, updates)
+        if not updates:
+            return 0
+        comic_pks = cls._normalize_comic_pks(comic_pks)
+        if not comic_pks:
+            return 0
+
+        # Single Python timestamp for the whole batch — both phases
+        # share it so ``updated_at`` stays consistent across the
+        # update + create halves of the operation.
+        now = django_timezone.now()
+
+        update_count, covered = cls._update_bookmarks(
+            auth_filter, comic_pks, updates, now
+        )
+        # Skip the create-path SELECT entirely when phase 1 already
+        # covered every input pk — the hot path on a sequential read
+        # (page 2..N of one comic) hits this branch every time after
+        # the first bookmark is created.
+        missing_pks = set(comic_pks) - covered
+        create_count = cls._create_bookmarks(auth_filter, missing_pks, updates)
+
+        count = update_count + create_count
         if count:
             uid = next(iter(auth_filter.values()))
             cls._notify_library_changed(uid)

--- a/codex/librarian/bookmark/user_active.py
+++ b/codex/librarian/bookmark/user_active.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 
-from django.contrib.auth.models import User
 from django.utils import timezone as django_timezone
 
 from codex.models.auth import UserAuth
@@ -20,20 +19,33 @@ class UserActiveMixin:
         self._user_active_recorded = {}  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def update_user_active(self, pk: int, log) -> None:
-        """Update user active timestamp on the user's :class:`UserAuth` row."""
-        # Offline because profile gets hit rapidly in succession.
+        """
+        Update user active timestamp on the user's :class:`UserAuth` row.
+
+        ``UserAuth`` rows are provisioned by
+        :meth:`AdminUserViewSet.perform_create` at user creation time, so
+        the row is guaranteed to exist for any logged-in pk reaching the
+        bookmark thread. ``filter().update()`` is one round trip vs the
+        prior ``User.objects.get`` + ``update_or_create`` (which fired
+        SELECT + SELECT + UPDATE-or-INSERT). Mirrors the
+        ``UserAuth`` / ``GroupAuth`` write-path pattern from
+        admin-views-perf PR #610.
+
+        ``auto_now=True`` on ``BaseModel.updated_at`` only fires on
+        ``save()`` — ``.update()`` skips it — so pass the timestamp
+        explicitly. A missing row is a silent no-op (the create flow
+        broke its invariant; logging it surfaces the data integrity
+        issue rather than masking it with ``update_or_create``).
+        """
+        last_recorded = self._user_active_recorded.get(pk, EPOCH_START)
+        now = django_timezone.now()
+        if now - last_recorded <= self.USER_ACTIVE_RESOLUTION:
+            return
         try:
-            last_recorded = self._user_active_recorded.get(pk, EPOCH_START)
-            now = django_timezone.now()
-            if now - last_recorded > self.USER_ACTIVE_RESOLUTION:
-                user = User.objects.get(pk=pk)
-                # update_or_create touches ``updated_at`` via auto_now on
-                # BaseModel; the row also carries the per-user age-rating
-                # ceiling but that stays untouched here.
-                UserAuth.objects.update_or_create(user=user)
-                self._user_active_recorded[pk] = now
-        except User.DoesNotExist:
-            pass
+            updated = UserAuth.objects.filter(user_id=pk).update(updated_at=now)
         except Exception as exc:
-            reason = f"Update user activity {exc}"
-            log.warning(reason)
+            log.warning(f"Update user activity {exc}")
+            return
+        if not updated:
+            log.warning(f"No UserAuth row for user pk={pk}; skipping touch.")
+        self._user_active_recorded[pk] = now


### PR DESCRIPTION
## Summary

Implementation of [`tasks/bookmarkd-perf/00-plan.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/bookmarkd-perf/00-plan.md).

Four commits, in the suggested implementation order.

### F1 + F2 — `BookmarkKey` correctness + hash cache (`44c0de12`)

`BookmarkKey.__eq__` returned `self.__hash__() == other.__hash__()`
— **collision-vulnerable**. Two distinct keys with a hash
collision would compare equal, so the aggregator merged one user's
bookmark into another user's cache entry, then wrote to that
other user's DB row. Replace with explicit field-equality on
`(auth_filter, comic_pks, user_pk)`.

Cache the hash on the dataclass via `__post_init__` so per-call
`tuple(auth_filter.items())` rebuilds go away. Sort the
auth_filter items defensively — today the auth_filter is always a
single-key dict so sorting is a no-op, but it forecloses a future
shape-drift bug.

### F6 — `update_user_active` `filter().update()` (`6c3a7312`)

`UserActiveMixin.update_user_active` fired `User.objects.get` +
`UserAuth.objects.update_or_create` per first-call-per-user-per-
restart — three round trips. UserAuth rows are guaranteed to exist
post-creation (provisioned by `AdminUserViewSet.perform_create`),
so swap to `UserAuth.objects.filter(user_id=pk).update(updated_at=now)`
— single UPDATE round trip. `auto_now=True` doesn't fire on
`.update()` so pass the timestamp explicitly.

Mirrors the UserAuth/GroupAuth write-path pattern from
admin-views-perf PR #610 finding 10.

### F3 (revised) + F4 — Skip create-path SELECT + single timestamp (`5b2ce42a`)

The plan's headline F3 was a single
`bulk_create(update_conflicts=True)` UPSERT to collapse 2 SELECT +
2 writes into one. **Empirically verified** that path is **not
viable** for the existing schema:

```sql
CREATE TABLE bm (user_id INT, session_id INT, comic_id INT, page INT,
                 UNIQUE(user_id, session_id, comic_id));
INSERT INTO bm VALUES (1, NULL, 100, 5);
INSERT INTO bm VALUES (1, NULL, 100, 10)
  ON CONFLICT(user_id, session_id, comic_id) DO UPDATE SET page=excluded.page;
SELECT * FROM bm;
-- [(1, NULL, 100, 5), (1, NULL, 100, 10)]   ← duplicate row created
```

SQLite (like ANSI SQL) treats NULLs in unique indexes as
distinct, so `ON CONFLICT (user_id, session_id, comic_id)` never
fires for the `{user_id: X, session_id: NULL}` shape that's the
actual hot path.

**Pivoted to a smaller-but-real win:** skip the create-path
SELECT entirely when phase 1 already covered every input pk.
Phase 1 now annotates `comic_id` on existing bookmarks and
returns the covered set; phase 2 only fires when
`set(comic_pks) - covered` is non-empty.

For the dominant hot path — sequential reader on one comic, page
2..N — phase 2 becomes a no-op every iteration after the first
bookmark is created:

| | per `FLOOD_DELAY` flush |
| --- | --- |
| Before | 2 SELECT + 1 UPDATE |
| After | **1 SELECT + 1 UPDATE** |

Cold path (user opens a comic for the first time) is unchanged:
2 SELECT + 2 writes.

**F4** — single timestamp captured at the top of
`update_bookmarks` and shared across both phases. Replaces
`Now()` per-instance, which `bulk_update` otherwise emits per row
in the generated `CASE WHEN`.

**Drive-by simplifications:**

- Normalize `comic_pks` to a tuple at the entry point. Browser
  callers pass a Comic QuerySet; the bookmark thread passes a
  tuple. Forcing the QuerySet here costs one `SELECT pk` but lets
  the rest of the flow do plain set arithmetic.
- `_get_comics_without_bookmarks` loses the
  `~Q(bookmark__user_id=...)` subquery — phase 1 already proved
  the pks are missing.
- `_create_bookmarks` loses dead `update_fields=` /
  `unique_fields=` args on `bulk_create`. Verified by reading
  Django's `_check_bulk_create_options`: those args are silently
  ignored when `update_conflicts=False`. Worked before only
  because phase 1 already pre-filtered conflicts away.

### F5 — Offload network I/O off the bookmark thread (`22eca631`)

`CodexLatestVersionTask` and `TelemeterTask` both make outbound
HTTP calls with a 5-second `urlopen` timeout. The aggregator was
running both **inline** inside `_process_task_immediately`, which
the main loop calls synchronously — every queued
`BookmarkUpdateTask` waited for the network roundtrip. On a slow
connection, page-turn writes stalled up to 5s behind a PyPI
fetch.

Add a small `_spawn_offline` helper that runs the target on a
daemon `threading.Thread`. Both tasks are infrequent (telemetry
once per week, version check once per day) so unbounded thread
creation isn't a real concern. `ClearLibrarianStatusTask` stays
inline — pure DB call, no network.

## Test plan

- [x] `make lint-python` clean.
- [x] `make test-python` clean (26 tests pass).
- [x] `make lint-frontend` / `make test-frontend` clean.
- [x] Empirical UPSERT-on-NULL verification (commit message of
  5b2ce42a) confirmed F3 pivot was correct.
- [ ] On a populated install, sequential read flips through 50
  pages — bookmark log should show 1 UPDATE per `FLOOD_DELAY` /
  3-second flush window after the first bookmark is created.
- [ ] Trigger a `CodexLatestVersionTask` while bookmarks are
  flushing — bookmark thread should not stall.

## References

- Plan: `tasks/bookmarkd-perf/00-plan.md`
- PR #610 finding 10 — same `filter().update()` pattern as F6
- Django `bulk_create` `_check_bulk_create_options` validation
  for the F3 dead-args cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)