### PR TITLE
Importer perf: pre-fetch Folder pk map + narrow prune prefetch

### DIFF
--- a/codex/librarian/scribe/importer/moved/comics.py
+++ b/codex/librarian/scribe/importer/moved/comics.py
@@ -50,44 +50,72 @@ class MovedComicsImporter(ReadMetadataImporter):
         self.status_controller.finish(status)
 
     def _prepare_moved_comic(
-        self, comic, folder_m2m_links, updated_comics, del_folder_rows
+        self,
+        comic,
+        folder_pk_by_path: dict[str, int],
+        folder_m2m_links: dict,
+        updated_comics: list,
+        del_folder_rows: list,
     ) -> None:
         """Prepare one comic for bulk update."""
         try:
-            new_path = self.task.files_moved[comic.path]
+            new_path_str = self.task.files_moved[comic.path]
             old_folder_pks = frozenset(folder.pk for folder in comic.folders.all())
-            comic.path = new_path
-            new_path = Path(new_path)
-            comic.parent_folder = Folder.objects.get(path=new_path.parent)
+            comic.path = new_path_str
+            new_path = Path(new_path_str)
+            # Library-scoped pk lookup via the prebuilt map. Replaces a
+            # per-comic ``Folder.objects.get(path=...)``, and tightens the
+            # search to this library so a parent_folder can no longer
+            # resolve to another library sharing the same on-disk path.
+            # Bracket access raises ``KeyError`` on a genuinely missing
+            # parent — same outer behavior as the prior ``DoesNotExist``
+            # (caught by the broad except below).
+            comic.parent_folder_id = folder_pk_by_path[str(new_path.parent)]
             comic.updated_at = Now()
             comic.presave()
+            # Missing ancestors silently absent from the set, matching
+            # the prior ``filter(path__in=...)`` behavior.
             new_folder_pks = frozenset(
-                Folder.objects.filter(path__in=new_path.parents).values_list(
-                    "pk", flat=True
-                )
+                pk
+                for parent in new_path.parents
+                if (pk := folder_pk_by_path.get(str(parent))) is not None
             )
             folder_m2m_links[comic.pk] = new_folder_pks
             updated_comics.append(comic)
             if del_folder_pks := old_folder_pks - new_folder_pks:
-                for pk in del_folder_pks:
-                    del_folder_rows.append((comic.pk, pk))
+                del_folder_rows.extend((comic.pk, pk) for pk in del_folder_pks)
         except Exception:
             self.log.exception(f"moving {comic.path}")
 
     def _bulk_comics_move_prepare(self) -> tuple[list, dict, dict]:
         """Prepare Update Comics."""
+        # _bulk_comics_moved_ensure_folders has already created any
+        # destination folders that were missing. One values_list pass
+        # here builds a path->pk map covering every parent path the
+        # per-comic loop below can possibly need; replaces the prior
+        # 2-SELECTs-per-moved-comic shape.
+        folder_pk_by_path: dict[str, int] = dict(
+            Folder.objects.filter(library=self.library).values_list(
+                PATH_FIELD_NAME, "pk"
+            )
+        )
+
         comics = (
             Comic.objects.prefetch_related(FOLDERS_FIELD_NAME)
             .filter(library=self.library, path__in=self.task.files_moved.keys())
             .only(PATH_FIELD_NAME, PARENT_FOLDER_FIELD_NAME, FOLDERS_FIELD_NAME)
         )
 
-        folder_m2m_links = {}
-        updated_comics = []
-        del_folder_rows = []
+        folder_m2m_links: dict = {}
+        updated_comics: list = []
+        del_folder_rows: list = []
         for comic in comics:
             self._prepare_moved_comic(
-                comic, folder_m2m_links, updated_comics, del_folder_rows
+                comic,
+                folder_pk_by_path,
+                folder_m2m_links,
+                updated_comics,
+                del_folder_rows,
             )
         self.task.files_moved = {}
         self.log.debug(f"Prepared {len(updated_comics)} for move...")

--- a/codex/librarian/scribe/importer/query/links_fk.py
+++ b/codex/librarian/scribe/importer/query/links_fk.py
@@ -10,11 +10,6 @@ from codex.librarian.scribe.importer.query.update_comics import QueryUpdateComic
 from codex.models.comic import Comic
 from codex.settings import IMPORTER_LINK_FK_BATCH_SIZE
 
