### PR TITLE
Search indexer perf: dead code + name mismatches + per-M2M batching

### DIFF
--- a/codex/librarian/scribe/search/sync.py
+++ b/codex/librarian/scribe/search/sync.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from math import floor
-from time import time
+from time import monotonic
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
@@ -58,26 +58,33 @@ _SIMPLE_FTS_ANNOTATIONS = MappingProxyType(
         "fts_age_rating_metron": F("age_rating__metron__name"),
     }
 )
-_M2M_FTS_RELS = (
-    "characters",
-    "credits__person",
-    "genres",
-    "locations",
-    "series_groups",
-    "identifiers__source",
-    "stories",
-    "story_arc_numbers__story_arc",
-    "tags",
-    "teams",
+# Alias → FK-traversal path. The alias becomes the FTS column name
+# the consumer reads (``prepare.py:_COMIC_KEYS``); the path is what
+# ``GROUP_CONCAT`` walks to extract the related ``name``. Decoupling
+# the two fixes a long-standing bug: the previous code derived the
+# alias from the path (``f"fts_{rel}"``), so paths with FK suffixes
+# like ``credits__person`` produced aliases like
+# ``fts_credits__person`` that the consumer's ``fts_credits`` lookup
+# silently dropped — three FTS columns (credits, sources,
+# story_arcs) ended up empty for sync-built entries.
+_M2M_FTS_REL_MAP = MappingProxyType(
+    {
+        "characters": "characters__name",
+        "credits": "credits__person__name",
+        "genres": "genres__name",
+        "locations": "locations__name",
+        "series_groups": "series_groups__name",
+        "sources": "identifiers__source__name",
+        "stories": "stories__name",
+        "story_arcs": "story_arc_numbers__story_arc__name",
+        "tags": "tags__name",
+        "teams": "teams__name",
+    }
 )
 _M2M_FTS_ANNOTATIONS = MappingProxyType(
     {
-        f"fts_{rel}": GroupConcat(
-            f"{rel}__name",
-            order_by=f"{rel}__name",
-            distinct=True,
-        )
-        for rel in _M2M_FTS_RELS
+        f"fts_{alias}": GroupConcat(target, distinct=True, order_by=target)
+        for alias, target in _M2M_FTS_REL_MAP.items()
     }
 )
 
@@ -122,26 +129,6 @@ class SearchIndexerSync(SearchIndexerRemove):
             "language",
             "scan_info",
             "tagger",
-        )
-
-    @staticmethod
-    def _prefetch_related_fts_query(qs):
-        # Prefecthing deep relations breaks the 1000 sqlite query depth limit
-        return qs.prefetch_related(
-            "characters",
-            "credits",
-            # "credits__person",
-            "identifiers",
-            # "identifiers__source",
-            "genres",
-            "locations",
-            "series_groups",
-            "stories",
-            "story_arc_numbers",
-            # "story_arc_numbers__story_arc",
-            "tags",
-            "teams",
-            "universes",
         )
 
     @staticmethod
@@ -194,12 +181,6 @@ class SearchIndexerSync(SearchIndexerRemove):
         status.increment_complete(num_comic_fts)
         self.status_controller.update(status, notify=True)
 
-    @staticmethod
-    def _get_operation_comics_query(qs, *, create: bool):
-        if create and not ComicFTS.objects.exists():
-            qs = Comic.objects.all()
-        return qs
-
     def _update_search_index_operate(
         self, comics_filtered_qs: QuerySet, *, create: bool
     ):
@@ -210,12 +191,19 @@ class SearchIndexerSync(SearchIndexerRemove):
         )
         chunk_human_size = intcomma(search_index_batch_size)
 
+        # Hoist the FTS-empty check out of the loop. After the first
+        # batch lands on an initially-empty index, ComicFTS has rows
+        # for the rest of the run; checking ``ComicFTS.objects.exists()``
+        # per iteration just spends a SELECT to learn what we already
+        # know. Decide once up-front and stash on the base queryset.
+        if create and not ComicFTS.objects.exists():
+            base_qs: QuerySet = Comic.objects.all()
+        else:
+            base_qs = comics_filtered_qs
+
         verb = "create" if create else "update"
         self.log.debug(f"Counting total search index entries to {verb}...")
-        total_comics = self._get_operation_comics_query(
-            comics_filtered_qs, create=create
-        )
-        total_comics = total_comics.count()
+        total_comics = base_qs.count()
         status = self._update_search_index_operate_get_status(
             total_comics, chunk_human_size, create=create
         )
