### PR TITLE
Importer perf: phase-level transaction.atomic + scoped SQLite PRAGMAs

### DIFF
--- a/codex/librarian/scribe/importer/create/__init__.py
+++ b/codex/librarian/scribe/importer/create/__init__.py
@@ -1,8 +1,10 @@
 """
-Create all missing comic foreign keys for an import.
+Create all missing comic many to many objects for an import.
 
 So we may safely create the comics next.
 """
+
+from django.db import transaction
 
 from codex.librarian.scribe.importer.create.foreign_keys import (
     CreateForeignKeysCreateUpdateImporter,
@@ -13,25 +15,35 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
     """Methods for creating foreign keys."""
 
     def create_and_update(self) -> None:
-        """Create and update FKs, covers and comics."""
-        if self.abort_event.is_set():
-            return
-        fk_count = self.create_all_fks()
-        if self.abort_event.is_set():
-            return
-        fk_count += self.update_all_fks()
-        self.counts.tags = fk_count
-        if self.abort_event.is_set():
-            return
+        """
+        Create and update FKs, covers and comics.
 
-        cover_count = self.create_custom_covers()
+        Wrapped in ``transaction.atomic`` to coalesce the ~2000+
+        bulk_create / bulk_update commits this phase generates into
+        one fsync. The codex daemon already serializes writers via
+        ``db_write_lock``, so the long write transaction does not
+        starve other writers; readers under WAL never block on a
+        writer regardless of transaction length.
+        """
         if self.abort_event.is_set():
             return
-        cover_count += self.update_custom_covers()
-        self.counts.covers = cover_count
+        with transaction.atomic():
+            fk_count = self.create_all_fks()
+            if self.abort_event.is_set():
+                return
+            fk_count += self.update_all_fks()
+            self.counts.tags = fk_count
+            if self.abort_event.is_set():
+                return
 
-        if self.abort_event.is_set():
-            return
-        comic_count = self.update_comics()
-        comic_count += self.create_comics()
-        self.counts.comic = comic_count
+            cover_count = self.create_custom_covers()
+            if self.abort_event.is_set():
+                return
+            cover_count += self.update_custom_covers()
+            self.counts.covers = cover_count
+
+            if self.abort_event.is_set():
+                return
+            comic_count = self.update_comics()
+            comic_count += self.create_comics()
+            self.counts.comic = comic_count

--- a/codex/librarian/scribe/importer/importer.py
+++ b/codex/librarian/scribe/importer/importer.py
@@ -1,6 +1,7 @@
 """The main importer class."""
 
 from codex.librarian.scribe.importer.moved import MovedImporter
+from codex.librarian.scribe.importer.pragmas import importer_pragmas
 
 _METHODS = (
     "init_apply",
@@ -22,10 +23,14 @@ class ComicImporter(MovedImporter):
         """Bulk import comics."""
         try:
             self.abort_event.clear()
-            for name in _METHODS:
-                method = getattr(self, name)
-                method()
-                if self.abort_event.is_set():
-                    return
+            # ``importer_pragmas`` bumps the page cache and defers
+            # WAL checkpoints for the duration of the run, then
+            # force-checkpoints + ``PRAGMA optimize`` on exit.
+            with importer_pragmas():
+                for name in _METHODS:
+                    method = getattr(self, name)
+                    method()
+                    if self.abort_event.is_set():
+                        return
         finally:
             self.finish()

--- a/codex/librarian/scribe/importer/link/__init__.py
+++ b/codex/librarian/scribe/importer/link/__init__.py
@@ -1,5 +1,7 @@
 """Bulk update m2m fields."""
 
+from django.db import transaction
+
 from codex.librarian.scribe.importer.link.many_to_many import LinkManyToManyImporter
 
 
@@ -7,9 +9,17 @@ class LinkComicsImporter(LinkManyToManyImporter):
     """Link comics methods."""
 
     def link(self) -> None:
-        """Link tags and covers."""
-        self.counts.link += self.link_comic_m2m_fields()
-        if self.abort_event.is_set():
-            return
-        if count := self.link_custom_covers():
-            self.counts.link_covers += count
+        """
+        Link tags and covers.
+
+        Wrapped in ``transaction.atomic`` for the same reason as
+        ``create_and_update``: coalesces the per-M2M-field
+        ``bulk_create`` commits (one per linked relation) into a
+        single fsync.
+        """
+        with transaction.atomic():
+            self.counts.link += self.link_comic_m2m_fields()
+            if self.abort_event.is_set():
+                return
+            if count := self.link_custom_covers():
+                self.counts.link_covers += count

--- a/codex/librarian/scribe/importer/pragmas.py
+++ b/codex/librarian/scribe/importer/pragmas.py
@@ -1,0 +1,116 @@
+"""
+SQLite PRAGMA overrides scoped to a bulk-import run.
+
+The steady-state PRAGMAs in ``codex/settings/__init__.py`` are tuned
+for concurrent readers plus a slow-drip writer. A bulk import
+inverts that balance: the writer dominates and reader concurrency is
+irrelevant for the run's duration.
+
+The override here:
+
+* bumps the page cache aggressively (the 600k-comic working set fits
+  inside it, eliminating page-cache misses across the link-phase
+  prune walk), and
+* defers WAL checkpoints until import finish (the default 1000-page
+  autocheckpoint fires hundreds of times per large import; each one
+  briefly stalls the writer).
+
+A ``connection_created`` signal handler re-applies the override on
+any connection Django opens during the import — Django recycles
+connections via ``CONN_MAX_AGE``, so without the signal a long-
+running import would silently lose the override mid-run.
+
+On exit, the steady-state values are restored, the WAL is
+force-checkpointed (otherwise it would carry the import's worth of
+deferred frames forever), and ``PRAGMA optimize`` is fired so the
+query planner uses fresh statistics post-import.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from django.db import connection
+from django.db.backends.signals import connection_created
+
+from codex.settings import IMPORTER_SQLITE_CACHE_KB
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# Steady-state SQLite cache; must match the value embedded in
+# ``settings/__init__.py``'s ``_SQLITE_PRAGMAS`` so the restore
+# returns the connection to its default behavior.
+_STEADY_STATE_CACHE_KB = 64000
+# Default ``wal_autocheckpoint`` per SQLite's docs.
+_STEADY_STATE_WAL_AUTOCHECKPOINT = 1000
+
+
+def _importer_pragmas() -> tuple[str, ...]:
+    """
+    Build the importer-scoped PRAGMA list.
+
+    Resolved at call time so the cache size honors a config-file
+    change between imports without a daemon restart.
+    """
+    return (
+        f"PRAGMA cache_size=-{IMPORTER_SQLITE_CACHE_KB}",
+        "PRAGMA wal_autocheckpoint=0",
+    )
+
+
+_RESTORE_PRAGMAS = (
+    f"PRAGMA cache_size=-{_STEADY_STATE_CACHE_KB}",
+    f"PRAGMA wal_autocheckpoint={_STEADY_STATE_WAL_AUTOCHECKPOINT}",
+)
+
+
+def _apply_pragmas(conn, pragmas: tuple[str, ...]) -> None:
+    """Run a sequence of PRAGMA statements on ``conn``."""
+    with conn.cursor() as cursor:
+        for pragma in pragmas:
+            cursor.execute(pragma)
+
+
+def _on_connection_created(
+    sender,  # noqa: ARG001
+    connection,
+    **_kwargs,
+) -> None:
+    """
+    Re-apply importer PRAGMAs to a freshly opened connection.
+
+    The signal passes the new connection as the ``connection`` arg.
+    Use it directly so we don't depend on which thread-local Django
+    has currently bound to the module-level ``connection`` proxy.
+    """
+    _apply_pragmas(connection, _importer_pragmas())
+
+
+@contextmanager
+def importer_pragmas() -> Generator[None]:
+    """
+    Apply importer PRAGMAs for the duration of an import.
+
+    Yields with the override in place. On exit, restores steady-state
+    values, force-checkpoints the WAL, and runs ``PRAGMA optimize``.
+    """
+    connection_created.connect(_on_connection_created)
+    _apply_pragmas(connection, _importer_pragmas())
+    try:
+        yield
+    finally:
+        connection_created.disconnect(_on_connection_created)
+        _apply_pragmas(connection, _RESTORE_PRAGMAS)
+        with connection.cursor() as cursor:
+            # TRUNCATE checkpoints the WAL and resets the file to a
+            # single frame. Without this, the deferred-checkpoint
+            # mode above leaves the WAL holding the import's worth
+            # of frames until a reader transaction crosses them.
+            cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            # Refresh planner statistics. SQLite's planner relies on
+            # sqlite_stat1 etc., which are stale until ANALYZE
+            # (or PRAGMA optimize) runs. Without this, the next few
+            # browser queries plan against pre-import stats.
+            cursor.execute("PRAGMA optimize")

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -161,6 +161,16 @@ IMPORTER_LINK_M2M_BATCH_SIZE = get_int(
 IMPORTER_UPDATE_COMIC_BATCH_SIZE = get_int(
     CODEX_CONFIG, "importer.update_comic_batch_size", default=400
 )
+# SQLite page cache size (KiB) for the importer connection during a
+# bulk import. The steady-state ``cache_size=-64000`` (64 MiB) is
+# tuned for concurrent readers + slow-drip writes; a bulk import
+# benefits from a much larger page cache so the working set fits.
+# 512 MiB default; bump higher on big-RAM hosts, drop on Pi-class
+# hosts with < 2 GiB RAM. Negative values are interpreted as KiB by
+# SQLite per its PRAGMA documentation.
+IMPORTER_SQLITE_CACHE_KB = get_int(
+    CODEX_CONFIG, "importer.sqlite_cache_kb", default=524288
+)
 
 ##############################
 # Codex Config: Librarian    #


### PR DESCRIPTION
## Summary

Implements `tasks/importer-perf/05-sqlite-tuning.md` from PR #627. Fourth in the importer perf series after #628 (link prepare), #629 (create FKs), #630 (query-prune).

Two independently revertable commits:

### `ce82a8d0` — wrap create/link phases in `transaction.atomic`
The scribe daemon previously had **no `transaction.atomic` anywhere** — every `bulk_create` / `bulk_update` ran in autocommit. For a fresh 600k-comic import that's ~2,300 fsyncs across `create_and_update` + `link` (50 FK creates + 600 comic creates + 200 M2M link batches + 1,500 comic updates). At SATA-SSD fsync costs that's ~15-25s of pure wait time the SQL itself doesn't need.

`transaction.atomic` wraps both phases so all batches commit on one fsync each. The existing `abort_event` checks stay inside; abort returns out cleanly (Django commits on normal exit, only rolls back on uncaught exception). The codex daemon already serializes writers via `db_write_lock`, so the long-write transaction doesn't starve other writers; readers under WAL never block on a writer regardless of transaction length.

### `d6f6aca0` — importer-scoped PRAGMAs + post-import checkpoint/optimize
New `pragmas.py` module exposes an `importer_pragmas()` context manager that wraps the entire `apply()` run:

- Bumps `cache_size` to `IMPORTER_SQLITE_CACHE_KB` (default 512 MiB, configurable via `importer.sqlite_cache_kb`). The 600k-comic working set fits, eliminating page-cache misses across the link-phase prune walk.
- Sets `wal_autocheckpoint=0` to defer WAL checkpoints during the import. The default 1000-page autocheckpoint fires hundreds of times per large import, stalling the writer each time.
- Hooks the `connection_created` signal so a mid-import reconnect (CONN_MAX_AGE recycle, pool grow) re-applies the override instead of silently inheriting the steady-state values.
- On exit: restores the steady-state PRAGMAs, runs `PRAGMA wal_checkpoint(TRUNCATE)` (otherwise the deferred frames stay resident until a reader transaction crosses them), and runs `PRAGMA optimize` so the planner sees fresh statistics post-import.

## Expected speedup
Order-of-magnitude estimate for a fresh 600k-comic import:

| Optimization | Time saved |
| --- | --- |
| Phase-level `atomic()` (2,300 fsyncs → 5) | ~15-25 s |
| 512 MiB cache (eliminates link-phase page misses) | ~30-90 s |
| `wal_autocheckpoint=0` (no mid-import checkpoint stalls) | ~5-15 s |
| **Combined** | ~1-2 minutes off a 30-min import |

Cumulative with the surgical-N+1 wins from #628/#629/#630.

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] WAL size check: after a 1k-comic test import, `Path('codex.sqlite3-wal').stat().st_size` < 4 KiB (one frame post-truncate)
- [ ] Wall-clock measurement on a real-scale fixture once one is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)