### PR TITLE
Importer perf: derive comicbox delete_keys from USED set

### DIFF
--- a/codex/librarian/scribe/importer/read/aggregate_path.py
+++ b/codex/librarian/scribe/importer/read/aggregate_path.py
@@ -22,58 +22,7 @@ from codex.librarian.scribe.importer.statii.failed import (
     ImporterFailedImportsQueryStatus,
 )
 from codex.librarian.scribe.importer.statii.read import ImporterAggregateStatus
-
-_USED_COMICBOX_FIELDS = frozenset(
-    {
-        # "alternate_images",
-        "age_rating",
-        "arcs",
-        # "bookmark",
-        "characters",
-        "collection_title",
-        "country",
-        "credits",
-        # "credit_primaries",
-        "critical_rating",
-        "date",
-        # "ext",
-        "file_type",  # extra
-        "genres",
-        "identifiers",
-        # "identifier_primary_source",
-        "imprint",
-        "issue",
-        "language",
-        "locations",
-        "metadata_mtime",  # extra
-        "monochrome",
-        "notes",
-        "original_format",
-        "path",  # extra
-        # "pages",
-        "page_count",
-        "protagonist",
-        # "prices",
-        "publisher",
-        "reading_direction",
-        # "remainders",
-        # "reprints",
-        "review",
-        # "rights",
-        "scan_info",
-        "series",
-        "series_groups",
-        "stories",
-        "summary",
-        "tagger",
-        "tags",
-        "teams",
-        "title",
-        "universes",
-        # "updated_at",
-        "volume",
-    }
-)
+from codex.settings import USED_COMICBOX_FIELDS
 
 
 class AggregateMetadataImporter(AggregatePathMetadataImporter):
@@ -82,7 +31,7 @@ class AggregateMetadataImporter(AggregatePathMetadataImporter):
     @staticmethod
     def _transform_metadata(md) -> None:
         for key in tuple(md.keys()):
-            if key not in _USED_COMICBOX_FIELDS:
+            if key not in USED_COMICBOX_FIELDS:
                 md.pop(key, None)
 
         if date := md.pop(DATE_KEY, None):

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -16,6 +16,7 @@ from types import MappingProxyType
 
 from comicbox.config import get_config
 from comicbox.config.frozenattrdict import FrozenAttrDict
+from comicbox.schemas.comicbox.yaml import ComicboxYamlSubSchema
 from django.utils.csp import (  # pyright: ignore[reportMissingImports], # ty: ignore[unresolved-import]
     CSP,
 )
@@ -725,27 +726,79 @@ create_custom_cover_group_dirs()
 # Comicbox #
 ############
 
+# Top-level comicbox fields the importer actually consumes. Source of
+# truth for the codex<->comicbox contract — the importer's
+# ``aggregate_path`` code drops anything outside this set, and the
+# ``delete_keys`` config below tells comicbox to skip parse work for
+# everything else.
+#
+# Three entries (``file_type``, ``metadata_mtime``, ``path``) are
+# codex-side extras populated by ``comicbox/process.py``'s ``_read_one``
+# rather than from the parsed metadata; they are intentionally not in
+# the ``ComicboxYamlSubSchema`` field set.
+USED_COMICBOX_FIELDS: frozenset[str] = frozenset(
+    {
+        "age_rating",
+        "arcs",
+        "characters",
+        "collection_title",
+        "country",
+        "credits",
+        "critical_rating",
+        "date",
+        "file_type",  # codex-side extra
+        "genres",
+        "identifiers",
+        "imprint",
+        "issue",
+        "language",
+        "locations",
+        "metadata_mtime",  # codex-side extra
+        "monochrome",
+        "notes",
+        "original_format",
+        "path",  # codex-side extra
+        "page_count",
+        "protagonist",
+        "publisher",
+        "reading_direction",
+        "review",
+        "scan_info",
+        "series",
+        "series_groups",
+        "stories",
+        "summary",
+        "tagger",
+        "tags",
+        "teams",
+        "title",
+        "universes",
+        "volume",
+    }
+)
+
+# Tell comicbox to skip parse work for every top-level field codex
+# does not consume. Pages and reprints are short-circuited inside
+# their respective computed actions; the rest are excluded at schema
+# parse time and dropped post-merge as a backstop. Derived from the
+# live comicbox schema rather than hand-curated so a comicbox release
+# that adds a new top-level field is auto-deleted (codex maintainer
+# adds it to ``USED_COMICBOX_FIELDS`` if it's needed). Closes the
+# pre-existing ``cover_image`` gap.
+#
+# ``_declared_fields`` is the standard marshmallow class-level field
+# registry; it has been the public-by-convention enumeration surface
+# for marshmallow schemas since 3.x.
+_COMICBOX_DELETE_KEYS: frozenset[str] = frozenset(
+    ComicboxYamlSubSchema._declared_fields.keys()  # noqa: SLF001
+    - USED_COMICBOX_FIELDS
+)
+
 COMICBOX_CONFIG = FrozenAttrDict(
     get_config(
         {
             "loglevel": LOGLEVEL,
-            "delete_keys": frozenset(
-                {
-                    # Only pages and reprints are optimized away for sure with comicbox 2.0.2
-                    "alternate_images",
-                    "bookmark",
-                    "credit_primaries",
-                    "ext",
-                    "identifier_primary_source",
-                    "manga",
-                    "pages",
-                    "prices",
-                    "remainders",
-                    "reprints",
-                    "rights",
-                    "updated_at",
-                }
-            ),
+            "delete_keys": _COMICBOX_DELETE_KEYS,
         }
     )
 )


### PR DESCRIPTION
## Summary

Implements the field-projection half of `tasks/importer-perf/06-comicbox-side.md` (planning PR #627). Independent of #632 (filesystem mtime pre-filter, the other half of sub-plan 06).

After investigating the comicbox internals, the plan's "Improvement A: `to_dict(keys=...)`" turned out to be ~95% **already implemented** via comicbox's existing `delete_keys` config — codex passes `delete_keys` to skip parse work for unwanted top-level fields, and the most expensive computed action (`pages`) is already short-circuited when `pages` is in `delete_keys`. The substantive runtime win for sub-plan 06 was Improvement D (filesystem mtime pre-filter, PR #632).

What was actually missing:

1. **`cover_image` was never added to `delete_keys`** despite codex never reading it — comicbox parsed it on every comic and dropped it downstream.
2. **Future comicbox releases that add a new top-level schema field** would silently come through as parsed-but-unused work until someone noticed and updated the hand-curated `delete_keys`.

## Change

- Move `USED_COMICBOX_FIELDS` to `settings/__init__.py` as the single source of truth for the codex↔comicbox contract.
- Derive `_COMICBOX_DELETE_KEYS` programmatically from `ComicboxYamlSubSchema._declared_fields - USED_COMICBOX_FIELDS`.
  - New comicbox fields default to deleted (safe default — codex maintainer adds to USED if needed).
  - `cover_image` is now correctly included.
- `aggregate_path.py` imports the constant from settings instead of maintaining its own copy. The runtime `_transform_metadata` filter still uses the same set, so the codex-side post-extract drop remains the second-line backstop.

Net `delete_keys`: 12 → 13 entries (`cover_image` newly included). No other behavior change; this just keeps the existing mechanism honest going forward.

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [x] Verified derived delete_keys contains the previous 12 entries plus `cover_image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)