@@ -236,14 +224,7 @@ class SearchIndexerSync(SearchIndexerRemove):
                 self.log.debug(
                     f"Preparing up to {chunk_human_size} comics for search indexing..."
                 )
-                # This query is supposed to get only comics that don't need creating but it doesn't
-                # So the start total exit assists it with that.
-                comics = self._get_operation_comics_query(
-                    comics_filtered_qs, create=create
-                )
-                comics = self._prefetch_related_fts_query(comics)
-                comics = comics.order_by("pk")
-                comics = comics[:search_index_batch_size]
+                comics = base_qs.order_by("pk")[:search_index_batch_size]
                 comics = self._annotate_fts_query(comics)
                 for comic in comics.values():
                     SearchEntryPrepare.prepare_sync_fts_entry(
@@ -295,7 +276,11 @@ class SearchIndexerSync(SearchIndexerRemove):
     def _update_search_index(self, *, rebuild: bool) -> None:
         """Update or Rebuild the search index."""
         self.log.debug("In update search index before init statii.")
-        start_time = time()
+        # ``monotonic()`` over ``time()`` for the elapsed reporting
+        # below — wall-clock jumps (NTP / DST / manual adjustment)
+        # would skew ``time() - start_time``. Mirrors the same fix
+        # applied to other librarian threads in PR #623 / #624.
+        start_time = monotonic()
         self._init_statuses(rebuild)
 
         if self.abort_event.is_set():
@@ -308,7 +293,7 @@ class SearchIndexerSync(SearchIndexerRemove):
             return
         created_count = self._update_search_index_create()
 
-        elapsed_time = time() - start_time
+        elapsed_time = monotonic() - start_time
         elapsed = naturaldelta(elapsed_time)
         if rebuild:
             cleaned = "cleared entire search index"

--- a/codex/librarian/scribe/search/sync.py
+++ b/codex/librarian/scribe/search/sync.py
@@ -81,12 +81,6 @@ _M2M_FTS_REL_MAP = MappingProxyType(
         "teams": "teams__name",
     }
 )
-_M2M_FTS_ANNOTATIONS = MappingProxyType(
-    {
-        f"fts_{alias}": GroupConcat(target, distinct=True, order_by=target)
-        for alias, target in _M2M_FTS_REL_MAP.items()
-    }
-)
 
 
 class SearchIndexerSync(SearchIndexerRemove):
@@ -118,36 +112,85 @@ class SearchIndexerSync(SearchIndexerRemove):
             self.remove_stale_records(log_success=False)
 
     @staticmethod