-_QUERY_LINK_FK_PRUNE_ONLY = (
-    PATH_FIELD_NAME,
-    *COMIC_FK_FIELD_NAMES,
-)
-
 
 class QueryPruneLinksFKs(QueryUpdateComics):
     """Prune M2O links that don't need updating."""
@@ -75,25 +70,49 @@ class QueryPruneLinksFKs(QueryUpdateComics):
         for field_name in field_names:
             self._query_prune_comic_fk_links_field(comic, path, field_name)
             status.increment_complete()
-            self.status_controller.update(status)
+        # Refresh the controller once per comic — the controller already
+        # rate-limits at _UPDATE_DELTA, so calling it inside the
+        # per-FK-field loop only burns CPU on the early-return path.
+        self.status_controller.update(status)
         if not self.metadata[LINK_FKS][path]:
             del self.metadata[LINK_FKS][path]
 
     def _query_prune_comic_fk_links_batch(
-        self, batch_paths: tuple[str, ...], status
+        self,
+        batch_paths: tuple[str, ...],
+        select_related_fields: tuple[str, ...],
+        only_fields: tuple[str, ...],
+        status,
     ) -> None:
         comics = (
             Comic.objects.filter(library=self.library, path__in=batch_paths)
-            .select_related(*COMIC_FK_FIELD_NAMES)
-            .only(*_QUERY_LINK_FK_PRUNE_ONLY)
+            .select_related(*select_related_fields)
+            .only(*only_fields)
         )
         for comic in comics:
             self._query_prune_comic_fk_links_comic(comic, status)
+
+    def _collect_referenced_fk_fields(self) -> tuple[str, ...]:
+        """
+        Return the COMIC_FK_FIELD_NAMES subset actually referenced.
+
+        Most imports only touch a few FKs per comic; narrowing the
+        ``select_related`` JOIN drops table breadth on the underlying
+        SELECT and the column-decode cost in the Django cursor.
+        """
+        referenced: set[str] = set()
+        for path_link in self.metadata[LINK_FKS].values():
+            referenced.update(path_link.keys())
+        return tuple(name for name in COMIC_FK_FIELD_NAMES if name in referenced)
 
     def query_prune_comic_fk_links(self, status) -> None:
         """Prune comic fk links that already exist."""
         status.subtitle = "Many to One"
         self.status_controller.update(status)
+        select_related_fields = self._collect_referenced_fk_fields()
+        if not select_related_fields:
+            return
+        only_fields = (PATH_FIELD_NAME, *select_related_fields)
         paths = tuple(self.metadata[LINK_FKS].keys())
         num_paths = len(paths)
 
@@ -103,5 +122,7 @@ class QueryPruneLinksFKs(QueryUpdateComics):
                 return
             end = start + IMPORTER_LINK_FK_BATCH_SIZE
             batch_paths = paths[start:end]
-            self._query_prune_comic_fk_links_batch(batch_paths, status)
+            self._query_prune_comic_fk_links_batch(
+                batch_paths, select_related_fields, only_fields, status
+            )
             start += IMPORTER_LINK_FK_BATCH_SIZE

--- a/codex/librarian/scribe/importer/query/links_m2m.py
+++ b/codex/librarian/scribe/importer/query/links_m2m.py
@@ -69,7 +69,10 @@ class QueryPruneLinksM2M(QueryPruneLinksFKs):
                 comic, field_name, m2m_obj, kept_existing_values, proposed_values
             )
             status.increment_complete()
-            self.status_controller.update(status)
+        # Refresh the controller once per (comic, field) — the controller
+        # already rate-limits at _UPDATE_DELTA, so calling it inside the
+        # per-through-row loop only burns CPU on the early-return path.
+        self.status_controller.update(status)
         if kept_existing_values and (deleted or proposed_values):
             self.add_to_fts_existing(comic.pk, field_name, tuple(kept_existing_values))
         if not self.metadata[LINK_M2MS][comic.path][field_name]:
@@ -82,26 +85,47 @@ class QueryPruneLinksM2M(QueryPruneLinksFKs):
         if not self.metadata[LINK_M2MS][comic.path]:
             del self.metadata[LINK_M2MS][comic.path]
 
-    def _query_prune_comic_m2m_links_batch(self, paths: tuple[str], status) -> None:
+    def _query_prune_comic_m2m_links_batch(
+        self, paths: tuple[str, ...], prefetch_fields: tuple[str, ...], status
+    ) -> None:
         comics = (
             Comic.objects.filter(library=self.library, path__in=paths)
-            .prefetch_related(*COMIC_M2M_FIELD_NAMES)
-            .only(*COMIC_M2M_FIELD_NAMES)
+            .prefetch_related(*prefetch_fields)
+            .only(*prefetch_fields)
         )
         for comic in comics.iterator(chunk_size=IMPORTER_LINK_M2M_BATCH_SIZE):
             self._query_prune_comic_m2m_links_comic(comic, status)
