### PR TITLE
Flip DEFAULT_AUTO_FIELD to BigAutoField + migration 0042

### DIFF
--- a/codex/migrations/0042_alter_adminflag_id_alter_agerating_id_and_more.py
+++ b/codex/migrations/0042_alter_adminflag_id_alter_agerating_id_and_more.py
@@ -1,0 +1,308 @@
+"""Migrate every codex-app primary key from AutoField to BigAutoField."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Switch codex PKs to BigAutoField under the new DEFAULT_AUTO_FIELD."""
+
+    dependencies = [
+        ("codex", "0041_strip_pycountry_names"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="adminflag",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agerating",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="ageratingmetron",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="bookmark",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="character",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="comic",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="country",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="credit",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="creditperson",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="creditrole",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="customcover",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="failedimport",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="folder",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="genre",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="groupauth",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="identifier",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="identifiersource",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="imprint",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="language",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="librarianstatus",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="library",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="location",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="originalformat",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="publisher",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="scaninfo",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="series",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="seriesgroup",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="settingsbrowser",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="settingsbrowserfilters",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="settingsbrowserlastroute",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="settingsbrowsershow",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="settingsreader",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="story",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="storyarc",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="storyarcnumber",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="tag",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="tagger",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="team",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="timestamp",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="universe",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="userauth",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="volume",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+    ]

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -441,11 +441,11 @@ if DEBUG:
     }
     DATABASE_ROUTERS = ["codex.db_routers.SilkRouter"]
 
-# The new DEFAULT_AUTO_FIELD in Django 3.2 is BigAutoField (64 bit),
-#   but it can't be auto migrated. Automigration has been punted to
-#   Django 4.0 at the earliest:
-#   https://code.djangoproject.com/ticket/32674
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+# Django 6 defaults DEFAULT_AUTO_FIELD to ``BigAutoField`` (64-bit).
+# Pin it here to match — explicit ``> AutoField`` migration support
+# landed in Django 4.0 (ticket #32674) so the legacy 32-bit override
+# this codebase carried since Django 3.2 is no longer needed.
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 ##################
 # Authentication #


### PR DESCRIPTION
## Summary

Two-line settings change + auto-generated migration to flip every
codex-app primary key from 32-bit `AutoField` to 64-bit
`BigAutoField`.

### Why now

Codex carried an explicit `DEFAULT_AUTO_FIELD = "django.db.models.AutoField"` override since Django 3.2, pinned because the 3.2 / 4.0-era automigration support was incomplete (ticket #32674).
Django 4.0 shipped the schema migration; the override is no
longer needed.

Django 6's global default for `DEFAULT_AUTO_FIELD` is already
`BigAutoField`, so removing the override drops to the framework
default. Setting it explicitly here documents the choice and
forecloses surprise changes from future Django defaults.

### What changes

- `codex/settings/__init__.py` — flip `DEFAULT_AUTO_FIELD` from
  `AutoField` to `BigAutoField`. Update the dated comment.
- `codex/migrations/0042_alter_adminflag_id_alter_agerating_id_and_more.py`
  — autogenerated by `makemigrations`. 42 `AlterField`
  operations, one per codex-app model. Docstrings added to
  satisfy ruff D100 / D101.

### What does NOT change

Built-in Django apps keep their existing PK types — Django's
auth, contenttypes, and sessions apps each set
`default_auto_field = "django.db.models.AutoField"` in their
`AppConfig` to insulate them from the project-level setting.
Verified at runtime:

| App.Model | PK type |
| --- | --- |
| `codex.Comic` | `BigAutoField` |
| `auth.User` | `AutoField` |
| `auth.Group` | `AutoField` |
| `contenttypes.ContentType` | `AutoField` |
| `sessions.Session` | `session_key CharField` |

So the wire-format / integration impact is limited to codex's own
tables. FK columns on codex models that point to codex models
likewise widen to `bigint`; FKs that point to `auth.User` (e.g.
`Bookmark.user`, `UserAuth.user`) keep the existing 32-bit
column.

## Test plan

- [x] `make lint-python` clean (D100 / D101 docstrings on the
  generated migration).
- [x] `make test-python` clean (26 tests pass against the
  rebuilt schema — Django's test runner runs the new migration
  fresh).
- [ ] `make migrate` against an existing populated dev DB —
  SQLite's `ALTER TABLE` for the PK type change rebuilds each
  table; expect a measurable runtime on installs with millions of
  Comic rows. Schedule for a maintenance window if running
  against a large library.

## Operational note

This is a schema-rebuild migration. SQLite's strategy for
"alter PK type" is `CREATE TABLE new ...; INSERT INTO new SELECT *
FROM old; DROP TABLE old; ALTER TABLE new RENAME TO old`, repeated
for every affected table. On a library with ~1M comics this
typically takes a few minutes. Users running the upgrade should
expect a one-time import-style downtime on first boot post-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)