### PR TITLE
Threads + worker: gate type-only imports + monotonic clock

### DIFF
--- a/codex/librarian/threads.py
+++ b/codex/librarian/threads.py
@@ -1,17 +1,25 @@
 """Abstract Thread worker for doing queued tasks."""
 
-import time
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from multiprocessing.queues import Queue
 from queue import Empty, SimpleQueue
 from threading import Thread
-from typing import override
+from time import monotonic
+from typing import TYPE_CHECKING, override
 
 from django.db import close_old_connections
-from loguru._logger import Logger
 from setproctitle import setproctitle
 
 from codex.librarian.worker import WorkerStatusMixin
+
+if TYPE_CHECKING:
+    # Both type-hint-only — defer until type checkers run. Keeps
+    # the runtime import graph for ``threads.py`` lean across the
+    # nine librarian modules that import it.
+    from multiprocessing.queues import Queue
+
+    from loguru._logger import Logger
 
 
 class BreakLoopError(Exception):
@@ -116,12 +124,19 @@ class AggregateMessageQueuedThread(QueuedThread, ABC):
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the cache."""
         self.cache = {}
-        self._last_send = time.time()
+        # ``time.monotonic`` over ``time.time``: elapsed-time math
+        # (``monotonic() - self._last_send``) must not be affected by
+        # wall-clock jumps from NTP / daylight saving / manual
+        # adjustments. Slightly cheaper than ``time.time`` on most
+        # platforms (clock_gettime(CLOCK_MONOTONIC) vs gettimeofday)
+        # — the bigger win is correctness on the flush-timing path
+        # in subclasses like BookmarkThread / NotifierThread.
+        self._last_send = monotonic()
         super().__init__(*args, **kwargs)
 
     def set_last_send(self) -> None:
         """Set the last send time to now."""
-        self._last_send = time.time()
+        self._last_send = monotonic()
 
     @override
     def get_timeout(self):
@@ -148,7 +163,7 @@ class AggregateMessageQueuedThread(QueuedThread, ABC):
     def process_item(self, item) -> None:
         """Aggregate items and sleep in case there are more."""
         self.aggregate_items(item)
-        since_last_timed_out = time.time() - self._last_send
+        since_last_timed_out = monotonic() - self._last_send
         waited_too_long = since_last_timed_out > self.MAX_DELAY
         if waited_too_long:
             self.timed_out()

--- a/codex/librarian/worker.py
+++ b/codex/librarian/worker.py
@@ -1,11 +1,17 @@
 """Mixin for common librarian thread attributes."""
 
-from multiprocessing.queues import Queue
-from typing import override
+from __future__ import annotations
 
-from loguru._logger import Logger
+from typing import TYPE_CHECKING, override
 
 from codex.librarian.status_controller import StatusController
+
+if TYPE_CHECKING:
+    # Type-hint-only — runtime imports stay lean across the nine
+    # librarian modules that import this chain.
+    from multiprocessing.queues import Queue
+
+    from loguru._logger import Logger
 
 
 class WorkerMixin:


### PR DESCRIPTION
## Summary

Two small changes to `codex/librarian/threads.py` and its sibling
`codex/librarian/worker.py`. Both files sit at the head of the
import chain for all 9 librarian daemons (cover / bookmark /
notifier / scribe / fs.event_batcher / fs.watcher / fs.poller /
cron / librariand), so savings here multiply across the
codebase's startup graph.

### F1 — Type-only imports gated behind `TYPE_CHECKING`

`multiprocessing.queues.Queue` and `loguru._logger.Logger` are
referenced *only* in function-signature type annotations
(`NamedThread.__init__` and `WorkerMixin.init_worker`). Adding
`from __future__ import annotations` makes the annotations
forward-references at runtime, so the imports can move into a
`TYPE_CHECKING` block.

**`multiprocessing.queues` cold import cost:**

```
$ uv run python -X importtime -c "from multiprocessing.queues import Queue" \
    2>&1 | grep multiprocessing.queues
import time:    14045 us | multiprocessing.queues
```

After this change `codex.librarian.threads` no longer pulls in
`multiprocessing.queues` at all — confirmed via:

```python
import codex.librarian.threads
import sys
assert 'multiprocessing.queues' not in sys.modules  # passes
```

`loguru._logger` was already loaded transitively by Django's
logging configuration, so the savings for it is structural
rather than measurable. The type-only import in worker.py was
misleading either way.

### F2 — `time.time()` → `time.monotonic()` in `AggregateMessageQueuedThread`

The aggregator thread does elapsed-time math
(`time.time() - self._last_send`) on every queued item to decide
whether to flush the cache. `time.time()` returns wall-clock and
can jump (NTP correction, daylight saving, manual clock change),
which would skew the flush-timing logic in subclasses that rely
on it (`BookmarkThread`, `NotifierThread`).

`time.monotonic()` is immune to clock jumps and is also slightly
cheaper on most platforms (`CLOCK_MONOTONIC` vs `gettimeofday`).
Correctness fix with an incidental perf win on the per-item hot
path.

## Test plan

- [x] `make lint-python` clean (ruff + format + basedpyright +
  vulture + complexipy + codespell).
- [x] `make test-python` clean (26 tests pass).
- [x] `import codex.librarian.threads` no longer loads
  `multiprocessing.queues` (verified via `sys.modules`).
- [ ] Live-run on a populated librarian — bookmark / notifier
  flush-timing unaffected. Aggregator threads should still flush
  per `MAX_DELAY` cycle; the only behavior change is immunity to
  wall-clock jumps.

## Why this surface specifically

9 importers × the cost of any redundant
runtime work cascade across startup and per-item dispatch. F1
benefits cold import; F2 benefits per-item runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)