+
+    def _collect_referenced_m2m_fields(self) -> tuple[str, ...]:
+        """
+        Return the COMIC_M2M_FIELD_NAMES subset actually referenced.
+
+        Most imports only touch a handful of M2M fields (credits, tags,
+        characters); narrowing the prefetch_related/only set drops 10+
+        wasted IN-queries per batch and the in-memory through-rows that
+        come with them.
+        """
+        referenced: set[str] = set()
+        for path_link in self.metadata[LINK_M2MS].values():
+            referenced.update(path_link.keys())
+        return tuple(name for name in COMIC_M2M_FIELD_NAMES if name in referenced)
 
     def query_prune_comic_m2m_links(self, status) -> None:
         """Prune comic m2m links that already exists or should be deleted."""
         status.subtitle = "Many to Many"
         self.status_controller.update(status)
+        prefetch_fields = self._collect_referenced_m2m_fields()
+        if not prefetch_fields:
+            return
         paths = tuple(self.metadata[LINK_M2MS].keys())
         # Batch path__in to stay under SQLite's variable limit.
         for start in range(0, len(paths), IMPORTER_LINK_FK_BATCH_SIZE):
             if self.abort_event.is_set():
                 return
             batch_paths = paths[start : start + IMPORTER_LINK_FK_BATCH_SIZE]
-            self._query_prune_comic_m2m_links_batch(batch_paths, status)
+            self._query_prune_comic_m2m_links_batch(
+                batch_paths, prefetch_fields, status
+            )
         field_names = tuple(self.metadata[DELETE_M2MS].keys())
         for field_name in field_names:
             rows = self.metadata[DELETE_M2MS][field_name]


### PR DESCRIPTION
## Summary

Implements `tasks/importer-perf/03-query-prune.md` from PR #627. Third surgical batch after #628 (link prepare) and #629 (create FKs).

Two independently revertable commits:

### `f2bddf25` — moved comics: pre-fetch Folder pk map (headline)
`_prepare_moved_comic` previously fired two SELECTs per moved comic (parent folder + ancestor M2M rebuild). For a 600k-comic library reorg that was **~1.2M small SELECTs**. `_bulk_comics_moved_ensure_folders` already runs first and creates any missing destination folders, so a single `values_list` pass at the top of the prepare loop builds a `{path: pk}` map covering this library; the per-comic loop becomes dict lookups.

**Bonus correctness fix**: the prebuilt map is `library=self.library`-scoped, while the prior `Folder.objects.get(path=...)` was not — on multi-library installs a `parent_folder` could resolve to another library sharing the same on-disk path. Tightens the search to this library.

### `9b3af11f` — prune: narrow prefetch/select_related, hoist status update
- `query_prune_comic_m2m_links` was calling `prefetch_related(*COMIC_M2M_FIELD_NAMES)` (14 M2Ms) per batch even though most imports only touch credits/tags/characters. Now computes the LINK_M2MS-referenced subset once per phase and prefetches only that — typically 3-5 IN-queries instead of 14, with proportional drop in through-row memory pressure.
- `query_prune_comic_fk_links` similarly narrowed from a 12-table `select_related` JOIN to a 3-table JOIN.
- `_query_prune_comic_m2m_links_field` and `_query_prune_comic_fk_links_comic` were calling `status_controller.update()` inside their per-through-row / per-FK-field inner loops. The controller already rate-limits at `_UPDATE_DELTA = 5s`, so the inner calls only burned CPU on the early-return path. Hoisted to once per (comic, field) and once per comic respectively; visible refresh cadence is identical.
- Drops the unused module-level `_QUERY_LINK_FK_PRUNE_ONLY` constant.

## Query count summary

| Hot path | Before | After |
| --- | --- | --- |
| Moved (600k moves) | ~1.2M SELECTs | 2 SELECTs |
| Prune M2M (per batch) | 14 prefetch IN-queries | 3-5 |
| Prune FK (per batch) | 12-table JOIN | ~3-table JOIN |

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] Field check on a real fixture: rename a 1k-comic library and assert resulting `Comic.parent_folder` and `Comic.folders` M2M rows match the pre-PR baseline
- [ ] Wall-clock measurement on a real-scale fixture once one is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)