### PR TITLE
Importer perf: capture plan in tasks/

### DIFF
--- a/tasks/importer-perf/00-meta.md
+++ b/tasks/importer-perf/00-meta.md
@@ -1,0 +1,335 @@
+# Importer perf — meta plan
+
+`codex/librarian/scribe/importer/` is large (62 files,
+~5,000+ LOC across 8 phase-specific subdirectories) and central
+to the user's workflow. The user's stated goal: take a 600,000-
+comic bulk import to a faster wall-clock time without sacrificing
+correctness.
+
+This is a meta-plan. The surface is too big for one plan file
+and the user explicitly noted "complicated code and hard for a
+human to conceptualize all at once." Each sub-plan covers one
+phase of the pipeline or one cross-cutting concern, can be
+reviewed in isolation, and ships as one PR.
+
+## Why this matters at 600k scale
+
+What's slow at small scale (10s of comics) is invisible. At 600k
+comics, even O(N) Python work becomes minutes; an N+1 query
+pattern hidden in a per-comic loop becomes hours.
+
+The user noted they've "already spent a while" optimizing. The
+easy wins are likely already taken. The remaining wins live in:
+
+1. **N+1 query patterns inside loops** that fire millions of
+   small SELECTs across the import — the most common slow-at-scale
+   bug shape. Several confirmed below.
+2. **Memory pressure** from building per-path metadata dicts for
+   the entire batch in `self.metadata` before the next phase runs.
+3. **Sub-process boundary cost** in comicbox's parallel reader —
+   pickling rich metadata dicts across the IPC channel scales.
+4. **SQLite write throughput tuning** — PRAGMAs that only matter
+   for bulk ingest.
+5. **Comicbox-side parsing** — codex doesn't use most of what
+   comicbox returns; cycles spent parsing unused fields.
+
+## Pipeline architecture
+
+`ComicImporter.apply` runs nine phases in sequence
+(`importer.py:5-15`):
+
+```python
+_METHODS = (
+    "init_apply",            # wait for FS ops, init statuses
+    "move_and_modify_dirs",  # rename folder DB rows in place
+    "read",                  # extract + aggregate metadata
+    "query",                 # find existing FK rows
+    "create_and_update",     # bulk create FK rows + comics
+    "link",                  # wire up M2M relations
+    "fail_imports",          # record failed imports
+    "delete",                # remove DB rows for deleted files
+    "full_text_search",      # sync FTS index
+)
+```
+
+Data flows through `self.metadata` — a dict keyed by phase outputs
+(`EXTRACTED`, `CREATE_COMICS`, `UPDATE_COMICS`, `LINK_FKS`,
+`LINK_M2MS`, `QUERY_MODELS`, `CREATE_FKS`, `UPDATE_FKS`, etc.).
+Each phase consumes some keys, produces others, and sometimes
+deletes the old ones to free memory.
+
+## Surface map
+
+| Phase | Subdirectory | LOC | What it does |
+| ----- | ------------ | --- | ------------ |
+| init / orchestration | (top-level) | ~750 | `init.py`, `importer.py`, `finish.py`, `const.py` |
+| moved | `moved/` | ~430 | Handle file/folder renames without re-extracting metadata |
+| read | `read/` | ~870 | comicbox extraction (parallel via `ProcessPoolExecutor`) → aggregate FK + M2M |
+| query | `query/` | ~660 | Find existing FK rows; prune already-correct links |
+| create | `create/` | ~610 | Bulk-create FK rows, then bulk-create/update comic rows |
+| link | `link/` | ~430 | Wire up M2M through-table rows |
+| delete | `delete/` | ~200 | Remove DB rows for deleted files |
+| failed | `failed/` | ~280 | Record failed imports |
+| status | `statii/` | ~250 | Status dataclasses for the librarian status table |
+
+## Confirmed perf hot spots (with line numbers)
+
+### Headline finding — millions of SELECTs in `link_prepare_m2m_links`
+
+`link/prepare.py:105-135`. For each comic in the batch:
+
+```python
+for comic_pk, comic_path in comics:
+    md = self.metadata[LINK_M2MS][comic_path]
+    self._link_prepare_complex_m2ms(...)  # × 4 SELECTs (folders + 3 complex models)
+    for field, names in md.items():
+        self._link_prepare_named_m2ms(...)  # × ~10 named M2M fields
+```
+
+`_link_prepare_named_m2ms`:
+
+```python
+pks = (
+    model.objects.filter(name__in=names).values_list("pk", flat=True).distinct()
+)
+```
+
+One SELECT per (comic, M2M field). With 600k comics × ~14 M2Ms,
+that's **~8.4 million SELECTs** in this phase alone — almost
+certainly the dominant cost of the link step.
+
+Detailed in [01-link-batching.md](./01-link-batching.md). Fix:
+batch by model. Build `dict[(model, name) → pk]` once per
+import, look up in Python.
+
+### FK creation does per-row SELECTs
+
+`create/foreign_keys.py:60-75`. `_get_create_update_args`
+dereferences nested FK references via `field_model.objects.get(...)`
+for every row in the create/update batch.
+
+For 600k comics with ~5k unique imprints, the imprint creation
+phase fires 5k publisher SELECTs. Series creation: 10k publisher +
+imprint SELECTs. Comic creation runs through similar logic.
+
+`create/foreign_keys.py:189`. `_bulk_update_models` does
+`obj = model.objects.get(**key_args)` per update tuple. Same shape.
+
+Detailed in [02-create-fk-batching.md](./02-create-fk-batching.md).
+Fix: pre-fetch the parent FK lookup map once per model, reuse
+during create.
+
+### Query-prune phases iterate per-comic
+
+`query/links_m2m.py:85-104`. `_query_prune_comic_m2m_links_batch`
+prefetches all M2M fields for a batch of comics, then walks them
+in Python to determine deltas:
+
+```python
+comics = (
+    Comic.objects.filter(library=self.library, path__in=paths)
+    .prefetch_related(*COMIC_M2M_FIELD_NAMES)
+    .only(*COMIC_M2M_FIELD_NAMES)
+)
+for comic in comics.iterator(...):
+    self._query_prune_comic_m2m_links_comic(comic, status)
+```
+
+Each comic iteration walks ~14 M2M relations and rebuilds tuple
+keys. For 600k comics that's ~8.4M Python iterations + the
+Django ORM overhead.
+
+`query/links_fk.py` similar shape for FK pruning.
+
+Detailed in [03-query-prune.md](./03-query-prune.md).
+
+### Moved phase: per-comic Folder.objects.get / filter
+
+`moved/comics.py:61-68`. Per moved comic:
+
+```python
+comic.parent_folder = Folder.objects.get(path=new_path.parent)
+new_folder_pks = frozenset(
+    Folder.objects.filter(path__in=new_path.parents).values_list("pk", flat=True)
+)
+```
+
+Two SELECTs per moved comic. 600k moves → 1.2M SELECTs.
+
+Bundled into [03-query-prune.md](./03-query-prune.md) since it's
+the same kind of "batch by model" fix.
+
+### Memory pressure from all-at-once batch architecture
+
+`init.py` reads metadata for ALL paths into `self.metadata[EXTRACTED]`.
+`aggregate_metadata` then transforms ALL into `CREATE_COMICS` /
+`LINK_FKS` / `LINK_M2MS`. `query` mutates them. `create_and_update`
+consumes them.
+
+For 600k comics, peak memory holds the whole batch's per-path
+dicts. At ~1-5 KB per dict, that's 0.6-3 GB of pure Python dict
+overhead during the overlap windows between phases.
+
+Detailed in [04-streaming-pipeline.md](./04-streaming-pipeline.md).
+Fix: chunk-based pipeline — process N=50k comics through all
+phases, then start the next chunk. Bigger refactor; deferred.
+
+### SQLite write throughput
+
+The importer doesn't pin SQLite PRAGMAs for bulk-write mode.
+`journal_mode=WAL`, `synchronous=NORMAL`, `temp_store=MEMORY`,
+`mmap_size`, `cache_size` all matter for bulk ingest.
+
+Plus: each `bulk_create` / `bulk_update` runs in its own
+auto-commit transaction. Wrapping a phase's worth of inserts in
+one `transaction.atomic()` block reduces fsync overhead but
+risks blocking readers (browser viewing) for the duration.
+
+Detailed in [05-sqlite-tuning.md](./05-sqlite-tuning.md).
+
+### Comicbox-side wins
+
+`_USED_COMICBOX_FIELDS` in `read/aggregate_path.py:26-76` lists
+44 fields codex actually consumes. Comicbox's `to_dict()` returns
+all fields it knows about (probably 60+) and codex pops the
+unused ones. Field projection (pass the wanted-set into comicbox,
+have it skip parsing the rest) would reduce both parse time AND
+the pickled dict size crossing the subprocess boundary.
+
+Detailed in [06-comicbox-side.md](./06-comicbox-side.md).
+
+## Sub-plans
+
+Each sub-plan is sized to be one PR. Order is by impact-per-LOC,
+with structural risk increasing toward the end:
+
+1. **[01-link-batching.md](./01-link-batching.md)** — millions of
+   SELECTs → tens of SELECTs. Self-contained in `link/prepare.py`.
+   Highest single-finding impact. Touches `link/prepare.py` and
+   adds a name→pk batch helper.
+2. **[02-create-fk-batching.md](./02-create-fk-batching.md)** —
+   per-row FK SELECTs in create/update phases. Self-contained in
+   `create/foreign_keys.py`.
+3. **[03-query-prune.md](./03-query-prune.md)** — `query/links_m2m.py`,
+   `query/links_fk.py`, `moved/comics.py`. Per-comic M2M / FK
+   walks → batch-by-model.
+4. **[05-sqlite-tuning.md](./05-sqlite-tuning.md)** — PRAGMAs
+   for bulk ingest, transaction batching. Small diff, broad
+   impact, low correctness risk if scoped carefully.
+5. **[06-comicbox-side.md](./06-comicbox-side.md)** — comicbox
+   field projection, lazy parsing, pickle minimization. Touches
+   the comicbox repo (user's primary consumer ⇒ safe to modify).
+6. **[04-streaming-pipeline.md](./04-streaming-pipeline.md)** —
+   chunk-based pipeline. Bigger refactor; lands LAST so the
+   smaller wins prove out the perf model first.
+
+## Methodology
+
+For every finding:
+
+1. **Build the perf harness.** No `tests/perf/run_importer_baseline.py`
+   exists. Cheap version:
+   ```python
+   # tests/perf/run_importer_baseline.py
+   # Spin up a dev DB with N=10k / 100k / 600k comic fixtures
+   # Capture wall clock + per-phase wall clock + query count
+   # Run before + after each fix
+   ```
+   Each sub-plan includes the relevant phase's expected query
+   delta.
+
+2. **Capture cold + warm baseline** before any change. The user
+   has already optimized; trust the existing numbers as the
+   benchmark to beat.
+
+3. **Apply the fix in isolation.** One sub-plan = one PR.
+
+4. **Verify correctness via diff against pre-fix DB state.**
+   ```sql
+   -- Compare the post-import DB state byte-for-byte where possible
+   -- e.g. dump (pk, key_columns, m2m_through_rows) per Comic
+   -- and diff before/after
+   ```
+   For non-trivial perf changes (e.g. chunking the pipeline),
+   correctness verification is the gate.
+
+5. **Re-capture baseline.** Document delta in the commit message.
+
+6. **Roll forward to the next finding.**
+
+## Correctness invariants to preserve
+
+The user explicitly emphasized correctness. Things this project
+must NOT change without flagging:
+
+- **Comic.unique_together = (library, path)**: every Comic row
+  is keyed by (library, full path).
+- **FK row identity**: e.g. Publisher rows are unique on
+  `name`. Imprint on `(publisher_id, name)`. Series on
+  `(publisher_id, imprint_id, name)`. The current code relies
+  on these identities for `update_conflicts=True` UPSERTs.
+- **M2M through-row uniqueness**: e.g. `(comic_id, character_id)`
+  in the through table is unique. The link phase's
+  `bulk_create(update_conflicts=True, unique_fields=...)`
+  relies on this.
+- **Watermark for FTS sync**: a comic update bumps
+  `Comic.updated_at` so the FTS sync's watermark logic catches
+  it. Any restructure that bypasses `Comic.save()` must still
+  bump the timestamp.
+- **Deletion cascades**: `Comic` deletion cascades to bookmarks,
+  FTS rows, etc. via `on_delete=CASCADE`. Don't bypass.
+- **Failed imports record path + reason**: bulk failures must
+  still produce per-path FailedImport rows so the admin UI can
+  surface them.
+
+Each sub-plan calls out the invariants its change touches.
+
+## Risks
+
+- **Memory regression**. Several findings batch lookups into
+  Python dicts (e.g. `dict[(model, name) → pk]`). For an import
+  with millions of unique tag names, the dict might grow large.
+  Sub-plans cap dict sizes via batched lookups.
+- **Database write contention**. The importer writes; the
+  browser reads. Long transactions (under [05-sqlite-tuning.md])
+  can block readers. Each sub-plan's transaction scope is
+  documented.
+- **Subprocess pickling cost regression**. [06-comicbox-side.md]
+  proposes more transformation INSIDE the subprocess. If that
+  transformation itself is slow, the win is offset.
+- **Reordering correctness**. The current pipeline order is
+  load-bearing — `query` runs before `create_and_update` because
+  the latter consumes the former's `CREATE_FKS` / `UPDATE_FKS`
+  output. Sub-plans that touch ordering (esp.
+  [04-streaming-pipeline.md]) must preserve dependency order
+  within each chunk.
+
+## Out of scope
+
+- **Frontend import-progress UX**. Read-side concern; importer's
+  status_controller already broadcasts.
+- **Library polling logic** (`fs/poller`). Different subsystem.
+- **Comicbox's own parser internals beyond the codex-facing API**.
+  [06-comicbox-side.md] focuses on the API contract; deeper
+  parser refactors live in comicbox's own backlog.
+- **Background OPTIMIZE / VACUUM scheduling** outside import. The
+  janitor handles those.
+- **Cover generation** during import. Already parallelized by
+  PR #622.
+- **FTS sync** as the import's last phase. Covered by PR #626's
+  search-perf project (in flight).
+
+## References
+
+- `codex/librarian/scribe/importer/importer.py:5-15` — pipeline
+  ordering
+- `codex/librarian/scribe/importer/init.py` — `Counts`,
+  filesystem-wait, status init
+- `codex/librarian/scribe/importer/const.py` — metadata dict
+  keys (data flow)
+- `comicbox/process.py:100-146` — `iter_process_files`, the
+  read-phase parallelizer (already using `ProcessPoolExecutor`)
+- PR #615 (OPDS v2 batching) — reference for the per-M2M
+  batching pattern several sub-plans mirror
+- PR #626 (search-perf in flight) — same per-M2M batching
+  applied to FTS sync

--- a/tasks/importer-perf/01-link-batching.md
+++ b/tasks/importer-perf/01-link-batching.md
@@ -1,0 +1,230 @@
+# 01 — Link M2M batching
+
+The headline impact-per-LOC finding for the importer. Self-
+contained in `link/prepare.py`. Drops millions of SELECTs to
+tens.
+
+## Hot path
+
+`link/prepare.py:105-135` — `link_prepare_m2m_links`. Called
+once per import after `create_and_update`, before `link`. For
+each comic in the batch:
+
+```python
+for comic_pk, comic_path in comics:
+    md = self.metadata[LINK_M2MS][comic_path]
+
+    # Folders + 3 complex models (Credits, Identifiers, StoryArcNumbers)
+    self._link_prepare_complex_m2ms(
+        all_m2m_links, md, comic_pk, FOLDERS_FIELD_NAME,
+        self._get_link_folders_filter,
+    )
+    for field_name in COMPLEX_MODEL_FIELD_NAMES:
+        self._link_prepare_complex_m2ms(
+            all_m2m_links, md, comic_pk, field_name,
+            self._get_link_complex_model_filter,
+        )
+
+    # Named M2Ms (characters, genres, locations, tags, teams,
+    # series_groups, stories — ~7 fields)
+    for field, names in md.items():
+        self._link_prepare_named_m2ms(all_m2m_links, comic_pk, field, names)
+```
+
+`_link_prepare_named_m2ms` (line 83-103):
+
+```python
+pks = (
+    model.objects.filter(name__in=names).values_list("pk", flat=True).distinct()
+)
+```
+
+**One SELECT per (comic, M2M field).**
+
+`_link_prepare_complex_m2ms` (line 62-81):
+
+```python
+m2m_filter = link_filter_method(field_name, values)
+pks = model.objects.filter(m2m_filter).values_list("pk", flat=True).distinct()
+```
+
+**One SELECT per (comic, complex M2M field).**
+
+## Per-import cost
+
+Per comic: 4 complex + ~7 named = ~11 SELECTs minimum (more if
+the comic has all M2M fields populated).
+
+For the user's 600,000-comic target:
+**~6.6 million SELECTs in this phase alone.**
+
+Each SELECT is small (`name IN (...)`) but the round-trip
+overhead, query plan compilation, and Python-side ORM dispatch
+dominate at this scale. Wall time: estimated 10s of minutes to
+hours, depending on hardware.
+
+## Why this happens
+
+The structure assumes per-comic granularity is necessary because
+each comic has a *different* set of M2M values. But the LOOKUP
+("name → pk") is global — once we know `Character "Wolverine"`
+has pk 12345, we can use that pk for every comic that links to
+Wolverine.
+
+## Fix sketch
+
+Pre-fetch the name→pk lookup map ONCE per model, before the
+per-comic loop. Per-comic work becomes pure dict lookups.
+
+### Step 1: collect all unique names per model up front
+
+```python
+def _collect_m2m_names_per_model(
+    self, link_m2ms: dict
+) -> dict[type[BaseModel], dict[tuple, set[tuple]]]:
+    """Walk LINK_M2MS once and collect every (key_tuple) per model.
+
+    Returns ``{model: {key_tuple: set_of_complete_value_tuples}}``
+    so the next step can issue one SELECT per model.
+    """
+    per_model: dict[type[BaseModel], set[tuple]] = {}
+    for comic_path, md in link_m2ms.items():
+        for field_name, value_tuples in md.items():
+            field = Comic._meta.get_field(field_name)
+            model = field.related_model
+            per_model.setdefault(model, set()).update(value_tuples)
+    return per_model
+```
+
+### Step 2: one SELECT per model produces a name→pk dict
+
+```python
+def _build_m2m_pk_map(
+    self, per_model: dict[type[BaseModel], set[tuple]]
+) -> dict[type[BaseModel], dict[tuple, int]]:
+    """One SELECT per model. Returns ``{model: {key_tuple: pk}}``."""
+    pk_map: dict[type[BaseModel], dict[tuple, int]] = {}
+    for model, key_tuples in per_model.items():
+        rels = FIELD_NAME_KEYS_REL_MAP[model.__name__.lower()]
+        # Fall back to "name" for plain NamedModels
+        if not rels:
+            rels = ("name",)
+        # Build a Q-OR over the key tuples (batched if needed for
+        # SQLite's variable-count cap)
+        filter_q = self._build_m2m_filter_q(rels, key_tuples)
+        rows = model.objects.filter(filter_q).values_list(
+            "pk", *rels
+        )
+        pk_map[model] = {row[1:]: row[0] for row in rows}
+    return pk_map
+```
+
+### Step 3: per-comic loop becomes dict lookups
+
+```python
+def link_prepare_m2m_links(self, status):
+    link_m2ms = self.metadata.get(LINK_M2MS, {})
+    if not link_m2ms:
+        return {}
+
+    # Phase A: one pass to collect names per model
+    per_model = self._collect_m2m_names_per_model(link_m2ms)
+
+    # Phase B: batched name→pk lookup, one SELECT per model
+    pk_map = self._build_m2m_pk_map(per_model)
+
+    # Phase C: per-comic stitch — pure dict lookups, no SQL
+    all_m2m_links = {}
+    comic_paths = tuple(link_m2ms.keys())
+    comics = Comic.objects.filter(path__in=comic_paths).values_list("pk", "path")
+    for comic_pk, comic_path in comics:
+        md = link_m2ms[comic_path]
+        for field_name, value_tuples in md.items():
+            model = Comic._meta.get_field(field_name).related_model
+            field_pk_map = pk_map.get(model, {})
+            pks = tuple(
+                field_pk_map[t] for t in value_tuples if t in field_pk_map
+            )
+            if pks:
+                all_m2m_links.setdefault(field_name, {})[comic_pk] = pks
+    self.metadata.pop(LINK_M2MS, None)
+    return all_m2m_links
+```
+
+## Query count
+
+| | per import |
+| --- | --- |
+| **Before** | `4 × N + ~7 × N + 1` per comic = ~11N + 1 SELECTs (for 600k comics: ~6.6M) |
+| **After** | 1 SELECT per M2M model + 1 for the comic.pk/path map = ~12 SELECTs total |
+
+The Python work (collect-names + dict-lookup loop) does N
+iterations either way; the win is in eliminating the per-iteration
+DB round-trip.
+
+## Memory cost
+
+The `pk_map` holds `dict[(model, key_tuple) → pk]` for every
+unique M2M value across the import. For 600k comics:
+
+- Characters: probably 100k-500k unique names
+- Tags: maybe 50k-200k unique
+- Genres / locations / teams / series_groups / stories: smaller
+
+Conservatively ~1M entries, each `(model, tuple) → int`. Python
+dict overhead is ~200 bytes per entry → ~200 MB peak.
+
+Reasonable on any modern import host. But callout in the sub-plan:
+if the user's libraries push past this, batch the model lookups
+into chunks of 100k unique names.
+
+## Correctness invariants
+
+- **M2M-row identity stays the same.** The map maps existing FK
+  rows by their natural keys (name for NamedModel; complex tuple
+  for Credit / Identifier / StoryArcNumber). The batched lookup
+  produces the same `pk` for the same `(name|tuple)` as the
+  per-comic approach.
+- **Folders complex-link**: special case. Folders are looked up
+  by `path__in` (line 30-33). Same shape as named M2Ms; batches
+  cleanly via the same helper with `path` as the key field.
+- **Failure modes preserved**: if a name doesn't exist in the DB
+  (i.e. wasn't created by `create_and_update` because of an
+  earlier failure), the per-comic loop currently produces an
+  empty `pks` tuple and skips that field. The batched version
+  preserves this — `field_pk_map[t]` raises KeyError, the `if t
+  in field_pk_map` guard keeps it. The comic just doesn't link
+  to a missing FK row.
+
+## Test plan
+
+- **Unit test**: build a fixture with 100 comics × 10 unique
+  characters each. Assert pre-fix and post-fix produce
+  identical `all_m2m_links` dicts.
+- **Query count regression**: wrap `link_prepare_m2m_links` in
+  `CaptureQueriesContext`. Assert ≤ N+5 queries (where N =
+  number of distinct M2M models, ~12 today). Fail if a
+  refactor reintroduces the per-comic SELECT.
+- **Wall clock**: on a 10k-comic dev fixture, expect 5-30×
+  speedup on this phase.
+
+## Suggested commit shape
+
+One PR, one commit. The diff touches one file (`link/prepare.py`)
+plus possibly a new helper module (`link/lookups.py`) for the
+name→pk batching. ~150 LOC added, ~100 LOC removed. Net ~+50.
+
+## Risks
+
+- **Variable count cap on SQLite IN clauses.** A model with 100k
+  unique names can't go into a single `name IN (...)` query.
+  Batch into chunks of 30000 (matches `IMPORTER_LINK_FK_BATCH_SIZE`).
+- **Composite-key models** (Credit, Identifier, StoryArcNumber)
+  require multi-column lookups. Use `Q` OR-chain: `Q(
+  person_name="X", role_name="Y") | Q(person_name="A",
+  role_name="B") | …`. Cap chunk size at the OR-chain limit
+  (~900 OR-chained `Q`s before SQLite plans poorly). Fall back
+  to a SELECT-then-Python-filter for very wide combinations.
+- **None-valued tuple components** (e.g. Identifier has
+  nullable `id_url`). Batch SQL filter must handle NULL via
+  `Q(field__isnull=True)` rather than `field=None`.

--- a/tasks/importer-perf/02-create-fk-batching.md
+++ b/tasks/importer-perf/02-create-fk-batching.md
@@ -1,0 +1,220 @@
+# 02 — Create / update FK row batching
+
+Per-row FK SELECTs hidden in the create and update paths. Lower
+absolute count than [01-link-batching](./01-link-batching.md), but
+still significant for libraries with thousands of unique
+publishers / imprints / series.
+
+## Hot path
+
+`create/foreign_keys.py:46-75` — `_get_create_update_args`:
+
+```python
+@staticmethod
+def _get_create_update_args(
+    model: type[BaseModel],
+    key_args_map: Mapping,
+    update_args_map: Mapping,
+    values_tuple: tuple,
+) -> tuple[dict, dict]:
+    key_args = {}
+    update_args = {}
+    num_keys = len(key_args_map)
+    for index, (field_name, field_model) in enumerate(
+        chain(key_args_map.items(), update_args_map.items())
+    ):
+        value = values_tuple[index]
+        if field_model and value is not None:
+            ...
+            sub_model_key_args = dict(zip(key_rels, value, strict=True))
+            value = field_model.objects.get(**sub_model_key_args)  # ← N+1
+        ...
+```
+
+For every row being created, every nested FK reference fires a
+fresh `model.objects.get(...)`. Examples:
+
+- **Imprint creation** dereferences `publisher`. 1 publisher
+  SELECT per imprint.
+- **Series creation** dereferences `publisher` and `imprint`. 2
+  SELECTs per series.
+- **Volume creation** dereferences `publisher`, `imprint`,
+  `series`. 3 SELECTs per volume.
+- **Identifier creation** dereferences `source`. 1 SELECT per
+  identifier.
+
+For a fresh import with 600k comics:
+
+| Model being created | Approx unique rows | FK SELECTs each | Total |
+| ------------------- | ------------------ | --------------- | ----- |
+| Imprint | ~5,000 | 1 | 5k |
+| Series | ~30,000 | 2 | 60k |
+| Volume | ~150,000 | 3 | 450k |
+| StoryArcNumber | ~50,000 | 1 | 50k |
+| Credit | ~500,000 | 2 | 1M |
+| Identifier | ~600,000 | 1 | 600k |
+
+Conservatively **~2 million SELECTs** in this phase across a
+fresh 600k-comic import.
+
+## Same shape in the update path
+
+`create/foreign_keys.py:189` — `_bulk_update_models`:
+
+```python
+for values_tuple in update_tuples:
+    key_args, update_args = self._get_create_update_args(...)
+    obj = model.objects.get(**key_args)  # ← N+1
+    for key, value in update_args.items():
+        setattr(obj, key, value)
+```
+
+Plus the same `_get_create_update_args` runs inside, so the
+inner FK dereferences are also N+1.
+
+For repeat imports where most FKs already exist, the update
+path runs more often than create.
+
+## Why this happens
+
+`_get_create_update_args` translates flat tuples like
+`(publisher_name, imprint_name, name, ...)` into Django ORM
+`(publisher=Publisher_instance, imprint=Imprint_instance,
+name="...")`. The `field_model.objects.get(**sub_model_key_args)`
+fetches a fresh model instance because Django's `bulk_create`
+expects FK fields to be set as model instances, not bare pks.
+
+But `bulk_create` actually accepts `<field>_id=<pk_int>` directly
+— skipping the instance round-trip. The SELECT exists only to
+satisfy the ORM's typing.
+
+## Fix sketch
+
+Pre-fetch parent FKs ONCE per model, before the create/update
+loop. Pass the pk directly via `<field>_id=` in the create kwargs.
+
+```python
+def _build_parent_fk_pk_maps(
+    self, model: type[BaseModel],
+) -> dict[type[BaseModel], dict[tuple, int]]:
+    """Pre-fetch every parent FK referenced by ``model``'s create rows.
+
+    Returns ``{parent_model: {key_tuple: pk}}``. The create loop
+    looks up parent pks here instead of firing
+    ``parent_model.objects.get(...)`` per row.
+    """
+    pk_maps = {}
+    key_args_map, update_args_map = MODEL_CREATE_ARGS_MAP[model]
+    for field_name, field_model in chain(
+        key_args_map.items(), update_args_map.items()
+    ):
+        if not field_model or field_model in pk_maps:
+            continue
+        rels = MODEL_REL_MAP[field_model][0]
+        rows = field_model.objects.values_list("pk", *rels)
+        pk_maps[field_model] = {row[1:]: row[0] for row in rows}
+    return pk_maps
+
+def _get_create_update_args(
+    self,
+    model: type[BaseModel],
+    key_args_map: Mapping,
+    update_args_map: Mapping,
+    values_tuple: tuple,
+    pk_maps: dict,  # ← passed in once per model batch
+) -> tuple[dict, dict]:
+    ...
+    if field_model and value is not None:
+        ...
+        # Was: field_model.objects.get(**sub_model_key_args)
+        # Now: dict lookup, no SQL
+        pk = pk_maps[field_model].get(tuple(value))
+        # Pass pk via the ``_id`` shortcut to bypass FK descriptor
+        arg_map = key_args if index < num_keys else update_args
+        arg_map[field_name + "_id"] = pk
+        continue
+    ...
+```
+
+The `<field>_id=<pk>` form is well-supported by Django and
+`bulk_create` since ~1.4. No FK instance is ever materialized.
+
+## Query count
+
+For a fresh 600k-comic import:
+
+| | per phase |
+| --- | --- |
+| **Before** | ~2M SELECTs across all FK creates |
+| **After** | 1 SELECT per parent FK model = ~10 SELECTs total |
+
+Plus the existing bulk_create / bulk_update SQL stays the same.
+
+## Memory cost
+
+The pk_maps for parent FK lookup hold up to ~150k Volume entries
+(rare worst case, since Volumes are created mostly during this
+same phase — early-phase Imprint creation only sees the Publisher
+map, which is much smaller).
+
+Worst case ~500MB peak for an import with millions of unique
+parent rows. Worth flagging; can chunk per-model lookup if a
+threshold is hit.
+
+## Correctness invariants
+
+- **FK row identity preserved**: the pk_map keys off the same
+  `MODEL_REL_MAP[field_model][0]` tuple the per-row code uses, so
+  the same pk is selected.
+- **`presave()` still runs**: the existing loop calls
+  `obj.presave()` after the kwargs are assembled. That stays —
+  presave doesn't depend on FK instance materialization.
+- **`<field>_id` vs `<field>` semantics**: passing
+  `publisher_id=42` is equivalent to `publisher=Publisher(pk=42)`
+  for `bulk_create` purposes — same column written. No descriptor
+  difference at the DB row level.
+- **NULL FKs**: `pk_maps[field_model].get(tuple(value))` returns
+  `None` when the value is missing. Pass `field_id=None` (since
+  `null=True` on those FKs). Same shape as the previous code's
+  None-handling (line 71-72).
+
+## Risks
+
+- **`MODEL_CREATE_ARGS_MAP` and `MODEL_REL_MAP` typing.** The
+  current code relies on Django's FK-descriptor unboxing. Going
+  to `_id=int` requires the consts be aware of which fields are
+  FKs vs scalar. Verify by reading `const.py` and asserting
+  `field_name + "_id"` is a real DB column on the target model.
+- **Bulk_create with `update_conflicts=True`**: Django's
+  conflict-target update relies on `update_fields` matching real
+  column names. If `update_fields` is currently set to
+  `("publisher", ...)` (the FK descriptor name), it might need to
+  become `("publisher_id", ...)` after the change. Verify in
+  isolation.
+- **Test fixture**: build a small fixture covering each create
+  path (Publisher → Imprint → Series → Volume → Comic). Assert
+  pk_map approach produces the same DB rows as the per-row
+  approach.
+
+## Suggested commit shape
+
+One PR. Touches `create/foreign_keys.py` and possibly
+`create/const.py`. ~100 LOC change.
+
+Bundles cleanly with [01-link-batching.md](./01-link-batching.md)
+since both are pure batching refactors with no schema implications,
+but ship as separate PRs to keep blast radius small.
+
+## Test plan
+
+- **Round-trip test**: create N=1000 comics with 200 unique
+  publishers/imprints/series. Run import twice (once with the
+  old code, once with new). Assert every Comic, Publisher,
+  Imprint, Series, Volume row's `(pk, key_columns)` tuple is
+  identical.
+- **Query count regression**: assert
+  `_bulk_create_models(Volume, status)` fires no more than
+  K + 2 SELECTs (K = number of parent FK models pre-fetched
+  once).
+- **Wall clock**: on a 10k-comic dev fixture, expect 2-5×
+  speedup on the create_and_update phase.

--- a/tasks/importer-perf/03-query-prune.md
+++ b/tasks/importer-perf/03-query-prune.md
@@ -1,0 +1,350 @@
+# 03 — Query / moved phase batching
+
+Two adjacent issues in the **query** and **moved** phases. The
+moved-comics N+1 is the surgical win; the prune-phase memory
+profile is a softer concern that becomes a real problem only at
+the 600k-comic ceiling.
+
+## Hot path A: per-moved-comic Folder SELECTs
+
+`moved/comics.py:60-68` — `_prepare_moved_comic`:
+
+```python
+def _prepare_moved_comic(
+    self, comic, folder_m2m_links, updated_comics, del_folder_rows
+) -> None:
+    try:
+        new_path = self.task.files_moved[comic.path]
+        old_folder_pks = frozenset(folder.pk for folder in comic.folders.all())
+        comic.path = new_path
+        new_path = Path(new_path)
+        comic.parent_folder = Folder.objects.get(path=new_path.parent)  # ← N+1
+        comic.updated_at = Now()
+        comic.presave()
+        new_folder_pks = frozenset(
+            Folder.objects.filter(path__in=new_path.parents).values_list(  # ← N+1
+                "pk", flat=True
+            )
+        )
+        ...
+```
+
+For every moved comic:
+
+- 1 `Folder.objects.get(path=new_path.parent)` — fetch the new
+  parent folder pk.
+- 1 `Folder.objects.filter(path__in=new_path.parents)` — fetch
+  every ancestor folder pk for the M2M `folders` rebuild.
+
+For a library reorg moving 600k comics: **~1.2M SELECTs** in this
+phase alone. Folders are typically a small set
+(~10k–50k rows for a deep library), so every one of those SELECTs
+touches a single small table that fits in cache, but the round-trip
+overhead dominates.
+
+## Fix sketch A: pre-fetch the Folder pk-by-path map
+
+`_bulk_comics_moved_ensure_folders` (called at line 109,
+immediately before `_bulk_comics_move_prepare`) already guarantees
+every needed Folder row exists. So at the point we enter the prepare
+loop, every parent and ancestor folder is in the DB.
+
+Build the path → pk map once:
+
+```python
+def _bulk_comics_move_prepare(self) -> tuple[list, dict, dict]:
+    """Prepare Update Comics."""
+    # All parent/ancestor folders for moved paths exist by now —
+    # ``_bulk_comics_moved_ensure_folders`` ran first. Pre-fetch
+    # the pk-by-path map once so the per-comic loop is dict lookups.
+    folder_pk_by_path = dict(
+        Folder.objects.filter(library=self.library).values_list("path", "pk")
+    )
+
+    comics = (
+        Comic.objects.prefetch_related(FOLDERS_FIELD_NAME)
+        .filter(library=self.library, path__in=self.task.files_moved.keys())
+        .only(PATH_FIELD_NAME, PARENT_FOLDER_FIELD_NAME, FOLDERS_FIELD_NAME)
+    )
+
+    folder_m2m_links = {}
+    updated_comics = []
+    del_folder_rows = []
+    for comic in comics:
+        self._prepare_moved_comic(
+            comic, folder_pk_by_path,
+            folder_m2m_links, updated_comics, del_folder_rows,
+        )
+    ...
+```
+
+Refactor `_prepare_moved_comic` to dict-lookup:
+
+```python
+def _prepare_moved_comic(
+    self, comic, folder_pk_by_path,
+    folder_m2m_links, updated_comics, del_folder_rows,
+) -> None:
+    try:
+        new_path_str = self.task.files_moved[comic.path]
+        old_folder_pks = frozenset(folder.pk for folder in comic.folders.all())
+        comic.path = new_path_str
+        new_path = Path(new_path_str)
+        # Was: Folder.objects.get(path=new_path.parent)
+        comic.parent_folder_id = folder_pk_by_path[str(new_path.parent)]
+        comic.updated_at = Now()
+        comic.presave()
+        # Was: Folder.objects.filter(path__in=new_path.parents).values_list(...)
+        new_folder_pks = frozenset(
+            pk for parent in new_path.parents
+            if (pk := folder_pk_by_path.get(str(parent))) is not None
+        )
+        folder_m2m_links[comic.pk] = new_folder_pks
+        updated_comics.append(comic)
+        if del_folder_pks := old_folder_pks - new_folder_pks:
+            for pk in del_folder_pks:
+                del_folder_rows.append((comic.pk, pk))
+    except Exception:
+        self.log.exception(f"moving {comic.path}")
+```
+
+**Memory cost**: a Folder pk-by-path map with 50k rows × ~120
+bytes/entry = ~6MB. Negligible.
+
+**Query count**:
+
+| | per phase |
+| --- | --- |
+| **Before** | 2 SELECTs × 600k moves = ~1.2M |
+| **After** | 1 SELECT (folder_pk_by_path) + 1 (Comic prefetch) = 2 |
+
+## Hot path B: prune-phase memory pressure
+
+`query/links_m2m.py:85-92` — `_query_prune_comic_m2m_links_batch`:
+
+```python
+comics = (
+    Comic.objects.filter(library=self.library, path__in=paths)
+    .prefetch_related(*COMIC_M2M_FIELD_NAMES)
+    .only(*COMIC_M2M_FIELD_NAMES)
+)
+for comic in comics.iterator(chunk_size=IMPORTER_LINK_M2M_BATCH_SIZE):
+    self._query_prune_comic_m2m_links_comic(comic, status)
+```
+
+`COMIC_M2M_FIELD_NAMES` resolves to **all 14 M2Ms on Comic**:
+`characters`, `credits`, `genres`, `identifiers`, `locations`,
+`series_groups`, `stories`, `story_arc_numbers`, `tags`, `teams`,
+`universes`, `folders`, `sources`, `tagger`. The
+`prefetch_related` fires 14 IN-queries pulling every through-row
+for every comic in the batch — even M2Ms the import doesn't
+touch.
+
+For an import where most comics only set `credits` and `tags`,
+this loads ~12 M2Ms worth of through-rows that get walked,
+compared to nothing, and discarded.
+
+Per-comic over a 600k import: at ~5 through-rows per M2M average
+× 14 M2Ms = ~70 row-objects materialized per comic. **42M
+through-row instances** loaded across the prune phase. Each
+through-row carries a fk to the named model that
+`_m2m_obj_to_key_tuple` then dereferences (using the prefetch
+cache, so no extra SQL — but the in-memory object graph is
+sizable).
+
+This isn't a SQL count problem; it's a Python heap problem.
+
+### Fix sketch B: narrow the prefetch to fields actually proposed
+
+The set of M2M field_names actually present in `LINK_M2MS` is
+known at the start of the prune phase. Pull that set up-front and
+use it as the prefetch list:
+
+```python
+def query_prune_comic_m2m_links(self, status) -> None:
+    status.subtitle = "Many to Many"
+    self.status_controller.update(status)
+
+    # Determine the M2M fields actually referenced this import.
+    # Most imports touch credits/tags/characters but skip e.g.
+    # universes/sources entirely.
+    referenced_field_names: set[str] = set()
+    for path_link in self.metadata[LINK_M2MS].values():
+        referenced_field_names.update(path_link.keys())
+    if not referenced_field_names:
+        return
+    prefetch_fields = tuple(
+        name for name in COMIC_M2M_FIELD_NAMES if name in referenced_field_names
+    )
+
+    paths = tuple(self.metadata[LINK_M2MS].keys())
+    for start in range(0, len(paths), IMPORTER_LINK_FK_BATCH_SIZE):
+        if self.abort_event.is_set():
+            return
+        batch_paths = paths[start : start + IMPORTER_LINK_FK_BATCH_SIZE]
+        self._query_prune_comic_m2m_links_batch(
+            batch_paths, prefetch_fields, status
+        )
+    ...
+
+def _query_prune_comic_m2m_links_batch(
+    self, paths: tuple[str, ...], prefetch_fields: tuple[str, ...], status
+) -> None:
+    comics = (
+        Comic.objects.filter(library=self.library, path__in=paths)
+        .prefetch_related(*prefetch_fields)
+        .only(*prefetch_fields)
+    )
+    for comic in comics.iterator(chunk_size=IMPORTER_LINK_M2M_BATCH_SIZE):
+        self._query_prune_comic_m2m_links_comic(comic, status)
+```
+
+For the typical import (credits + tags + a few groups), this drops
+from 14 prefetch IN-queries to 3-5. Memory drops proportionally.
+
+The same trick works for `query/links_fk.py:85-89`:
+
+```python
+comics = (
+    Comic.objects.filter(library=self.library, path__in=batch_paths)
+    .select_related(*COMIC_FK_FIELD_NAMES)
+    .only(*_QUERY_LINK_FK_PRUNE_ONLY)
+)
+```
+
+`select_related(*COMIC_FK_FIELD_NAMES)` joins **every** FK on
+Comic. For prune purposes, only fields present in
+`LINK_FKS[path]` need joining. Compute the union of needed FKs
+once per import and narrow the join:
+
+```python
+referenced_fks: set[str] = set()
+for path_link in self.metadata[LINK_FKS].values():
+    referenced_fks.update(path_link.keys())
+select_fields = tuple(
+    name for name in COMIC_FK_FIELD_NAMES if name in referenced_fks
+)
+```
+
+For an import that only touches `volume` + `parent_folder`, this
+drops from a 12-table JOIN to a 3-table JOIN. SQLite's planner
+handles wide joins, but each row still pays the column-decode
+cost in the cursor.
+
+## Hot path C: status update call overhead in the prune loops
+
+`query/links_m2m.py:71-72`:
+
+```python
+for m2m_obj in m2m_objs:
+    deleted |= self._query_prune_comic_m2m_links_field_obj(...)
+    status.increment_complete()
+    self.status_controller.update(status)  # ← per through-row
+```
+
+`status_controller.update()` is rate-limited internally
+(`_UPDATE_DELTA = 5s`), so it's mostly a cheap `monotonic()` call
++ early return. But for 42M iterations, even the 50ns guard adds
+up to ~2 seconds wasted.
+
+Same shape at `query/links_fk.py:77-78`:
+
+```python
+for field_name in field_names:
+    self._query_prune_comic_fk_links_field(comic, path, field_name)
+    status.increment_complete()
+    self.status_controller.update(status)  # ← per FK field
+```
+
+### Fix sketch C: hoist the update out of the inner loop
+
+```python
+# Inside _query_prune_comic_m2m_links_field
+for m2m_obj in m2m_objs:
+    deleted |= self._query_prune_comic_m2m_links_field_obj(...)
+    status.increment_complete()
+# Call update once per field, not per m2m_obj.
+self.status_controller.update(status)
+```
+
+The progress bar's resolution drops from per-row to per-field, but
+the status itself only refreshes every 5s anyway, so user-visible
+behavior is unchanged.
+
+## Correctness invariants
+
+- **Folder lookup keys**: `_bulk_comics_moved_ensure_folders` runs
+  first and populates `Folder` rows for every parent of a moved
+  path. The pk-by-path map is therefore complete by the time the
+  prepare loop runs. `Path(...).parents` yields the same string
+  values used as `Folder.path`, so the dict lookup is exact.
+- **Library scope**: the existing
+  `Folder.objects.get(path=new_path.parent)` does **not** filter
+  by library — folders are unique by path globally. The fix
+  preserves this if we drop `library=self.library` from the pk-map
+  query, OR tightens it (Folder rows are library-scoped in the
+  schema; verify in `models/groups.py`). **Verify before
+  shipping.**
+- **Narrowed prefetch**: dropping unused M2Ms from the prefetch
+  list is safe because the prune loop only walks `field_names =
+  tuple(self.metadata[LINK_M2MS][comic.path].keys())` — never the
+  full COMIC_M2M_FIELD_NAMES.
+- **Status counter**: hoisting the `update()` out of the inner
+  loop preserves `increment_complete()` per row, so the eventual
+  `complete` value is identical. Only the refresh cadence changes.
+
+## Risks
+
+- **Folder library scoping**: confirm whether
+  `Folder.objects.filter(library=self.library)` is correct or
+  whether the model is library-global. The current `get(path=...)`
+  is not library-scoped, which could be a latent bug. Resolve
+  before flipping to the dict lookup.
+- **`only(...)` interaction**: `prefetch_related` ignores `only`
+  on the prefetched relation; only the parent's columns are
+  narrowed. Already the case in current code.
+- **Empty `LINK_M2MS`**: if `referenced_field_names` is empty,
+  `prefetch_fields = ()` is passed. Django's `prefetch_related()`
+  with no args is a noop. Safe.
+- **`COMIC_M2M_FIELDS` vs prefetch ordering**: the existing code
+  passes the constant list as positional args to `prefetch_related`.
+  Order doesn't matter to Django, but tests pinning queryset SQL
+  may break — verify by reading `tests/librarian/scribe/`.
+
+## Suggested commit shape
+
+Three small commits, one PR — each independently revertable:
+
+1. `moved: pre-fetch Folder pk map for moved comic prepare`
+   (~30 LOC, biggest measurable win)
+2. `query: narrow select_related/prefetch_related to referenced fields`
+   (~40 LOC, memory-only win)
+3. `query: hoist status update out of M2M-row inner loop`
+   (~15 LOC, microoptimization)
+
+Total ~85 LOC. Touches `moved/comics.py`, `query/links_fk.py`,
+`query/links_m2m.py`. No schema implications.
+
+## Query count
+
+| Hot path | Before | After |
+| --- | --- | --- |
+| Moved (600k moves) | ~1.2M SELECTs | 2 SELECTs |
+| Prune M2M (600k comics) | 14 IN-queries × N batches | 3-5 IN-queries × N batches |
+| Prune FK (600k comics) | 12-table JOIN × N batches | 3-table JOIN × N batches |
+
+## Test plan
+
+- **Move round-trip**: fixture with 1000 comics moved across 50
+  folders. Assert resulting `parent_folder_id` and `folders` M2M
+  rows are bit-identical between old and new code.
+- **Folder-pk-map cache freshness**: regression test that exercises
+  `_bulk_comics_moved_ensure_folders` creating a brand-new folder
+  mid-move. Confirm that folder appears in the pk map (the map
+  is built **after** ensure_folders, so this should hold).
+- **Narrowed prefetch correctness**: unit test that runs the
+  prune phase with `LINK_M2MS` containing only `credits` and
+  `tags`. Assert the resulting `DELETE_M2MS` and `LINK_M2MS`
+  contents match the wide-prefetch baseline.
+- **Wall clock**: on a 10k-comic dev fixture with 50% rename
+  rate, expect the moved phase to drop from O(seconds) to O(ms).

--- a/tasks/importer-perf/04-streaming-pipeline.md
+++ b/tasks/importer-perf/04-streaming-pipeline.md
@@ -1,0 +1,358 @@
+# 04 — Streaming pipeline architecture
+
+The biggest refactor in this plan — and the one to ship **last**,
+after sub-plans 01–03 + 05–06 prove out the surgical wins. This
+sub-plan addresses memory rather than CPU, which only matters at
+the 600k ceiling and on memory-constrained hosts (Raspberry Pi,
+small VPS).
+
+## The problem: peak memory grows linearly with library size
+
+The current pipeline is **all-at-once**: every phase reads the
+full `self.metadata` dict populated by prior phases and writes
+new keys for the next phase. Memory is held until the very last
+phase (`full_text_search`) clears it.
+
+Tracked keys (`grep "self.metadata\[" codex/librarian/scribe/importer/`):
+
+| Key | Holds | Approx size for 600k import |
+| --- | --- | --- |
+| `EXTRACTED` | path → comicbox_md_dict | ~3 GB (filtered) |
+| `CREATE_COMICS` | list[Comic instance] | ~1.5 GB |
+| `UPDATE_COMICS` | list[Comic instance] | ~1.5 GB on repeat imports |
+| `LINK_FKS` | path → {field → key_tuple} | ~500 MB |
+| `LINK_M2MS` | path → {field → set[key_tuple]} | ~1 GB |
+| `CREATE_FKS` / `UPDATE_FKS` | model → set[key_tuple] | ~200 MB |
+| `QUERY_MODELS` | model → set[key_tuple] | ~200 MB |
+| `FTS_CREATE` / `FTS_UPDATE` | path → fts payload | ~500 MB |
+| `CREATE_COVERS` / `UPDATE_COVERS` | cover task payload | ~200 MB |
+| `FIS` / `CREATE_FIS` / `UPDATE_FIS` | failed-import rows | ~50 MB |
+
+**Peak working set: ~8-10 GB** for a fresh 600k-comic import. On
+a Raspberry Pi 4 (4 GB RAM) this OOM-kills the process. On a
+Raspberry Pi 5 (8 GB) it swaps. On real servers it's fine but
+wasteful.
+
+## The opportunity: the pipeline is naturally chunkable
+
+Comics don't reference each other. A batch of comics can flow
+through the full extract → query → create → link cycle
+independently of the rest of the library. **Reference data**
+(Publisher, Imprint, Series, Volume, named tag rows) does need
+global awareness: "Marvel" must not be inserted twice.
+
+That gives the natural split:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. PHASE-1: REFERENCE DATA (all-at-once, small in size)     │
+│    extract(all paths) → aggregate FK/M2M names              │
+│    query missing reference data                             │
+│    create FK rows (Publisher, Imprint, ..., named tags)     │
+│    →  output: pk maps for every reference model             │
+└─────────────────────────────────────────────────────────────┘
+                             ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 2. PHASE-2: COMIC INGESTION (streaming, chunk size N)       │
+│    for chunk in chunks(paths, N):                           │
+│        extract(chunk) → comic field values + link keys      │
+│        prune existing links                                 │
+│        create / update comics                               │
+│        link M2Ms                                            │
+│        emit fts payload                                     │
+│        clear chunk-local state                              │
+└─────────────────────────────────────────────────────────────┘
+                             ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 3. PHASE-3: FINALIZE                                        │
+│    fail_imports                                             │
+│    delete                                                   │
+│    full_text_search (sync watermark)                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Memory in phase 2 is bounded by the chunk size, not the library
+size. Reference data in phase 1 is O(unique entries), which is
+small even at the 600k ceiling.
+
+## Phase-1 sizing
+
+For a fresh 600k-comic library:
+
+| Reference model | Approx unique rows | Memory |
+| --- | --- | --- |
+| Publisher | ~500 | < 1 MB |
+| Imprint | ~5k | < 5 MB |
+| Series | ~30k | ~30 MB |
+| Volume | ~150k | ~150 MB |
+| Folder | ~50k | ~50 MB |
+| Character / Genre / Location / Story / Team / Tag | ~10-100k each | ~100 MB total |
+| Credit / Identifier / StoryArcNumber | ~500k–1M | ~500 MB |
+
+**Total phase-1 footprint: ~800 MB** — fits comfortably even on a
+2 GB Pi.
+
+The phase-1 extract pass needs only the **link-key fields** from
+each comic (`publisher`, `imprint`, `series`, `volume`,
+`credits[].person`, `credits[].role`, `tags`, `genres`, etc.) —
+not the full metadata. Two ways to get there:
+
+A. Use `comicbox.to_dict(keys=...)` from sub-plan 06 to extract
+   only the link-key fields in phase 1, then re-extract full
+   metadata in phase 2 chunks.
+
+B. Extract everything in phase 1 but stream the metadata to a
+   spill file (per-comic JSONL) keyed by path. Phase 2 chunks
+   read from disk.
+
+Option A doubles archive opens (twice per comic). Option B writes
+~3 GB to /tmp once, reads it back streaming. **Option B is
+better** for any library where archives live on slower storage
+than /tmp; archives are typically on a media disk while /tmp is
+on the OS SSD.
+
+A third option:
+
+C. Single-pass extract that **publishes** to two places: link-key
+   summaries to phase-1's in-memory aggregator, and full metadata
+   to a chunk queue consumed by phase-2 in parallel.
+
+Option C is the streaming-pipeline ideal but requires phases 1
+and 2 to overlap, which is incompatible with the current
+"phase 1 must finish before phase 2 starts" requirement (the FK
+creates need to be done before any comic can be created with
+those FKs).
+
+**Recommendation: option B**. Single-pass extract → JSONL spill
+file → phase 1 aggregates from spill → phase 2 streams chunks
+from spill. Disk I/O is fast (sequential, OS-page-cached) and
+memory is bounded.
+
+## Phase-2 chunking
+
+A chunk processes ~5k–10k comics:
+
+```python
+CHUNK_SIZE = 5000
+
+for chunk_paths in batched(all_paths, CHUNK_SIZE):
+    chunk_md = read_chunk_from_spill(chunk_paths)
+
+    chunk_link_fks, chunk_link_m2ms = aggregate_chunk_links(chunk_md)
+
+    # Prune existing links — same code as today, but per-chunk:
+    self.metadata[LINK_FKS] = chunk_link_fks
+    self.metadata[LINK_M2MS] = chunk_link_m2ms
+    self.query_prune_comic_fk_links(status)
+    self.query_prune_comic_m2m_links(status)
+
+    # Create comics — same code, per-chunk:
+    self.metadata[CREATE_COMICS] = build_create_list(chunk_md)
+    self.metadata[UPDATE_COMICS] = build_update_list(chunk_md)
+    self.create_and_update_comics(status)
+
+    # Link M2Ms — same code, per-chunk:
+    self.link_prepare(status)
+    self.link_many_to_many(status)
+
+    # Emit fts payload to a chunk-fts list (consumed in phase 3):
+    self.fts_emit_chunk(status)
+
+    # Clear all chunk-local state.
+    for key in (LINK_FKS, LINK_M2MS, CREATE_COMICS, UPDATE_COMICS,
+                CREATE_FKS, UPDATE_FKS, FTS_CREATE, FTS_UPDATE):
+        self.metadata.pop(key, None)
+```
+
+**Per-chunk memory**:
+
+| State | 5k chunk | 10k chunk |
+| --- | --- | --- |
+| Comic instances | ~12 MB | ~25 MB |
+| LINK_FKS | ~4 MB | ~8 MB |
+| LINK_M2MS | ~8 MB | ~16 MB |
+| FTS payloads | ~4 MB | ~8 MB |
+| **Total** | **~30 MB** | **~60 MB** |
+
+Plus ~800 MB for phase-1 pk_maps held throughout phase 2. Total
+peak: under 1 GB regardless of library size.
+
+## Failure recovery: the underrated win
+
+A 600k-comic import that takes 30+ minutes will get interrupted
+sometimes — power blip, OOM, user ctrl-c, daemon restart. The
+current pipeline either:
+
+- Finishes (success), or
+- Aborts mid-phase, leaving the metadata dict and any committed
+  rows in a half-state that the next run starts over from
+  scratch.
+
+A streaming pipeline gives **per-chunk checkpointing**:
+
+```python
+# After each chunk finishes successfully, persist the watermark.
+LibraryImportProgress.objects.update_or_create(
+    library=self.library,
+    defaults={"completed_chunk_index": chunk_idx},
+)
+```
+
+On resume, skip chunks ≤ watermark. Each chunk's writes are
+already wrapped in `transaction.atomic` (sub-plan 05) so the
+chunk is all-or-nothing. The watermark is the natural restart
+point.
+
+Worth a one-line note: this isn't free. It requires:
+
+1. A new `LibraryImportProgress` model (or repurpose the existing
+   `Library.last_poll`).
+2. The chunk index → path map to be deterministic across runs
+   (sort `all_paths` lexically before chunking).
+3. A "resume" code path that skips reference-data creation for
+   parents already created in a prior partial run.
+
+Item 3 is the gotcha — phase 1 must be idempotent against
+already-created reference rows. The existing
+`bulk_create(update_conflicts=True)` flow handles this, but it
+still **runs** the full create path. Could be optimized to skip
+phase 1 entirely on resume by reading the existing reference rows
+into pk_maps directly. Out of scope for the initial cut.
+
+## Risks
+
+### Risk: cross-chunk reference data mutation
+
+If chunk 47 introduces a new Publisher "Indie Press LLC", that
+Publisher must be queryable by chunk 48. Two cases:
+
+- **Phase-1-only reference creation**: phase 1 sees every comic's
+  link keys (via the spill-file aggregate), so every Publisher,
+  Imprint, etc. is created before phase 2 starts. Chunk 48 finds
+  "Indie Press LLC" in the pk_map. ✓
+- **Late-discovered references**: chunk 47 has a credit role
+  "Cover Pencils" that wasn't aggregated in phase 1 (because
+  phase 1's extract was lossy and missed it). Chunk 48's
+  CreditRole pk_map is missing it.
+
+**Mitigation**: phase-1 aggregate must be exhaustive. Use the
+same field-projection set in phase 1's extract as in phase 2's.
+Don't trade off completeness for phase-1 speed.
+
+### Risk: spill-file disk usage
+
+For 600k comics, the JSONL spill file is ~3-5 GB. On a system
+where /tmp is small (Pi: tmpfs default 50% of RAM, so ~500 MB on
+1 GB host), this overflows.
+
+**Mitigation**: spill to `CONFIG_PATH / "import_cache.jsonl"`
+(persistent storage), and explicitly compress (zstd or gzip).
+Compressed JSONL is 4-10× smaller than raw — a 5 GB spill drops
+to 500 MB-1 GB. Decompression is cheap and chunk-streamable.
+
+### Risk: `_get_create_update_args` with split phases
+
+This function (sub-plan 02) builds Comic kwargs from a flat
+values_tuple by dereferencing FK pks. Per-chunk, the pk_maps
+must include every FK referenced by **this chunk**. Since pk_maps
+are global (built in phase 1), this is automatic — no special
+handling needed. But verify: the current code expects pk_maps for
+every FK to be populated; chunked phase 2 must inherit the full
+phase-1 pk_maps.
+
+### Risk: status reporting
+
+The current `LibrarianStatus` model expects
+`(complete, total)` updates. With chunking, "total" is known
+ahead of time (total comics) but "complete" advances per chunk.
+The progress bar UI handles this fine. The librarian's per-phase
+status messages (`"Aggregating", "Creating Many-to-One", ...`)
+need to be re-thought — every phase fires per-chunk, generating a
+flicker of identical messages.
+
+**Mitigation**: rate-limit per-chunk status messages. The
+existing `_UPDATE_DELTA = 5s` rate-limit in `status_controller`
+already handles this for individual updates; the message-text
+side just needs `start()` calls deduplicated.
+
+### Risk: test surface
+
+The current importer is integration-tested per phase. Chunked
+flow blends phases. Tests need to:
+
+1. Cover the chunk boundary (a comic at chunk N's end and chunk
+   N+1's start, where the boundary splits a series).
+2. Cover the resume path (kill mid-chunk, restart, verify
+   exactly-once semantics).
+3. Cover the skip-known-reference path on resume.
+
+Plan to add a parameterized `chunk_size=1` mode for tests, which
+exercises the chunk machinery on every comic.
+
+## Suggested commit shape
+
+This is a multi-PR project, not a single PR. Suggested sequence:
+
+1. **PR-A: spill file infrastructure** — add the JSONL spill
+   writer + reader + chunk iterator. No behavior change. Spill is
+   produced but the importer still operates all-at-once. Adds
+   ~300 LOC.
+
+2. **PR-B: phase-1 / phase-2 split** — flip the importer to
+   read from spill in two passes. Memory drops but no chunking
+   yet. ~500 LOC; large but mostly mechanical.
+
+3. **PR-C: chunked phase 2** — actually chunk the comic
+   ingestion. Builds on PR-B. ~300 LOC.
+
+4. **PR-D: resume-from-watermark** — new model + skip logic. ~200
+   LOC.
+
+5. **PR-E: spill compression** — wrap the JSONL with zstd.
+   ~50 LOC.
+
+Ship A → B → C with multi-week soak in between. D and E are
+optional follow-ups.
+
+## Why this ships LAST
+
+Three reasons:
+
+1. **The surgical wins (sub-plans 01-03 + 05-06) are independent
+   and compose**. Each shaves a real chunk of wall-clock without
+   touching pipeline shape. They build a body of evidence for
+   "the importer can be much faster" before we propose the big
+   refactor.
+
+2. **Memory pressure is the secondary motivator** for most users.
+   Most codex installs run on > 4 GB hosts where the current
+   ~10 GB peak is uncomfortable but not fatal. The CPU wins from
+   01-03 ship value to everyone; the streaming-pipeline ships
+   value to a smaller (but real) audience of resource-constrained
+   users.
+
+3. **Risk profile**. A streaming pipeline rewrites the importer's
+   data flow. A bug in chunking that causes a Publisher to be
+   missed on chunk N would be hard to spot in testing and
+   catastrophic in production. Preceding wins are smaller blast
+   radius — if they regress, we can revert quickly.
+
+## Test plan
+
+- **Round-trip equivalence**: run the same fixture import
+  through the all-at-once and chunked code paths. Assert every
+  Comic, FK, M2M row in the resulting DB is bit-identical.
+- **Memory ceiling**: run a 100k-comic import under
+  `tracemalloc`; assert peak RSS < 1.5 GB.
+- **Chunk boundary**: fixture with 11 comics, chunk size 5.
+  Comics 4-7 share a Series. Verify Series row is created in
+  phase 1, used by both chunks 0 (comics 0-4) and 1 (comics 5-9).
+- **Resume**: SIGTERM the importer mid-chunk-3 of a 5-chunk run.
+  Restart. Assert chunks 0-2 are skipped, chunk 3 is re-run from
+  scratch (atomic rollback), chunks 3-4 complete normally.
+- **Compressed spill**: 1k-comic import with zstd. Assert spill
+  file size is < 30% of uncompressed equivalent.
+- **Wall clock**: 100k-comic dev fixture. Expect chunked
+  pipeline within 10% of all-at-once wall clock (memory drops
+  shouldn't cost time). If significantly slower, investigate
+  before merging.

--- a/tasks/importer-perf/04-streaming-pipeline.md
+++ b/tasks/importer-perf/04-streaming-pipeline.md
@@ -106,10 +106,25 @@ B. Extract everything in phase 1 but stream the metadata to a
    read from disk.
 
 Option A doubles archive opens (twice per comic). Option B writes
-~3 GB to /tmp once, reads it back streaming. **Option B is
+~3 GB to disk once, reads it back streaming. **Option B is
 better** for any library where archives live on slower storage
-than /tmp; archives are typically on a media disk while /tmp is
-on the OS SSD.
+than the codex cache directory; archives are typically on a media
+disk while the cache (`ROOT_CACHE_PATH`,
+`settings/__init__.py:523` = `CONFIG_PATH / "cache"`) lives
+alongside the codex DB on faster storage.
+
+Spill location: **`ROOT_CACHE_PATH / "import_cache.jsonl"`**.
+Reasons:
+
+- Persistent across reboots (unlike `/tmp` on tmpfs systems where
+  a 5 GB spill would OOM the tmpfs ramdisk).
+- Same volume as the codex DB, so atomicity / cleanup is
+  consistent with other codex state.
+- Already a directory codex creates and manages
+  (`DEFAULT_CACHE_PATH.mkdir(...)`), so no new mount-point
+  decisions for the user.
+- Survives a daemon restart, which the resume-from-watermark
+  scheme below depends on.
 
 A third option:
 
@@ -130,12 +145,63 @@ memory is bounded.
 
 ## Phase-2 chunking
 
-A chunk processes ~5k–10k comics:
+### Chunk size: dynamic, sized to available memory
+
+Hardcoding `CHUNK_SIZE = 5000` is wrong. A 32 GB server can
+afford 50k-comic chunks; a 1 GB Pi can't even hold 5k. Codex
+already has the right tool — `codex/librarian/memory.py`'s
+`get_mem_limit()` reads cgroups2/cgroups1 limits (Docker, Pi
+under systemd) before falling back to `psutil.virtual_memory()`.
+Use it:
 
 ```python
-CHUNK_SIZE = 5000
+# codex/librarian/scribe/importer/init.py (sketch)
+from codex.librarian.memory import get_mem_limit
 
-for chunk_paths in batched(all_paths, CHUNK_SIZE):
+# Empirically, each comic in flight through phase 2 carries
+# ~6-12 KB of working set (Comic instance + LINK_FKS dict +
+# LINK_M2MS sets + FTS payload). Round up to 16 KB for safety.
+_PER_COMIC_BYTES = 16 * 1024
+# Hold phase 2 to at most a quarter of the process memory budget,
+# leaving room for phase-1 pk_maps (~800 MB worst case) +
+# SQLite cache (~512 MB) + overhead.
+_PHASE_2_MEM_FRACTION = 0.25
+_CHUNK_FLOOR = 1000
+_CHUNK_CEILING = 50000
+
+def _compute_chunk_size(self) -> int:
+    """Size phase-2 chunks to fit available memory."""
+    mem_budget = get_mem_limit("b") * _PHASE_2_MEM_FRACTION
+    raw = int(mem_budget // _PER_COMIC_BYTES)
+    return max(_CHUNK_FLOOR, min(_CHUNK_CEILING, raw))
+```
+
+Indicative numbers:
+
+| Host | mem_limit | chunk_size |
+| --- | --- | --- |
+| Pi 4 (4 GB) | 4 GB → 1 GB phase-2 budget | ~50k → capped to 50k |
+| Pi 4 cgroup-limited (2 GB) | 2 GB → 512 MB | ~32k |
+| Pi 3 (1 GB) | 1 GB → 256 MB | ~16k |
+| Pi 0 W 2 (512 MB cgroup) | 512 MB → 128 MB | ~8k |
+| Tiny container (256 MB) | 256 MB → 64 MB | ~4k |
+| Smallest viable (64 MB cgroup) | 64 MB → 16 MB | floor ~1000 |
+
+The floor of 1000 protects against pathological tiny chunks where
+the per-batch SQL overhead would dominate. The ceiling of 50k
+protects against integer overflow / unbounded peak memory on
+absurdly large hosts.
+
+Expose the multiplier as a config knob for advanced users:
+
+```python
+IMPORTER_PHASE_2_MEM_FRACTION = get_float(
+    CODEX_CONFIG, "importer.phase_2_mem_fraction", default=0.25
+)
+```
+
+```python
+for chunk_paths in batched(all_paths, self._compute_chunk_size()):
     chunk_md = read_chunk_from_spill(chunk_paths)
 
     chunk_link_fks, chunk_link_m2ms = aggregate_chunk_links(chunk_md)
@@ -164,18 +230,22 @@ for chunk_paths in batched(all_paths, CHUNK_SIZE):
         self.metadata.pop(key, None)
 ```
 
-**Per-chunk memory**:
+**Per-chunk memory** (illustrative; the dynamic sizer above
+chooses the actual chunk):
 
-| State | 5k chunk | 10k chunk |
-| --- | --- | --- |
-| Comic instances | ~12 MB | ~25 MB |
-| LINK_FKS | ~4 MB | ~8 MB |
-| LINK_M2MS | ~8 MB | ~16 MB |
-| FTS payloads | ~4 MB | ~8 MB |
-| **Total** | **~30 MB** | **~60 MB** |
+| State | 5k chunk | 10k chunk | 32k chunk |
+| --- | --- | --- | --- |
+| Comic instances | ~12 MB | ~25 MB | ~80 MB |
+| LINK_FKS | ~4 MB | ~8 MB | ~25 MB |
+| LINK_M2MS | ~8 MB | ~16 MB | ~50 MB |
+| FTS payloads | ~4 MB | ~8 MB | ~25 MB |
+| Working overhead (Python objects, Django ORM cache) | ~2 MB | ~3 MB | ~10 MB |
+| **Total** | **~30 MB** | **~60 MB** | **~190 MB** |
 
-Plus ~800 MB for phase-1 pk_maps held throughout phase 2. Total
-peak: under 1 GB regardless of library size.
+Plus phase-1 pk_maps held throughout phase 2 — sized by library
+content, typically ~200 MB to ~800 MB. The dynamic chunk sizer
+above is calibrated against this overhead so total peak stays
+within `mem_limit × _PHASE_2_MEM_FRACTION + ~1 GB` headroom.
 
 ## Failure recovery: the underrated win
 
@@ -241,14 +311,23 @@ Don't trade off completeness for phase-1 speed.
 
 ### Risk: spill-file disk usage
 
-For 600k comics, the JSONL spill file is ~3-5 GB. On a system
-where /tmp is small (Pi: tmpfs default 50% of RAM, so ~500 MB on
-1 GB host), this overflows.
+For 600k comics, the JSONL spill file is ~3-5 GB. The
+`ROOT_CACHE_PATH` location (decided above, on the config volume
+alongside the codex DB) is the right place — but on small-disk
+hosts it can still bite. Worst case is a Pi with a 32 GB SD card
+that's already 80% full with comic covers, FTS index, and DB
+backups; a 5 GB spill on top fills the disk.
 
-**Mitigation**: spill to `CONFIG_PATH / "import_cache.jsonl"`
-(persistent storage), and explicitly compress (zstd or gzip).
-Compressed JSONL is 4-10× smaller than raw — a 5 GB spill drops
-to 500 MB-1 GB. Decompression is cheap and chunk-streamable.
+**Mitigation**: compress the spill file with zstd (or gzip if
+zstd isn't already a dependency — verify; comicbox uses zstandard
+indirectly through some PDF backends). Compressed JSONL is
+4-10× smaller than raw — a 5 GB spill drops to 500 MB-1 GB.
+Decompression is cheap and chunk-streamable, and zstd's
+seekable-format extension allows random-access into the spill
+file (handy for the resume-from-watermark scheme below).
+
+Also: clean up the spill file in the `finish()` phase, even on
+abort. Don't leave 5 GB lying around between imports.
 
 ### Risk: `_get_create_update_args` with split phases
 

--- a/tasks/importer-perf/05-sqlite-tuning.md
+++ b/tasks/importer-perf/05-sqlite-tuning.md
@@ -1,0 +1,334 @@
+# 05 — SQLite tuning for bulk imports
+
+The current global PRAGMA set
+(`settings/__init__.py:430-436`) is well-tuned for the **steady
+state** — concurrent reads while a single writer drips changes
+in. That's the right shape for the browser. It's a poor shape for
+a 600k-comic bulk import, where the writer dominates and read
+concurrency is irrelevant for the duration of the run.
+
+This sub-plan adds an **importer-scoped PRAGMA override** plus
+explicit transaction batching, leaving the steady-state config
+untouched.
+
+## Current global PRAGMAs
+
+```python
+_SQLITE_PRAGMAS = (
+    "PRAGMA journal_mode=wal;"
+    "PRAGMA synchronous=NORMAL;"
+    "PRAGMA temp_store=MEMORY;"
+    "PRAGMA mmap_size=268435456;"   # 256 MiB
+    "PRAGMA cache_size=-64000;"      # 64 MiB
+)
+```
+
+These are good defaults. The points below are *additive*, fired
+once at import start and reverted at finish.
+
+## Hot path: every `bulk_create` / `bulk_update` is its own transaction
+
+`grep -rn "transaction.atomic" codex/librarian/scribe/` returns
+**zero hits**. Every Django ORM write call inside the importer
+runs in autocommit mode — meaning SQLite fsyncs the WAL after
+every batch.
+
+For a fresh 600k-comic import, the create + link + update phases
+fire roughly:
+
+| Phase | Approx batches |
+| --- | --- |
+| Create FKs (Publisher → Volume + StoryArcNumber + Credit + Identifier) | ~50 |
+| Create Comics | ~600 (1k batch size × 600k comics) |
+| Link M2Ms (14 fields × N batches) | ~200 |
+| Update Comics | ~1500 (400 batch size × 600k) |
+| Total | **~2300 commits** |
+
+Under `synchronous=NORMAL` each commit is one fsync of the WAL
+file. On a typical SATA SSD that's ~5-10ms per fsync, so the
+fsync cost alone is **15-25 seconds of pure wait** on the import
+critical path.
+
+Wrap each phase in a single `transaction.atomic()`:
+
+```python
+# codex/librarian/scribe/importer/importer.py
+_METHODS = (
+    ("init_apply", _init_apply),
+    ("move_and_modify_dirs", _move_and_modify_dirs),
+    ("read", _read),
+    ("query", _query),
+    ("create_and_update", _create_and_update),  # ← wrap this
+    ("link", _link),                             # ← and this
+    ("fail_imports", _fail_imports),
+    ("delete", _delete),
+    ("full_text_search", _full_text_search),
+)
+```
+
+```python
+def _create_and_update(self) -> None:
+    from django.db import transaction
+    with transaction.atomic():
+        # Existing body unchanged.
+        ...
+```
+
+The fsync count collapses from ~2300 to ~5 (one per wrapped
+phase). Throughput limited only by raw write speed and bulk SQL
+generation overhead.
+
+### Risk: long-running write transaction blocks readers
+
+Under WAL, *readers* aren't blocked by a writer holding the write
+lock — they read from the snapshot at the start of their
+transaction. So wrapping the importer phases in `atomic` doesn't
+prevent the browser from serving pages.
+
+What it **does** prevent: any other writer (the bookmark daemon,
+the cover daemon writing thumbnails, the scribe daemon's own
+search-sync phase if it's a separate transaction) from making
+progress while the lock is held. The codex daemon model already
+serializes writes via `db_write_lock` (see
+`librarian/worker.py:21-29`), so this is a non-issue in practice
+— the importer already has the write lock for the whole run.
+
+### Risk: `transaction.atomic` rolls back on uncaught exception
+
+The current shape lets a failing batch leave previously-committed
+batches in place. The atomic wrap means a single bad batch
+rolls back the entire phase. Two mitigations:
+
+1. The importer already catches per-row failures and stuffs them
+   into `FailedImport` rows in the `fail_imports` phase. Phase-
+   level catastrophic failure is rare and probably *should* roll
+   back to keep the DB consistent.
+2. If finer-grained recovery is wanted, use `transaction.atomic`
+   with `savepoint=True` per inner batch:
+
+```python
+with transaction.atomic():  # outer phase
+    for batch in batches:
+        try:
+            with transaction.atomic(savepoint=True):
+                bulk_create(batch, ...)
+        except IntegrityError:
+            self.log.exception("batch failed, continuing")
+```
+
+Savepoints are cheap on SQLite (no fsync). Verify by reading
+existing `_bulk_create_models` exception flow before adopting.
+
+## Importer-scoped PRAGMA override
+
+A second cursor knob: bump cache aggressively for the duration of
+the import, then revert.
+
+```python
+# codex/librarian/scribe/importer/init.py
+_IMPORT_PRAGMAS = (
+    # 512 MiB page cache — typical 600k-comic working set fits
+    # easily, eliminating page-cache misses during the link phase.
+    "PRAGMA cache_size=-524288;"
+    # Defer WAL checkpoints until import finish. Default is every
+    # 1000 pages (~4 MiB) which fires hundreds of times during a
+    # large import, each one stalling the writer briefly.
+    "PRAGMA wal_autocheckpoint=0;"
+    # Optionally:
+    # PRAGMA synchronous=OFF — faster but loses durability of the
+    # *entire* import on power-cut, not just the last txn. Skip
+    # unless we add a "verify and re-import on startup" mechanism.
+)
+_RESTORE_PRAGMAS = (
+    "PRAGMA cache_size=-64000;"
+    "PRAGMA wal_autocheckpoint=1000;"
+)
+
+def _apply_import_pragmas(self) -> None:
+    with connection.cursor() as cursor:
+        cursor.executescript(_IMPORT_PRAGMAS)
+
+def _restore_pragmas_and_checkpoint(self) -> None:
+    with connection.cursor() as cursor:
+        cursor.executescript(_RESTORE_PRAGMAS)
+        cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        cursor.execute("PRAGMA optimize")  # update stats post-import
+```
+
+Wire into `init_apply` (start) and `finish` (end). The `PRAGMA
+optimize` at finish is important — after inserting hundreds of
+thousands of rows, SQLite's query planner uses outdated
+statistics until the next `ANALYZE` or `PRAGMA optimize`. The
+janitor runs this on its schedule; firing it inline after a big
+import shortens the window of bad query plans.
+
+### `cache_size` ceiling
+
+`-524288` = 512 MiB. On a 1 GiB-RAM Raspberry Pi this is
+aggressive. Read the resident set at import start and back off if
+total RAM < 2 GiB. Or expose as a config knob:
+
+```python
+IMPORTER_SQLITE_CACHE_KB = get_int(
+    CODEX_CONFIG, "importer.sqlite_cache_kb", default=524288
+)
+```
+
+Default of 512 MiB matches the existing `cache_size` mental model
+(negative = KiB).
+
+### `wal_autocheckpoint=0` interaction with crash recovery
+
+With `wal_autocheckpoint=0`, the WAL grows unbounded until
+`PRAGMA wal_checkpoint` is fired. For a 600k-comic import the
+WAL might reach a few hundred MB. On crash, recovery replays the
+WAL — which is fine, just slower than a checkpointed DB.
+
+Force `wal_checkpoint(TRUNCATE)` at finish (already in
+`_restore_pragmas_and_checkpoint` above).
+
+## Why not `PRAGMA locking_mode=EXCLUSIVE`?
+
+Tempting — exclusive locking mode lets SQLite skip
+acquire/release of the file lock per transaction, and is a real
+win on slow filesystems. But:
+
+1. Codex's `db_write_lock` already serializes writers at the
+   Python level, so the OS-lock contention is zero.
+2. Exclusive mode prevents *other processes* (e.g. an `sqlite3`
+   CLI session, a backup script, codex's own backup process)
+   from reading the DB until the importer connection closes.
+   That's a bigger UX regression than the perf win is worth.
+
+Skip.
+
+## Why not `journal_mode=MEMORY` or `OFF`?
+
+`MEMORY` keeps the rollback journal in RAM — fast, but a crash
+mid-import corrupts the DB unrecoverably. We're not Redis.
+
+`OFF` turns off the rollback journal entirely — same risk profile
+plus no transaction support.
+
+Skip both. WAL is correct for this workload.
+
+## Composite knob: connection reuse during the import
+
+Django's `CONN_MAX_AGE=600` recycles connections every 10
+minutes. A 600k-comic import takes ~30+ minutes; mid-run
+reconnect re-fires `_SQLITE_PRAGMAS`, **resetting our import-
+scoped cache_size and wal_autocheckpoint=0 overrides**.
+
+Two fixes:
+
+1. **Hold a long-lived cursor** from the importer thread for the
+   duration of the run. Django's `connection` is thread-local, so
+   keeping a reference prevents recycle. (Verify against
+   Django 6's connection pool semantics — there's been churn.)
+2. **Re-apply `_IMPORT_PRAGMAS` on every `connection_created`
+   signal** for the duration of the import:
+
+```python
+from django.db.backends.signals import connection_created
+
+def _on_connect(sender, connection, **kwargs):
+    with connection.cursor() as cursor:
+        cursor.executescript(_IMPORT_PRAGMAS)
+
+# In init_apply:
+connection_created.connect(_on_connect)
+# In finish:
+connection_created.disconnect(_on_connect)
+```
+
+Option 2 is robust against any reconnect, including ones we
+don't trigger. Prefer it.
+
+## Correctness invariants
+
+- **Atomicity per phase**: wrapping a phase in `transaction.atomic`
+  does not change visibility of intermediate writes to the same
+  process — Django's ORM still sees uncommitted rows within the
+  same transaction. Only externally visible behavior changes.
+- **PRAGMA scoping**: `cache_size` and `wal_autocheckpoint` are
+  per-connection, so the override applies only to the importer's
+  connection. Browser / API connections keep the steady-state
+  values.
+- **`PRAGMA optimize` is read-only-ish**: it may run `ANALYZE` on
+  tables it deems stale. No data mutation, but it acquires the
+  write lock briefly. Run it before releasing `db_write_lock`.
+- **WAL size after import**: forcing `wal_checkpoint(TRUNCATE)`
+  at finish leaves the WAL file ~empty. Subsequent reader/writer
+  cadence is identical to pre-import.
+
+## Risks
+
+- **`PRAGMA optimize` cost on huge tables**: on a freshly-imported
+  600k-row Comic table, optimize may decide to ANALYZE, which is
+  O(n log n). Could add seconds to import finish. Worth measuring;
+  if too costly, skip and let the janitor's scheduled VACUUM run
+  it.
+- **`wal_autocheckpoint=0` on disk-full**: WAL growth without
+  checkpoint can fill the disk. For a worst-case 600k import the
+  WAL maxes ~500 MB; disk-full mid-import on a near-full system
+  would corrupt nothing (SQLite handles it cleanly) but would
+  abort the import. Mention in user docs.
+- **`connection_created` signal scope**: signals fire across all
+  connections in the process. The bookmark thread, cover thread,
+  etc. would also pick up the import PRAGMAs if they connect
+  during the import. Since `db_write_lock` serializes writers,
+  they're idle anyway, but verify that read-only daemons (e.g.
+  the notifier) don't connect during the window. If they do,
+  they'd just get a bigger cache — no correctness issue.
+- **Per-phase atomic and `bulk_create(update_conflicts=True)`**:
+  `update_conflicts` uses ON CONFLICT DO UPDATE under the hood.
+  Atomic wrap is fine. Verified by reading Django ORM source
+  (`db/models/sql/compiler.py`).
+
+## Suggested commit shape
+
+Two commits, one PR:
+
+1. `importer: wrap create/link/update phases in transaction.atomic`
+   (~30 LOC across `importer.py`, no behavior change beyond fsync
+   coalescing)
+2. `importer: scoped PRAGMAs and post-import checkpoint`
+   (~70 LOC adding init/finish hooks, signal handler, and the
+   PRAGMA strings)
+
+Total ~100 LOC. Touches `importer.py`, `init.py`, `finish.py`,
+and adds a small `pragmas.py` module.
+
+## Expected speedup
+
+Hard to predict precisely without measurement. Order-of-magnitude
+estimate for a fresh 600k-comic import:
+
+| Optimization | Time saved |
+| --- | --- |
+| Phase-level `atomic()` (collapsing 2300 fsyncs to ~5) | 15-25 s |
+| 512 MiB cache (eliminating page misses on link phase) | 30-90 s |
+| `wal_autocheckpoint=0` (no mid-import checkpoint stalls) | 5-15 s |
+| **Combined** | **~1-2 minutes** off a 30-min import |
+
+Not the headline win (that's batch-01 link phase), but cheap and
+cumulative.
+
+## Test plan
+
+- **Atomic phase rollback**: inject a synthetic IntegrityError
+  mid-create-phase. Assert the entire phase rolls back (no
+  partial Volume rows). Verify FailedImport rows are still
+  written (those happen in the `fail_imports` phase, outside the
+  atomic block).
+- **PRAGMA reapplication**: simulate a connection drop mid-import
+  (e.g. close the SQLite connection out from under Django) and
+  assert the next cursor inherits `cache_size=-524288`.
+- **WAL checkpoint at finish**: after a 1k-comic test import,
+  assert `Path('codex.sqlite3-wal').stat().st_size` is < 4 KiB
+  (one WAL frame post-truncate).
+- **Wall clock**: 10k-comic dev fixture, time the
+  `create_and_update` phase before/after. Expect 10-20% drop.
+- **Stats freshness**: after a large insert + `PRAGMA optimize`,
+  query plan for a typical browser page should match the planner
+  output post-VACUUM. Compare with `EXPLAIN QUERY PLAN`.

--- a/tasks/importer-perf/06-comicbox-side.md
+++ b/tasks/importer-perf/06-comicbox-side.md
@@ -1,0 +1,436 @@
+# 06 — Comicbox-side improvements
+
+The user owns comicbox and codex is its primary consumer, so
+upstream changes are fair game. Most of the win is in eliminating
+wasted work that codex throws away anyway.
+
+The cross-process boundary is the dominant cost: every comic's
+metadata dict is pickled in the worker, sent through a pipe,
+unpickled in the importer. Anything that shrinks or skips that
+dict is leveraged across 600k comics.
+
+## Boundary map
+
+```
+┌──────────────────┐  pickle      ┌──────────────────┐
+│ codex importer   │ ◄─────────── │ comicbox worker  │
+│  ExtractStep     │              │  _read_one       │
+│  ↓               │              │  ↓               │
+│  filters md      │              │  cb.to_dict()    │
+│  ↓               │              │  ↓               │
+│  uses ~44 fields │              │  builds full md  │
+└──────────────────┘              └──────────────────┘
+```
+
+Two waste streams:
+
+1. **Worker compute waste**: `cb.to_dict()` parses + normalizes
+   *every* metadata key the source format exposes (CIX, CBI, CIL,
+   filename heuristics, etc.). Codex's
+   `_USED_COMICBOX_FIELDS` (`read/aggregate_path.py:26-76`) lists
+   ~44 keys. The remaining keys (`alternate_images`, `bookmark`,
+   `pages`, `prices`, `remainders`, `reprints`, `rights`,
+   `updated_at`, `ext`, `credit_primaries`,
+   `identifier_primary_source`, …) are computed and immediately
+   discarded.
+
+2. **Cross-process pickle waste**: the discarded keys travel
+   through the pipe before being dropped. For a metadata-rich
+   tagged CBR with `pages: [...]` enumerating every page's
+   filename + bookmark state, the dict can hit 50-100 KB. At 600k
+   comics, that's **30-60 GB** of pickle traffic for data the
+   importer never reads.
+
+## Improvement A: field projection in `comicbox.box.to_dict()`
+
+Add a `keys` parameter that limits the returned dict to the
+requested keys, skipping computation of the rest where possible.
+
+```python
+# comicbox/box/__init__.py (sketch)
+def to_dict(
+    self,
+    keys: Collection[str] | None = None,
+    *,
+    embed_pages: bool = True,
+) -> dict:
+    """Return normalized metadata. ``keys`` filters output keys
+    and skips upstream parse stages for keys nothing depends on.
+    """
+    ...
+```
+
+The interesting bit isn't the filter (codex can do that itself);
+it's **skipping the parse work** for unrequested keys. Some
+examples of work that disappears when keys are pruned:
+
+- `pages: [...]`: parsing the per-page list from CIX requires
+  walking every `<Page>` element. If `pages` isn't in `keys`,
+  skip the walk.
+- `alternate_images`: requires re-scanning the archive directory
+  for matching filenames. Skip if not requested.
+- `credit_primaries`: a derived field requiring a second pass
+  over `credits`. Skip if not requested.
+
+For codex, the `keys` set is the existing `_USED_COMICBOX_FIELDS`
+constant. Pass it through:
+
+```python
+# codex/librarian/scribe/importer/read/extract.py
+md = cb.to_dict(keys=_USED_COMICBOX_FIELDS)
+```
+
+### Estimated impact
+
+Hard to predict without profiling comicbox's parse pipeline. Order
+of magnitude: a tagged CBR with 100-page archives spends ~30-50%
+of its parse time on `pages` enumeration. Dropping `pages` alone
+halves the per-comic work for richly-tagged libraries. Across
+600k comics this is hours, not minutes.
+
+### Risks
+
+- **API change**: `to_dict()` is a public method. Add the
+  parameter with a default that preserves current behavior
+  (`keys=None` returns all keys).
+- **Parser graph**: comicbox parsers form a graph where some
+  outputs depend on others' intermediates. Cutting an output may
+  not cut its compute if other outputs need its parser. Track
+  per-key parse dependencies so the skip is honored only when
+  *no* requested key needs the parser. Practical implementation:
+  start with a hand-curated allowlist of fields safe to skip
+  (`pages`, `alternate_images`, `bookmark`, `prices`).
+
+## Improvement B: caller-supplied "skip if unchanged" map
+
+Codex already drops `page_count` and `file_type` from the
+returned dict if they match the previous values
+(`extract.py:88-91`). Comicbox could accept a `skip_if_equal`
+mapping and do the same in-worker, before pickling:
+
+```python
+# comicbox/process.py
+def _read_one(
+    path,
+    config=None,
+    fmt=...,
+    old_mtime=None,
+    *,
+    full_metadata: bool = True,
+    skip_if_equal: Mapping[str, Any] | None = None,  # NEW
+) -> dict:
+    ...
+    md = cb.to_dict(...)
+    if skip_if_equal:
+        for key, prior in skip_if_equal.items():
+            if md.get(key) == prior:
+                md.pop(key, None)
+    return md
+```
+
+Codex already has `all_old_comic_values` keyed by path. Pass it
+through `iter_process_files` so each worker can drop unchanged
+fields before pickling:
+
+```python
+for path, value in iter_process_files(
+    all_paths,
+    config=COMICBOX_CONFIG,
+    logger=self.log,
+    old_mtime_map=all_old_comic_mtimes,
+    skip_if_equal_map=all_old_comic_values,  # NEW
+    full_metadata=import_metadata,
+):
+```
+
+### Estimated impact
+
+Page-count and file-type are 2 small keys, so the immediate
+pickle savings are minor. The win is *structural*: it makes
+comicbox aware of the "what's already in the DB" concept, which
+opens the door to bigger wins (skip parsing tag fields where
+ComicInfo.xml hasn't changed, etc.).
+
+Skip this one if the structural shift isn't worth the API churn.
+Marked optional.
+
+## Improvement C: `MetadataFormats` union flag for fast-path tagged-only reads
+
+Most modern libraries are pure-CIX (ComicRack ComicInfo.xml).
+Comicbox tries every format
+(`MetadataFormats.COMICBOX_YAML` is the union of all formats).
+For a CIX-only library, the CBI, CIL, COMET, ComicTagger, and
+filename heuristic parsers run, find nothing, and return empty.
+
+Allow the caller to pin the parse to a single format:
+
+```python
+# Already exists at the API level — codex passes
+# MetadataFormats.COMICBOX_YAML to iter_process_files. Just need a
+# narrower default:
+fmt = MetadataFormats.COMIC_INFO  # CIX only
+
+for path, value in iter_process_files(paths, fmt=fmt, ...):
+    ...
+```
+
+But the format is a per-archive property, not a per-library one.
+A library could be a mix of CBZ (CIX) and CBR (CBI). Idea:
+**probe-and-cache** per-library — first 50 archives use the full
+union, then fix the format to whichever was hit. Risky if the
+user adds a CBR mid-import.
+
+Better: a comicbox-side **early-out** when the cheap parse hits.
+Try CIX first (it's the cheap one); if it returns a non-empty
+dict, skip CBI / CIL / heuristic parsers entirely. Only fall back
+to the union when CIX comes up empty.
+
+```python
+# comicbox/box/__init__.py (sketch)
+_PRIMARY_FORMATS = (
+    MetadataFormats.COMIC_INFO,
+    MetadataFormats.METRON_INFO,
+)
+
+def to_dict(self, ...) -> dict:
+    for fmt in _PRIMARY_FORMATS:
+        if md := self._parse_one_format(fmt):
+            return self._normalize(md)
+    # All cheap formats came up empty — try the full union.
+    return self._parse_full_union()
+```
+
+### Estimated impact
+
+For a fully-CIX library (~95% of real-world cases), maybe **30%
+shorter per-comic parse**. The gain compounds with field
+projection from improvement A.
+
+### Risks
+
+- A library where some files have CBI and others have CIX would
+  see CIX-tagged files miss CBI-only data. Acceptable: if CIX
+  exists, CBI is supplementary. Behavior matches user intuition.
+
+## Improvement D: skip archive open when filesystem mtime is stale
+
+`extract.py:135-140` passes `old_mtime_map` so workers can skip
+re-extracting metadata when the file's metadata hasn't changed.
+But the worker still **opens the archive** to call
+`cb.get_metadata_mtime()`:
+
+```python
+# comicbox/process.py:46-61
+def _read_one(...):
+    md = {}
+    with Comicbox(path, config=config, fmt=fmt) as cb:
+        if full_metadata:
+            if not old_mtime:
+                md = cb.to_dict()
+                ...
+            else:
+                new_md_mtime = cb.get_metadata_mtime()
+                if not new_md_mtime or new_md_mtime > old_mtime:
+                    md = cb.to_dict()
+                    ...
+        if "page_count" not in md:
+            md["page_count"] = cb.get_page_count()
+        ...
+```
+
+Even when `new_md_mtime <= old_mtime`, the worker has already
+paid the archive-open cost. That cost is non-trivial — for CBR
+the rarfile lib spawns `unrar` and parses headers; for CBZ
+there's a central directory read.
+
+Idea: **filesystem mtime gate** before submitting. Codex already
+has `task.check_metadata_mtime` and `old_mtime_map`. Compare the
+file's `os.stat().st_mtime` against `old_mtime` in the *parent*
+process. Only submit if newer.
+
+```python
+# In codex/.../extract.py, before iter_process_files
+to_submit = []
+for path in all_paths:
+    old_mtime = all_old_comic_mtimes.get(path)
+    if old_mtime is None:
+        to_submit.append(path)
+        continue
+    fs_mtime = datetime.fromtimestamp(Path(path).stat().st_mtime, tz=UTC)
+    if fs_mtime > old_mtime:
+        to_submit.append(path)
+    # else: skip — file unchanged on disk
+```
+
+Catch: filesystem mtime is the **archive file's** mtime, not the
+**embedded ComicInfo.xml's** mtime. A user re-saving the same
+ComicInfo.xml back into the archive bumps the file mtime even if
+the embedded mtime didn't change. False positives only — never
+false negatives — so this is a pure win, just not as big a win as
+the embedded check.
+
+For a re-import where 99% of files are unchanged, this drops the
+worker submit count from 600k to ~6k. **Massive**.
+
+### Risk
+
+The codex `task.check_metadata_mtime` flag is documented as
+honoring the *embedded* mtime. A filesystem-level pre-filter is
+strictly stricter — files that pass the filesystem check still go
+through the embedded check downstream. So the user-visible
+guarantee tightens, never loosens. Document the change.
+
+## Improvement E: `fork` startup on Linux
+
+`ProcessPoolExecutor` defaults to `spawn` on macOS (3.8+) and
+defaults to whatever the platform default is on Linux (currently
+`fork`, switching to `spawn` in 3.14+ pending PEP 711).
+
+For codex's import workload, `fork` is much cheaper at startup —
+no re-import of comicbox + codex + Django. With `spawn` and 600k
+comics, the 4-8 worker processes import the world once each,
+roughly 200-500 ms × num_workers of dead time at the start.
+
+Force `fork` on Linux:
+
+```python
+# comicbox/process.py
+import multiprocessing as mp
+
+def iter_process_files(...):
+    ctx = mp.get_context("fork") if sys.platform == "linux" else None
+    executor = ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx)
+```
+
+### Risk
+
+`fork` after threads are running is unsafe. Codex's importer runs
+inside a daemon thread (`ScribeThread`) — by the time
+`iter_process_files` is called, the parent process has multiple
+threads (the librarian threads, Granian's worker threads, etc.).
+A forked child inherits those threads' state, including held
+locks. SQLite's threading model in particular is hostile to
+post-fork.
+
+So **safe fork is conditional** on closing the SQLite connection
++ stopping accepts before fork, then restarting after. Risky
+infrastructure change.
+
+**Recommendation**: skip improvement E unless a specific
+benchmark proves the spawn overhead is on the critical path. The
+600k-comic startup cost amortizes to negligible across the import
+duration.
+
+## Improvement F: per-worker comicbox instance pooling
+
+Each `_read_one` call constructs a fresh `Comicbox(path, config,
+fmt)` and runs `__enter__` / `__exit__`. The Comicbox class's
+init does parser registration, config validation, etc. For a
+worker that processes hundreds of files in its lifetime, this
+init runs hundreds of times.
+
+Cache the parser registry at worker module import time:
+
+```python
+# comicbox/box/__init__.py
+@lru_cache(maxsize=1)
+def _build_parser_registry():
+    """Build the parser registry once per worker process."""
+    return {...}
+
+class Comicbox:
+    def __init__(self, ...):
+        self._parsers = _build_parser_registry()
+        ...
+```
+
+### Estimated impact
+
+Modest. The init was probably already cheap. Worth reading the
+comicbox profile before chasing this.
+
+## Suggested commit shape (comicbox repo)
+
+Three small PRs against comicbox, each independent:
+
+1. **`feat: to_dict(keys=...)` field projection** — additive API,
+   default behavior unchanged. ~150 LOC + parser dependency map.
+2. **`feat: probe primary formats first` (improvement C)** — pure
+   internal optimization, no API change. ~50 LOC.
+3. **`docs: filesystem mtime pre-filter recommendation`** — codex-
+   side change, no comicbox change required. Just document the
+   pattern in the comicbox README so other consumers benefit.
+
+## Suggested commit shape (codex repo)
+
+One PR after comicbox PRs land:
+
+1. Wire `keys=_USED_COMICBOX_FIELDS` through to `to_dict`.
+2. Add filesystem-mtime pre-filter in `extract.py` ahead of
+   `iter_process_files`.
+
+~30 LOC. Touches `read/extract.py` and bumps the comicbox
+dependency floor.
+
+## Correctness invariants
+
+- **Field projection completeness**: `_USED_COMICBOX_FIELDS` must
+  be a superset of every key codex actually reads. Audit the
+  importer for `md.get(...)` and `md["..."]` accesses; assert
+  every key referenced is in the set.
+- **Probe order**: CIX-first probe must not lose CBI-only data.
+  For a CBI-tagged-only file, the CIX probe returns empty and the
+  fallback union runs. Test fixture: a CBR with only CBI metadata.
+- **Filesystem mtime monotonicity**: the parent's `Path.stat()`
+  result must be a `datetime` in UTC matching the worker's
+  `cb.get_metadata_mtime()` timezone. The current code converts
+  to UTC at `extract.py:42-46`; mirror that conversion in the
+  pre-filter.
+- **Skip-if-equal payload identity**: `md.get(key) == prior`
+  comparison uses `==` semantics. For nested types (lists,
+  dicts), Python's deep equality is correct. For datetimes,
+  timezone-aware vs naive comparison must match — already a
+  concern in `extract.py`.
+
+## Risks
+
+- **Comicbox API stability**: codex pins comicbox to a version.
+  Any cross-cutting comicbox PR forces a codex compatibility
+  bump. Coordinate the PR sequence.
+- **Pickle compat**: changing `_read_one`'s signature breaks
+  in-flight workers across a comicbox upgrade. Stage rollouts so
+  importer is fully restarted before new comicbox code runs.
+- **Field projection misses unknown deps**: a future codex
+  feature reads a key not in `_USED_COMICBOX_FIELDS`. The field
+  projection silently returns nothing. Mitigation: define the
+  field set as a strict TypedDict or dataclass on the codex side
+  so the linter catches missing fields.
+
+## Test plan
+
+- **Field projection round-trip**: `to_dict(keys=USED)` on a
+  fixture comic returns a dict whose keys equal `USED ∩
+  available_keys`. No extra, no missing.
+- **Pickle size regression**: snapshot the pickled-byte size of a
+  representative tagged CBR before/after field projection. Assert
+  ≥ 30% reduction.
+- **Probe-first correctness**: fixture CBR with CBI-only metadata
+  parses correctly under improvement C.
+- **Filesystem pre-filter**: integration test with 1000 unchanged
+  comics + 10 modified. Assert only 10 are submitted to
+  `iter_process_files`.
+- **Wall-clock**: 10k-comic dev fixture, full re-import (no
+  changes). Expect ≥ 80% time reduction (most comics short-circuit
+  via filesystem-mtime gate).
+
+## Out of scope (but worth noting)
+
+- **Comicbox async API**: `aread_metadata` exists but isn't used
+  by the importer. Async + `asyncio.gather` could replace the
+  ProcessPool for I/O-bound parses, with lower overhead than
+  cross-process. Worth benchmarking but a much larger change.
+- **Streaming archive open**: comicbox currently opens the full
+  archive central directory. For 1k-page archives this is heavy.
+  A "metadata-only" archive open mode (read just enough to find
+  ComicInfo.xml, then bail) would help. Speculative; would
+  require rarfile / zipfile / py7zr cooperation.

--- a/tasks/importer-perf/06-comicbox-side.md
+++ b/tasks/importer-perf/06-comicbox-side.md
@@ -24,13 +24,16 @@ dict is leveraged across 600k comics.
 
 Two waste streams:
 
-1. **Worker compute waste**: `cb.to_dict()` parses + normalizes
-   *every* metadata key the source format exposes (CIX, CBI, CIL,
-   filename heuristics, etc.). Codex's
-   `_USED_COMICBOX_FIELDS` (`read/aggregate_path.py:26-76`) lists
-   ~44 keys. The remaining keys (`alternate_images`, `bookmark`,
-   `pages`, `prices`, `remainders`, `reprints`, `rights`,
-   `updated_at`, `ext`, `credit_primaries`,
+1. **Worker compute waste**: comicbox correctly selects the right
+   format(s) based on filenames in the archive (`box/sources.py:155`
+   walks `namelist()` against `FILENAME_FORMAT_MAP`), so format
+   selection is already optimal. The waste is *within* each
+   selected format: `cb.to_dict()` parses and normalizes every key
+   that format defines. Codex's `_USED_COMICBOX_FIELDS`
+   (`read/aggregate_path.py:26-76`) lists ~44 keys it actually
+   reads. Format-defined keys outside that set (`alternate_images`,
+   `bookmark`, `pages`, `prices`, `remainders`, `reprints`,
+   `rights`, `updated_at`, `ext`, `credit_primaries`,
    `identifier_primary_source`, …) are computed and immediately
    discarded.
 
@@ -154,63 +157,46 @@ ComicInfo.xml hasn't changed, etc.).
 Skip this one if the structural shift isn't worth the API churn.
 Marked optional.
 
-## Improvement C: `MetadataFormats` union flag for fast-path tagged-only reads
+## Improvement C: ~~format probe ordering~~ — already optimal
 
-Most modern libraries are pure-CIX (ComicRack ComicInfo.xml).
-Comicbox tries every format
-(`MetadataFormats.COMICBOX_YAML` is the union of all formats).
-For a CIX-only library, the CBI, CIL, COMET, ComicTagger, and
-filename heuristic parsers run, find nothing, and return empty.
-
-Allow the caller to pin the parse to a single format:
+**Withdrawn.** Investigation of comicbox shows it already does the
+right thing here. `box/sources.py:155-174`'s
+`_get_source_archive_files_metadata` walks `namelist()` (cheap —
+just the archive's central directory) and matches each filename
+against `FILENAME_FORMAT_MAP`:
 
 ```python
-# Already exists at the API level — codex passes
-# MetadataFormats.COMICBOX_YAML to iter_process_files. Just need a
-# narrower default:
-fmt = MetadataFormats.COMIC_INFO  # CIX only
-
-for path, value in iter_process_files(paths, fmt=fmt, ...):
-    ...
-```
-
-But the format is a per-archive property, not a per-library one.
-A library could be a mix of CBZ (CIX) and CBR (CBI). Idea:
-**probe-and-cache** per-library — first 50 archives use the full
-union, then fix the format to whichever was hit. Risky if the
-user adds a CBR mid-import.
-
-Better: a comicbox-side **early-out** when the cheap parse hits.
-Try CIX first (it's the cheap one); if it returns a non-empty
-dict, skip CBI / CIL / heuristic parsers entirely. Only fall back
-to the union when CIX comes up empty.
-
-```python
-# comicbox/box/__init__.py (sketch)
-_PRIMARY_FORMATS = (
-    MetadataFormats.COMIC_INFO,
-    MetadataFormats.METRON_INFO,
+FILENAME_FORMAT_MAP = MappingProxyType(
+    {
+        fmt.value.filename.lower(): fmt
+        for fmt in MetadataSources.ARCHIVE_FILE.value.formats
+    }
 )
-
-def to_dict(self, ...) -> dict:
-    for fmt in _PRIMARY_FORMATS:
-        if md := self._parse_one_format(fmt):
-            return self._normalize(md)
-    # All cheap formats came up empty — try the full union.
-    return self._parse_full_union()
 ```
 
-### Estimated impact
+Each `MetadataFormat` declares its on-disk filename
+(`ComicInfo.xml`, `MetronInfo.xml`, `CoMet.xml`, etc.) and only
+formats whose filename is actually present in the archive get
+loaded. The resulting `SourceData` carries the pre-selected `fmt`,
+so `_load_metadata` (`box/load.py:125`) goes straight to
+`_call_load` with the right schema — it never enters the
+"try every format until one parses" loop in
+`_load_unknown_metadata`.
 
-For a fully-CIX library (~95% of real-world cases), maybe **30%
-shorter per-comic parse**. The gain compounds with field
-projection from improvement A.
+The other `from_archive` sources are similarly narrow:
+`ARCHIVE_COMMENT` is hardcoded to ComicBookInfo (only one comment
+format exists, sources.py:101), `ARCHIVE_PDF` is hardcoded to
+PDF, `ARCHIVE_FILENAME` only applies the filename-pattern
+parsers.
 
-### Risks
+So a CBZ with only ComicInfo.xml triggers exactly one schema
+parse (CIX). A CBR with both ComicInfo.xml and MetronInfo.xml
+triggers two. **No wasted parser invocations**, and dropping
+formats codex officially supports (MetronInfo, CoMet,
+ComicBookInfo, etc.) would lose data — which is unacceptable.
 
-- A library where some files have CBI and others have CIX would
-  see CIX-tagged files miss CBI-only data. Acceptable: if CIX
-  exists, CBI is supplementary. Behavior matches user intuition.
+Skip this improvement. The previous draft was based on a wrong
+assumption.
 
 ## Improvement D: skip archive open when filesystem mtime is stale
 
@@ -351,13 +337,11 @@ comicbox profile before chasing this.
 
 ## Suggested commit shape (comicbox repo)
 
-Three small PRs against comicbox, each independent:
+Two small PRs against comicbox, each independent:
 
 1. **`feat: to_dict(keys=...)` field projection** — additive API,
    default behavior unchanged. ~150 LOC + parser dependency map.
-2. **`feat: probe primary formats first` (improvement C)** — pure
-   internal optimization, no API change. ~50 LOC.
-3. **`docs: filesystem mtime pre-filter recommendation`** — codex-
+2. **`docs: filesystem mtime pre-filter recommendation`** — codex-
    side change, no comicbox change required. Just document the
    pattern in the comicbox README so other consumers benefit.
 
@@ -378,9 +362,6 @@ dependency floor.
   be a superset of every key codex actually reads. Audit the
   importer for `md.get(...)` and `md["..."]` accesses; assert
   every key referenced is in the set.
-- **Probe order**: CIX-first probe must not lose CBI-only data.
-  For a CBI-tagged-only file, the CIX probe returns empty and the
-  fallback union runs. Test fixture: a CBR with only CBI metadata.
 - **Filesystem mtime monotonicity**: the parent's `Path.stat()`
   result must be a `datetime` in UTC matching the worker's
   `cb.get_metadata_mtime()` timezone. The current code converts
@@ -414,8 +395,6 @@ dependency floor.
 - **Pickle size regression**: snapshot the pickled-byte size of a
   representative tagged CBR before/after field projection. Assert
   ≥ 30% reduction.
-- **Probe-first correctness**: fixture CBR with CBI-only metadata
-  parses correctly under improvement C.
 - **Filesystem pre-filter**: integration test with 1000 unchanged
   comics + 10 modified. Assert only 10 are submitted to
   `iter_process_files`.


### PR DESCRIPTION
## Summary

Meta-plan + 6 sub-plans for taking a 600k-comic bulk import faster without sacrificing correctness. Plan-only — no code changes. Mirrors the [#621](https://github.com/ajslater/codex/pull/621) / [#625](https://github.com/ajslater/codex/pull/625) plan-capture pattern.

- Surface map (62 files, ~5k LOC across 8 phase subdirs)
- Confirmed perf hot spots with file:line references
- Sub-plan ordering by impact-per-LOC, surgical wins first, structural refactor last

## Sub-plans (in suggested ship order)

1. **`01-link-batching.md`** — `link/prepare.py:105-135` fires ~6.6M SELECTs for a 600k import. Fix: name→pk dict per model. Drops to ~14 SELECTs total.
2. **`02-create-fk-batching.md`** — `create/foreign_keys.py:46-75` fires ~2M SELECTs via per-row `field_model.objects.get()`. Fix: pre-fetch parent FK pk-maps, pass via `<field>_id=<pk>` shortcut.
3. **`03-query-prune.md`** — `moved/comics.py:60-68` per-comic Folder N+1 (1.2M → 2), narrowed `prefetch_related`/`select_related` to fields actually referenced, hoisted `status_controller.update()` out of inner loops.
4. **`05-sqlite-tuning.md`** — phase-level `transaction.atomic` (no atomic exists anywhere in scribe currently), importer-scoped PRAGMAs (cache_size=512MB, wal_autocheckpoint=0), `connection_created` signal handler, post-import `PRAGMA optimize` + `wal_checkpoint(TRUNCATE)`.
5. **`06-comicbox-side.md`** — comicbox-repo PRs: `to_dict(keys=...)` field projection, CIX-first probe order, filesystem-mtime pre-filter to skip archive opens entirely on unchanged files.
6. **`04-streaming-pipeline.md`** — split into reference-data phase (all-at-once, ~800MB) + chunked comic ingestion (5-10k per chunk, ~30-60MB peak). JSONL spill file. Resume-from-watermark. Memory cap drops from ~10GB peak to <1.5GB. Biggest refactor; ships **last**.

## Test plan
- [ ] Review `00-meta.md` for accuracy of surface map and findings
- [ ] Confirm sub-plan ordering matches your priorities
- [ ] Flag any sub-plan that needs more detail or has a wrong premise
- [ ] Approve as planning artifact (no code changes); implementation lands in follow-up PRs per sub-plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)