-    def _select_related_fts_query(qs):
-        return qs.select_related(
-            "publisher",
-            "imprint",
-            "series",
-            "age_rating",
-            "age_rating__metron",
-            "country",
-            "language",
-            "scan_info",
-            "tagger",
+    def _build_fk_fts_rows(pks: list[int]) -> list[dict]:
+        """
+        One query: comic attrs + simple FK-resolved name columns.
+
+        Returns a list of dicts keyed by ``id`` plus the FTS columns
+        the consumer reads directly off Comic / FK ``__name``
+        traversals (no M2M, no GROUP BY). Order-by-pk so the caller
+        sees the same iteration order the megaquery used to produce.
+        """
+        return list(
+            Comic.objects.filter(pk__in=pks)
+            .order_by("pk")
+            .annotate(**_SIMPLE_FTS_ANNOTATIONS)
+            .values(
+                "id",
+                "name",
+                "collection_title",
+                "review",
+                "summary",
+                *_SIMPLE_FTS_ANNOTATIONS.keys(),
+            )
         )
 
     @staticmethod
-    def _annotate_fts_query(qs):
-        return qs.annotate(
-            **_SIMPLE_FTS_ANNOTATIONS,
-            **_M2M_FTS_ANNOTATIONS,
-            fts_universes=Concat(
-                GroupConcat(
-                    "universes__designation",
-                    distinct=True,
-                    order_by="universes__designation",
-                ),
-                Value(","),
-                GroupConcat(
-                    "universes__name", distinct=True, order_by="universes__name"
-                ),
-            ),
+    def _build_m2m_fts_dict(pks: list[int], target_path: str) -> dict[int, str]:
+        """
+        One query per M2M: GROUP_CONCAT(<rel>__name) keyed by comic pk.
+
+        Replaces the megaquery's per-M2M ``GROUP_CONCAT`` aggregations
+        — each was a LEFT JOIN to the related table contributing to a
+        cartesian product before GROUP BY collapse. Per-relation queries
+        each walk one M2M's index independently and produce per-pk
+        strings; no cartesian product, much smaller intermediate temp
+        tables on richly-tagged libraries.
+        """
+        rows = (
+            Comic.objects.filter(pk__in=pks)
+            .annotate(
+                fts_value=GroupConcat(target_path, distinct=True, order_by=target_path)
+            )
+            .values_list("pk", "fts_value")
         )
+        # GROUP_CONCAT over a LEFT JOIN with no related rows returns
+        # NULL → store empty string so the consumer's truthy filter
+        # treats absence and emptiness identically.
+        return {pk: (value or "") for pk, value in rows}
+
+    @staticmethod
+    def _build_universes_fts_dict(pks: list[int]) -> dict[int, str]:
+        """
+        Universes special case: Concat of designation + name aggregates.
+
+        Universes carry both a ``designation`` and a ``name`` worth
+        making searchable; the previous shape combined them via
+        ``Concat(GroupConcat(designation), Value(","), GroupConcat(name))``.
+        Single LEFT JOIN to the universes table, single GROUP BY on
+        comic_id; same SQL as the megaquery would have produced for
+        this column, just isolated from the other M2Ms.
+        """
+        rows = (
+            Comic.objects.filter(pk__in=pks)
+            .annotate(
+                fts_universes=Concat(
+                    GroupConcat(
+                        "universes__designation",
+                        distinct=True,
+                        order_by="universes__designation",
+                    ),
+                    Value(","),
+                    GroupConcat(
+                        "universes__name",
+                        distinct=True,
+                        order_by="universes__name",
+                    ),
+                )
+            )
+            .values_list("pk", "fts_universes")
+        )
+        return {pk: (value or "") for pk, value in rows}
 
     def _update_search_index_operate_get_status(
         self, total_comics: int, chunk_human_size: str, *, create: bool
@@ -224,9 +267,35 @@ class SearchIndexerSync(SearchIndexerRemove):
                 self.log.debug(
                     f"Preparing up to {chunk_human_size} comics for search indexing..."
                 )
-                comics = base_qs.order_by("pk")[:search_index_batch_size]
-                comics = self._annotate_fts_query(comics)
-                for comic in comics.values():
+                # Snapshot the batch's pk list once; every per-relation
+                # query below filters against the same set so they
+                # stitch back together cleanly in Python.
+                batch_pks = list(
+                    base_qs.order_by("pk").values_list("pk", flat=True)[
+                        :search_index_batch_size
+                    ]
+                )
+                if not batch_pks:
+                    break
+
+                # Per-M2M batched queries. Replaces the previous
+                # megaquery (10 GROUP_CONCAT aggregations + 20+
+                # LEFT JOINs + GROUP BY in a single SELECT) with one
+                # SELECT per relation — each walks one M2M's index
+                # independently, no cartesian product across the
+                # 10 M2Ms.
+                fk_rows = self._build_fk_fts_rows(batch_pks)
+                m2m_dicts = {
+                    f"fts_{alias}": self._build_m2m_fts_dict(batch_pks, target)
+                    for alias, target in _M2M_FTS_REL_MAP.items()
+                }
+                universes_dict = self._build_universes_fts_dict(batch_pks)
+
+                for comic in fk_rows:
+                    pk = comic["id"]
+                    for fts_alias, m2m_dict in m2m_dicts.items():
+                        comic[fts_alias] = m2m_dict.get(pk, "")
+                    comic["fts_universes"] = universes_dict.get(pk, "")
                     SearchEntryPrepare.prepare_sync_fts_entry(
                         comic, obj_list, create=create
                     )


### PR DESCRIPTION
## Summary

Implementation of [`tasks/search-perf/00-plan.md`](https://github.com/ajslater/codex/blob/v1.11-performance/tasks/search-perf/00-plan.md) (PR #625, still in flight). Two commits.

### Commit 1 — Dead code + name mismatches + small wins (`fc0498a2`)

**F1** — drop `_prefetch_related_fts_query`. Empirically verified that
`prefetch_related()` chained to `.values()` doesn't fire prefetches:

```python
>>> qs = Comic.objects.prefetch_related("characters").values("pk")
>>> with CaptureQueriesContext(connection) as ctx:
...     list(qs)
>>> len(ctx.captured_queries)
1   # only the main SELECT — zero prefetch queries
```

The 11 prefetch declarations (and the misleading "1000 sqlite query
depth" comment) were doing zero query work.

**F2** — reconcile column-name mismatches between annotation aliases
and consumer keys. `_M2M_FTS_RELS` produced annotations under
`fts_credits__person`, `fts_identifiers__source`,
`fts_story_arc_numbers__story_arc`, but `prepare.py:_COMIC_KEYS` read
`fts_credits` / `fts_sources` / `fts_story_arcs`. The dict
comprehension's `if comic.get(key)` filter silently dropped the
mismatched data — three GROUP_CONCAT aggregations ran, results were
discarded, and the resulting FTS columns were always empty for any
sync-built entry.

**Search by credit-person name / identifier-source / story-arc title
silently returned no hits before this fix.** Behavior change: those
searches now return real results.

Fix: split the rel definition into a name → path map.
`_M2M_FTS_REL_MAP` keeps the alias short (matches `_COMIC_KEYS`) but
preserves the FK-traversal path for GROUP_CONCAT. Same SQL generated;
just the alias name changes.

**F4** — hoist `ComicFTS.exists()` out of the operate loop. After
iteration 1 lands, ComicFTS has rows for the rest of the run; the
per-iteration `.exists()` SELECT was wasted.

**F5** — `time()` → `monotonic()` for elapsed_time reporting.
Wall-clock jumps (NTP / DST / manual adjustment) skew
`time() - start_time`. Same fix shape as PR #623 / #624 / #625 in
other librarian modules.

### Commit 2 — Per-M2M batched queries (the headline) (`1b00c9dd`)

The "megaquery" (1 SELECT with 10 GROUP_CONCAT aggregates + 10 LEFT
JOIN'd FK columns + GROUP BY) materialized a cartesian product per
batch. For a comic with 5 chars × 3 credits × 2 genres × 4 tags, the
intermediate temp table before GROUP BY had `5 × 3 × 2 × 4 × ...`
rows. SQLite sorted each GROUP_CONCAT for DISTINCT before collapsing.

Apply the OPDS metadata batching pattern:

| | per batch |
| --- | --- |
| Before | 1 megaquery, 30+ JOINs, cartesian product |
| After | 12 small queries (1 FK + 10 M2M + 1 universes), each walks one relation's index |

Each per-M2M query is a single LEFT JOIN + GROUP BY comic_id —
no cartesian product across the 10 M2Ms. Cost goes from
`O(product of M2M counts × batch_size)` to `O(sum of M2M-table-rows
per relation)`.

Three new helpers:

- `_build_fk_fts_rows(pks)` — comic attrs + simple FK names. One
  SELECT, no M2M, no GROUP BY. Returns list of dicts keyed by `id`.
- `_build_m2m_fts_dict(pks, target_path)` — per-M2M
  GROUP_CONCAT. Returns `dict[pk, comma_string]`.
- `_build_universes_fts_dict(pks)` — special case for universes
  (`Concat(designation_aggregate, ",", name_aggregate)`).

The batch loop builds the FK rows + 10 M2M dicts + universes dict,
then stitches per-pk dicts in Python before passing to
`prepare_sync_fts_entry`. Iteration order preserved via `order_by("pk")`
on the FK query.

Drive-by cleanup: drop `_select_related_fts_query` (defined but never
called — dead code) and the now-unused `_M2M_FTS_ANNOTATIONS`
constant.

## Test plan

- [x] `make lint-python` clean (ruff + format + basedpyright +
  vulture + complexipy + codespell).
- [x] `make test-python` clean (26 tests pass).
- [x] `make lint-frontend` / `make test-frontend` clean.
- [ ] On a populated install, fire `SearchIndexSyncTask(rebuild=True)`
  and watch wall time — should drop noticeably for richly-tagged
  libraries.
- [ ] After F2: search for a known credit-person name / story-arc
  title / identifier-source URN returns hits. Before F2: those
  searches returned zero.
- [ ] Spot-check the resulting FTS table for a sync-built entry —
  `credits` / `sources` / `story_arcs` columns should now contain
  real data instead of empty strings.

## References

- Plan: `tasks/search-perf/00-plan.md` (PR #625)
- `codex/views/opds/metadata.py:get_m2m_objects_by_comic` — the
  per-M2M UNION batching pattern this PR mirrors
- PR #615 (OPDS v2 batching) — same shape applied to OPDS feeds
- PR #623 / #624 / #625 — the `time()` → `monotonic()` fix
  applied to other librarian modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)