### PR TITLE
Janitor perf + correctness: capture plan in tasks/

### DIFF
--- a/tasks/janitor-perf/00-meta.md
+++ b/tasks/janitor-perf/00-meta.md
@@ -1,0 +1,262 @@
+# Janitor perf + correctness — meta plan
+
+`codex/librarian/scribe/janitor/` is small (~1200 LOC across 11
+files) compared to the importer, but it runs nightly against the
+entire DB and most of its work is unconditional table scans.
+Several hot spots fire repeatedly across all 25 tag/group models;
+a couple of latent correctness bugs put it at risk of stomping on
+in-flight imports.
+
+This is a meta-plan. The surface is small enough that one
+investigative pass found the bulk of the issues; the sub-plans
+below split them by concern (correctness first, perf wins second).
+
+## Why this matters
+
+The janitor's nightly task fires 14 sub-tasks (orphan folder
+adoption, three integrity checks, FK cleanup, cover cleanup,
+session/bookmark/settings cleanup, FTS sync + optimize, vacuum,
+backup, cover orphan removal). On a 600k-comic library most of
+these scan the full DB. A few bugs amplify: pathologically slow
+filesystem ops, multi-pass loops without caps, and missing locks
+that risk corrupting concurrent imports.
+
+The substantive remaining work after the importer-perf series
+(#628–#634) lives in two buckets:
+
+1. **Correctness bugs** that only manifest under concurrent load —
+   the kind that escape testing because they require a specific
+   timing window. Several janitor cleanup tasks write to the DB
+   without acquiring ``db_write_lock``, so a poll-driven import in
+   progress can have its just-created Publisher/Imprint deleted as
+   "orphan" before the import commits its referencing Comic.
+2. **Per-row work amplified across full-table scans** — the kind
+   the importer-perf series chased and largely won. Same flavor of
+   N+1 / per-row-FS-stat / per-row-SQL exists here at smaller
+   scale.
+
+## Surface map
+
+| Phase | File | LOC | What it does |
+| ----- | ---- | --- | ------------ |
+| Orchestration | `janitor.py` | 139 | Task dispatch, nightly task queueing |
+| Tasks | `tasks.py` | 75 | Dataclass task definitions |
+| Cleanup | `cleanup.py` | 235 | Orphan FK / cover / session / bookmark / settings deletion |
+| Integrity | `integrity/__init__.py` | 124 | `PRAGMA integrity_check`, `PRAGMA foreign_key_check`, FTS integrity |
+| FK fix | `integrity/foreign_keys.py` | 208 | Resolve `foreign_key_check` violations into NULL/DELETE statements |
+| Vacuum | `vacuum.py` | 53 | `PRAGMA optimize`, `VACUUM`, `VACUUM INTO` (backup) |
+| Adopt | `adopt_folders.py` | 76 | Re-parent orphan folders via ComicImporter |
+| Update | `update.py` | 91 | Codex software self-update |
+| Failed | `failed_imports.py` | 26 | Re-queue failed-import paths for retry |
+| Status | `status.py` | 162 | Status dataclasses |
+| Schedule | `scheduled_time.py` | 13 | Midnight calculator |
+
+## Confirmed concerns
+
+### Correctness — concurrent writes without `db_write_lock`
+
+`integrity/__init__.py` correctly wraps `foreign_key_check`,
+`integrity_check`, `fts_rebuild`, and `fts_integrity_check` in
+`with self.db_write_lock`. The cleanup writers do not:
+
+- `cleanup_fks` (`cleanup.py:138`) — deletes orphan FK rows across
+  25 models
+- `cleanup_custom_covers` (`cleanup.py:157`) — deletes covers
+- `cleanup_sessions` (`cleanup.py:175`) — deletes expired/corrupt
+  sessions
+- `cleanup_orphan_bookmarks` (`cleanup.py:210`) — deletes orphan
+  bookmarks
+- `cleanup_orphan_settings` (`cleanup.py:222`) — deletes orphan
+  settings
+- `vacuum_db` (`vacuum.py:19`) — `VACUUM` SQL holds an exclusive
+  lock; concurrent writers hit "database is locked"
+- `backup_db` (`vacuum.py:35`) — `VACUUM INTO` reads the entire DB
+
+The importer holds `db_write_lock` for the duration of an import
+(`librarian/worker.py`). If the janitor's nightly fires while a
+poll-driven import is mid-run:
+
+1. Importer creates Publisher "Indie Press LLC" in chunk 5, hasn't
+   committed the Comics referencing it yet.
+2. Janitor's `cleanup_fks` finds Publisher "Indie Press LLC" with
+   no inbound `comic_set` refs (because the comics haven't
+   committed) and deletes it.
+3. Importer commits Comics referencing the now-deleted Publisher
+   → IntegrityError, the whole importer chunk rolls back.
+
+Detailed in [01-write-lock-correctness.md](./01-write-lock-correctness.md).
+**Ship first.** Small change, biggest risk reduction.
+
+### Perf — `cleanup_fks` runs O(M × P) full-table scans
+
+`cleanup.py:130-148` `_cleanup_fks_one_level` walks all 25 FK
+models, fires a `model.objects.filter(**filter_dict).distinct()`
+per model. The outer `while count:` loop repeats until convergence.
+
+Each filter is `{rev_rel}__isnull=True` over all reverse relations
+— for a model with 10 incoming relations, that's a 10-LEFT-OUTER-JOIN
+query on the model's table. SQLite plans these but they are not
+free at scale.
+
+For 25 models × P passes (typically 2-4), that's 50-100 full-table
+scans per janitor run. On a 600k-comic library, the join-heavy
+queries can run for tens of seconds each.
+
+Plus: no convergence cap. Pathological data (a buggy importer state)
+could in principle loop forever; the only escape is `abort_event`.
+
+Detailed in [02-fk-cleanup.md](./02-fk-cleanup.md). Fix:
+- Run cleanup_fks inside one `transaction.atomic` so a single
+  multi-pass run is atomic.
+- Add iteration cap (5 passes is more than enough for any
+  realistic dependency graph).
+- Optionally fold the per-model queries into a single pass via
+  raw SQL `WITH` query against `sqlite_master` for the rev-rel
+  list — moderate complexity, marginal win.
+
+### Perf — `cleanup_custom_covers` per-row filesystem stat
+
+`cleanup.py:157-173`:
+
+```python
+for cover in covers.iterator():
+    if not Path(cover.path).exists():
+        delete_pks.append(cover.pk)
+```
+
+For each `CustomCover` row, fires `Path(cover.path).exists()` —
+serial filesystem stat. On NFS/SMB/cloud-mounted media (common for
+codex on a NAS) each stat is ~1-50 ms. For a library with 5,000
+custom covers that's 5-250 seconds of pure I/O wait.
+
+Detailed in [03-cover-cleanup-fs.md](./03-cover-cleanup-fs.md). Fix:
+- Group covers by parent directory and use `os.scandir(parent)`
+  to batch-list files; check membership against in-memory sets.
+- Or: parallelize via `concurrent.futures.ThreadPoolExecutor` —
+  filesystem stat is I/O-bound, threads work fine.
+
+### Perf — `fix_foreign_keys` per-rowid UPDATE/DELETE
+
+`integrity/foreign_keys.py:142-158` `_fix_fk_violations`:
+
+```python
+for rowid, fk_cols in rows.items():
+    if all_nullable:
+        cursor.execute(f'UPDATE "{table_name}" SET ... WHERE rowid = %s', [rowid])
+    else:
+        cursor.execute(f'DELETE FROM "{table_name}" WHERE rowid = %s', [rowid])
+```
+
+One SQL round-trip per violating row. `PRAGMA foreign_key_check`
+on a corrupted DB can return thousands of violations. Each is a
+small SQL statement; round-trip overhead dominates.
+
+Detailed in [04-fk-violations.md](./04-fk-violations.md). Fix:
+batch by `(table_name, set-of-fk-cols, all-nullable-or-not)` into
+`WHERE rowid IN (...)` form.
+
+### Perf + correctness — assorted
+
+`failed_imports.py:13-20` queues one `FSEventTask` per failed
+import path. For a library with thousands of failed imports
+(corrupt CBRs, etc.), the librarian queue receives thousands of
+items processed serially.
+
+`adopt_folders.py:48-76` has `while folders_left:` with no
+iteration cap. If the importer fails to actually move folders
+(permission errors, FS races), this can loop until the
+abort_event is set externally.
+
+`cleanup_sessions` (`cleanup.py:175-208`) iterates
+`Session.objects.all()` to validate signatures. For users with
+years of accumulated anonymous sessions this could be tens of
+thousands of rows loaded into memory.
+
+Detailed in [05-misc.md](./05-misc.md).
+
+## Out of scope
+
+- **`update.py` codex auto-update** — runs `pip install --upgrade`,
+  not a perf concern; correctness is "did pip succeed?".
+- **`scheduled_time.py`** — 13 LOC of datetime arithmetic.
+- **`status.py`** — pure data classes.
+- **The nightly task list itself** — order/composition is a
+  product-design decision, not a perf concern.
+
+## Sub-plans
+
+Sub-plans are independent and can ship in any order. Suggested
+order is by impact, with correctness first:
+
+1. **[01-write-lock-correctness.md](./01-write-lock-correctness.md)** —
+   Wrap cleanup / vacuum / backup writers in `with
+   self.db_write_lock`. Eliminates the importer-vs-janitor race.
+   Single-file diff, ~30 LOC.
+2. **[02-fk-cleanup.md](./02-fk-cleanup.md)** —
+   `cleanup_fks` transaction wrap + iteration cap + log when cap
+   hit. ~40 LOC.
+3. **[04-fk-violations.md](./04-fk-violations.md)** —
+   Batch the per-rowid UPDATE/DELETE in `fix_foreign_keys`. ~50
+   LOC.
+4. **[03-cover-cleanup-fs.md](./03-cover-cleanup-fs.md)** —
+   Group cover stat() by parent dir + scandir, or thread-pool
+   parallelize. ~80 LOC.
+5. **[05-misc.md](./05-misc.md)** —
+   Failed-import re-queue batching, session validation chunking,
+   adopt-folders iteration cap. ~60 LOC across three small fixes.
+
+## Methodology
+
+For each finding:
+
+1. **Reproduce in a test fixture** where possible (concurrent
+   importer + janitor race is hard to reproduce reliably; rely on
+   logical reasoning + code review).
+2. **Apply the fix in isolation** — one sub-plan = one PR.
+3. **Verify correctness via diff against pre-fix DB state** for
+   non-trivial changes — e.g., for FK cleanup, dump
+   `(model, count)` pairs before and after a janitor run on a
+   test fixture and confirm equality.
+
+## Correctness invariants to preserve
+
+- **`db_write_lock` semantics**: only one Python-level writer at a
+  time. The janitor must respect this boundary.
+- **Cascading delete semantics**: `cleanup_fks`'s convergence
+  loop relies on the property that deleting an orphan can produce
+  more orphans (e.g., delete a Credit → its CreditPerson and
+  CreditRole may now be orphan). Any rewrite must preserve this.
+- **`PRAGMA foreign_key_check` accuracy**: SQLite only reports
+  violations for `FOREIGN KEYS` declared with `PRAGMA
+  foreign_keys=ON`. Codex's connection has this on. ✓
+- **`VACUUM` blocks all readers and writers** — the steady-state
+  PRAGMAs include WAL mode but VACUUM is the exception. The fix
+  is the lock acquisition (sub-plan 01), not skipping VACUUM.
+
+## Risks
+
+- **Long-held `db_write_lock` during VACUUM** — VACUUM on a
+  multi-GB DB can take minutes. While held, all writers (importer,
+  bookmark daemon, scribe) wait. Not a regression — current
+  behavior is "concurrent writes hit `database is locked`",
+  which is worse. Sub-plan 01 makes the wait explicit and
+  serializes cleanly.
+- **Cover stat() parallelism on slow FS** — running 32 threads
+  against an NFS share with a tight rate limit could trigger
+  server-side throttling. Cap concurrency to a small number
+  (e.g., 8) and document.
+- **FK cleanup iteration cap might fire on legitimate deep
+  cascades** — typical FK graphs converge in 2-3 passes. A cap of
+  10 is generous. If it fires, log loud (warn) so the user can
+  investigate.
+
+## References
+
+- `codex/librarian/worker.py` — `WorkerStatusAbortableBase` +
+  `db_write_lock` semantics
+- `codex/librarian/scribe/importer/pragmas.py` — importer's
+  scoped PRAGMA pattern (potentially reusable for vacuum)
+- PR #631 (importer transaction.atomic) — reference for
+  `with transaction.atomic()` usage
+- PR #634 (importer chunked apply) — reference for memory-bounded
+  chunking patterns

--- a/tasks/janitor-perf/01-write-lock-correctness.md
+++ b/tasks/janitor-perf/01-write-lock-correctness.md
@@ -1,0 +1,210 @@
+# 01 — Acquire `db_write_lock` for cleanup / vacuum / backup writers
+
+The headline correctness finding. **Ship first.**
+
+## The bug
+
+The integrity checks (`integrity/__init__.py`) correctly wrap
+their writes in `with self.db_write_lock`. The cleanup writers
+do not. Concrete sites:
+
+| Site | File:line | Writes |
+| --- | --- | --- |
+| `cleanup_fks` | `cleanup.py:138-155` | DELETE across 25 FK models |
+| `cleanup_custom_covers` | `cleanup.py:157-173` | DELETE on CustomCover |
+| `cleanup_sessions` | `cleanup.py:175-208` | DELETE on Session |
+| `cleanup_orphan_bookmarks` | `cleanup.py:210-220` | DELETE on Bookmark |
+| `cleanup_orphan_settings` | `cleanup.py:222-235` | DELETE on Settings |
+| `vacuum_db` | `vacuum.py:19-33` | `VACUUM` — exclusive at SQLite level |
+| `backup_db` | `vacuum.py:35-53` | `VACUUM INTO` — heavy reader |
+
+The codex daemon model serializes writers via the Python-level
+`db_write_lock`, held by the importer for the whole duration of
+an import. Without acquiring the same lock, the janitor can race
+with an in-flight import.
+
+## The race window
+
+Concrete failure mode for `cleanup_fks` racing with the importer:
+
+```
+T+0   Importer chunk N starts:
+        - bulk_create(Publisher, ["Indie Press LLC"], update_conflicts=True)
+        - bulk_create(Imprint, [...], parent=Publisher)
+        - bulk_create(Comic, [...], publisher=Publisher) ← not yet committed
+T+1   Janitor's nightly fires; cleanup_fks starts.
+T+2   Janitor queries Publisher for orphans (no inbound comic_set).
+        - Importer's Publisher row is visible (auto-committed by chunk's
+          atomic block on phase finish) but the referencing Comics
+          haven't reached their atomic block yet.
+        - Filter ``comic_set__isnull=True`` matches "Indie Press LLC".
+T+3   Janitor DELETEs "Indie Press LLC".
+T+4   Importer attempts to bulk_create the Comics referencing it
+        → IntegrityError, the whole importer chunk rolls back.
+        Comic data lost from this chunk; user must re-import.
+```
+
+This isn't theoretical. Codex polls libraries on a timer. If a
+poll triggers an import around midnight (the janitor's default
+schedule), the windows overlap.
+
+For VACUUM the failure is louder:
+
+```
+T+0   Importer holds db_write_lock; mid-bulk_create.
+T+1   Janitor calls vacuum_db. Acquires SQLite's exclusive lock.
+T+2   Importer's next bulk_create hits "database is locked".
+        Importer aborts mid-phase.
+```
+
+The Python-level `db_write_lock` exists precisely to prevent
+SQLite-level lock contention from surfacing as user-facing
+errors. Bypassing it loses that protection.
+
+## Fix sketch
+
+For each cleanup writer, wrap the body in `with self.db_write_lock`:
+
+```python
+def cleanup_fks(self) -> None:
+    """Clean up unused foreign keys."""
+    self.abort_event.clear()
+    status = JanitorCleanupTagsStatus(0)
+    try:
+        self.status_controller.start(status)
+        self.log.debug("Cleaning up orphan tags...")
+        with self.db_write_lock:
+            count = 1
+            while count:
+                count = self._cleanup_fks_one_level(status)
+        level = "INFO" if status.complete else "DEBUG"
+        self.log.log(level, f"Cleaned up {status.complete} unused tags.")
+    finally:
+        if self.abort_event.is_set():
+            self.log.info("Cleanup tags task aborted early.")
+        self.abort_event.clear()
+        self.status_controller.finish(status)
+```
+
+Same shape for `cleanup_custom_covers`, `cleanup_sessions`,
+`cleanup_orphan_bookmarks`, `cleanup_orphan_settings`,
+`vacuum_db`, `backup_db`.
+
+## Lock scope considerations
+
+**How long should the lock be held?** As short as possible while
+covering all writes. For each task:
+
+- `cleanup_fks`: hold across the whole `while count:` loop —
+  partial cleanups are valid but don't release the lock between
+  passes (avoids window for an importer to re-create the orphan).
+- `cleanup_custom_covers`: hold only across the DELETE, not the
+  per-row stat() loop. The stat() phase is read-only and
+  identifies the pks; release after collecting, re-acquire for
+  the delete.
+- `cleanup_sessions`: hold only across the DELETEs. The
+  validation loop is read-only.
+- `cleanup_orphan_bookmarks` / `cleanup_orphan_settings`: hold
+  across the single DELETE. Microscopic.
+- `vacuum_db`: hold across `VACUUM` only. PRAGMA optimize is
+  cheap and can be inside or outside.
+- `backup_db`: hold across `VACUUM INTO`. The OS-level rename of
+  the previous backup file does not need the lock.
+
+For `cleanup_custom_covers` specifically, the read/write split
+matters: the per-cover filesystem stat is the slow part, and
+holding `db_write_lock` for it would block the importer for
+seconds-to-minutes on slow storage.
+
+```python
+def cleanup_custom_covers(self) -> None:
+    """Clean up unused custom covers."""
+    covers = CustomCover.objects.only("path")
+    status = JanitorCleanupCoversStatus(0, covers.count())
+    delete_pks = []
+    try:
+        self.status_controller.start(status)
+        # Read-only phase: identify covers whose source files are gone.
+        # Lock not held — importer may write freely.
+        for cover in covers.iterator():
+            if not Path(cover.path).exists():
+                delete_pks.append(cover.pk)
+            status.increment_complete()
+        # Write phase: delete in one transaction under the lock.
+        with self.db_write_lock:
+            delete_qs = CustomCover.objects.filter(pk__in=delete_pks)
+            count, _ = delete_qs.delete()
+            status.complete = count
+    finally:
+        self.status_controller.finish(status)
+```
+
+The read-then-write split has a TOCTOU window: a cover could be
+re-created between the stat and the delete. Acceptable —
+worst case we delete a freshly-created cover, which is then
+re-discovered by the next poll. No data loss.
+
+## Cleanup coordination with VACUUM
+
+Pre-existing concern: `vacuum_db` calls `PRAGMA optimize`,
+`VACUUM`, then `PRAGMA wal_checkpoint(TRUNCATE)` in sequence.
+SQLite docs: "VACUUM cannot be called within a transaction. It
+also cannot be run on a database with open transactions." With
+the importer's atomic blocks plus codex's WAL mode, this can
+fail if any reader holds a snapshot.
+
+The importer-perf series's PR #631 added `importer_pragmas()`
+which fires `PRAGMA wal_checkpoint(TRUNCATE)` on import finish.
+After an import finishes the WAL is empty. Janitor running after
+a successful import is fine.
+
+But: between import finish and janitor start, a browser request
+might open a read transaction holding a snapshot. The lock
+acquisition won't help with that — `db_write_lock` is for
+writers, not readers.
+
+**Mitigation**: log a warning and retry once if VACUUM fails.
+Out of scope for this sub-plan (correctness first); document in
+the implementation comment.
+
+## Correctness invariants
+
+- **No write semantics change**: every DELETE that ran before
+  still runs; same rows are affected.
+- **`abort_event` honored within lock**: each writer's existing
+  `abort_event` checks remain, just inside the lock. If the user
+  aborts mid-cleanup, the lock is released correctly via the
+  context manager's `__exit__`.
+- **Lock acquisition order**: codex's other writers (importer,
+  bookmark daemon) acquire `db_write_lock` and never any other
+  lock. Adding the janitor to this set doesn't introduce ordering
+  hazards.
+
+## Risks
+
+- **Lock starvation**: a long cleanup_fks under the lock could
+  block a polled import for tens of seconds. Acceptable — the
+  alternative is data loss. The 5-pass cap from sub-plan 02
+  bounds the worst case.
+- **Backup duration**: `VACUUM INTO` on a 600k-comic DB can take
+  minutes. The importer waits during this. Schedule expectation:
+  backup runs at 4-6 am local; users should accept import lag.
+- **Read-then-write split TOCTOU** in `cleanup_custom_covers`:
+  documented above. Net effect is a no-op delete worst case.
+
+## Suggested commit shape
+
+One PR, one commit. Touches `cleanup.py` and `vacuum.py`. ~30
+LOC change.
+
+## Test plan
+
+- **Read-write race**: integration test that fires a synthetic
+  import + janitor concurrently. Without the fix, expect
+  occasional IntegrityError. With the fix, expect zero.
+- **Sequential ordering**: assert that `db_write_lock` is held
+  exactly across the relevant DB statements (mock the lock,
+  assert acquired before any DELETE/UPDATE/VACUUM SQL).
+- **Wall clock**: cleanup_fks under no concurrent load should be
+  ≤ 1.05× the pre-fix wall clock (lock acquisition itself is
+  microseconds; only contention costs).

--- a/tasks/janitor-perf/02-fk-cleanup.md
+++ b/tasks/janitor-perf/02-fk-cleanup.md
@@ -1,0 +1,176 @@
+# 02 — `cleanup_fks` transaction wrap + iteration cap
+
+Self-contained in `cleanup.py:138-155`. After the write-lock fix
+from sub-plan 01, this tightens semantics and adds a safety cap.
+
+## Hot path
+
+```python
+def cleanup_fks(self) -> None:
+    self.abort_event.clear()
+    status = JanitorCleanupTagsStatus(0)
+    try:
+        self.status_controller.start(status)
+        self.log.debug("Cleaning up orphan tags...")
+        count = 1
+        while count:
+            # Keep churning until we stop finding orphan tags.
+            count = self._cleanup_fks_one_level(status)
+        ...
+```
+
+`_cleanup_fks_one_level` walks all 25 FK models and fires a
+`filter(...).delete()` per model. Each `.delete()` is its own
+implicit transaction.
+
+## Issues
+
+### No iteration cap
+
+`while count:` runs until convergence with no upper bound. For
+correctly-formed data this converges in 2-3 passes. For
+pathological data (a corrupt DB where deletes don't actually
+remove rows, or a buggy reverse-rel map) this loops indefinitely
+until `abort_event` is set externally.
+
+### No transaction wrap
+
+Each `.delete()` is auto-committed. If aborted mid-loop:
+- Some models cleaned up
+- Others not
+- DB state is consistent (orphans are still orphans, just more
+  of them than before)
+- But: the convergence guarantee is partially broken — next run
+  picks up where this one left off, which is fine.
+
+The risk is more subtle: if the per-model deletes interleave with
+another writer (after sub-plan 01 lands, this is impossible; but
+defense-in-depth is cheap), wrapping the whole loop in
+`transaction.atomic` makes the whole cleanup all-or-nothing.
+
+### Per-model deletes generate many small queries
+
+25 models × P passes = 50-100 small DELETE statements per janitor
+run. Each is a separate round-trip. Bundling them under one
+`atomic` doesn't reduce SQL volume but coalesces fsyncs.
+
+## Fix sketch
+
+```python
+_FK_CLEANUP_MAX_PASSES = 10
+
+def cleanup_fks(self) -> None:
+    """Clean up unused foreign keys."""
+    self.abort_event.clear()
+    status = JanitorCleanupTagsStatus(0)
+    try:
+        self.status_controller.start(status)
+        self.log.debug("Cleaning up orphan tags...")
+        with self.db_write_lock, transaction.atomic():
+            for pass_num in range(_FK_CLEANUP_MAX_PASSES):
+                if self.abort_event.is_set():
+                    return
+                count = self._cleanup_fks_one_level(status)
+                if not count:
+                    break
+            else:
+                self.log.warning(
+                    f"FK cleanup hit {_FK_CLEANUP_MAX_PASSES}-pass cap "
+                    "without converging — investigate the reverse-relation "
+                    "map or the data graph."
+                )
+        level = "INFO" if status.complete else "DEBUG"
+        self.log.log(level, f"Cleaned up {status.complete} unused tags.")
+    finally:
+        if self.abort_event.is_set():
+            self.log.info("Cleanup tags task aborted early.")
+        self.abort_event.clear()
+        self.status_controller.finish(status)
+```
+
+The `for...else` idiom: `else` fires only if the loop completes
+without `break`. Cleanly expresses "we hit the cap; warn".
+
+## Why 10 passes?
+
+Empirical guess. Codex's FK graph depth is bounded by the
+hierarchy:
+
+```
+Identifier → Publisher → Imprint → Series → Volume → Comic
+                                        ↘ Credit ↗
+                                        ↘ StoryArcNumber → StoryArc
+```
+
+In any deletion order, a fully-orphaned chain converges in at
+most ~5 passes. 10 doubles that for safety. If a real DB ever
+fails to converge in 10, that's a data integrity bug worth
+investigating, not a fix-by-bumping-the-cap problem.
+
+## Optional: collapse to a single SQL pass
+
+The plan's secondary item: replace the Python-side multi-pass
+loop with a single SQL `WITH RECURSIVE` query. SQLite supports
+recursive CTEs, and the orphan-detection logic is mechanical:
+
+```sql
+WITH RECURSIVE orphans(table_name, pk) AS (
+    -- Base case: rows with no inbound refs
+    SELECT 'codex_publisher', id FROM codex_publisher
+        WHERE id NOT IN (SELECT publisher_id FROM codex_imprint WHERE publisher_id IS NOT NULL)
+        AND id NOT IN ...
+    -- Recursive: rows whose only refs are themselves orphans
+    UNION ALL
+    SELECT ...
+)
+```
+
+Generating this query from the rev-rel map is doable but
+non-trivial and SQLite-specific. Skip for now — the Python
+loop is fine after the cap.
+
+## Correctness invariants
+
+- **Convergence semantics preserved**: the loop still runs to
+  exhaustion (or to the cap), so the same orphans get deleted.
+- **Atomic rollback on exception**: if a DELETE fails mid-loop,
+  the entire cleanup rolls back to pre-cleanup state. Acceptable
+  — the alternative is "some models cleaned up, some not", which
+  is also valid but less predictable.
+- **`abort_event` still works**: checked at the top of each pass.
+  Abort during a pass lets that pass complete, then exits.
+- **`status.complete` accumulates correctly**: `_cleanup_fks_one_level`
+  already increments status.complete per model. Atomic wrap
+  doesn't change that — even on rollback the status counter is
+  Python-side and reflects what was attempted.
+
+## Risks
+
+- **Lock held longer**: with sub-plan 01's `db_write_lock`, the
+  atomic wrap means the lock spans all passes. Worst case is
+  ~10 passes × ~25 models × ~ms = single-digit seconds of lock
+  hold. Acceptable.
+- **`atomic` rolls back on uncaught exception**: by design.
+  Reduces partial-cleanup confusion.
+- **Cap warning on legitimate convergence**: a graph that
+  legitimately needs more than 10 passes is exotic. The warn-and-
+  continue pattern is right; user can re-run the janitor
+  manually if needed.
+
+## Suggested commit shape
+
+One PR, one commit. Builds on sub-plan 01 (which adds the
+`with self.db_write_lock` wrapper). ~40 LOC change to `cleanup.py`.
+
+## Test plan
+
+- **Convergence in N passes**: synthetic fixture with a 5-deep
+  orphan chain. Assert cleanup converges in ≤ 5 passes and
+  doesn't fire the cap warning.
+- **Cap fires loudly**: synthetic fixture where deletes don't
+  actually remove rows (mock the model). Assert the warning fires
+  exactly once.
+- **Atomic rollback**: inject an IntegrityError mid-loop. Assert
+  no partial state survives.
+- **Wall clock**: 600k-comic DB with no orphans should run
+  cleanup in ≤ 1s (one pass, returns 0, exits).

--- a/tasks/janitor-perf/03-cover-cleanup-fs.md
+++ b/tasks/janitor-perf/03-cover-cleanup-fs.md
@@ -1,0 +1,183 @@
+# 03 — `cleanup_custom_covers` filesystem stat batching
+
+Self-contained in `cleanup.py:157-173`. The per-row `Path.exists()`
+serializes filesystem I/O, which is fine on local SSD and painful
+on NFS / SMB / cloud-mounted media.
+
+## Hot path
+
+```python
+def cleanup_custom_covers(self) -> None:
+    covers = CustomCover.objects.only("path")
+    status = JanitorCleanupCoversStatus(0, covers.count())
+    delete_pks = []
+    try:
+        self.status_controller.start(status)
+        for cover in covers.iterator():
+            if not Path(cover.path).exists():
+                delete_pks.append(cover.pk)
+            status.increment_complete()
+        delete_qs = CustomCover.objects.filter(pk__in=delete_pks)
+        count, _ = delete_qs.delete()
+        ...
+```
+
+For each `CustomCover` row, `Path(cover.path).exists()` fires a
+`stat(2)` system call. On a 1k-cover library hosted on:
+
+| Storage | Per-stat | 1k covers | 10k covers |
+| --- | --- | --- | --- |
+| Local SSD | ~10 µs | ~10 ms | ~100 ms |
+| Local HDD | ~100 µs | ~100 ms | ~1 s |
+| NFS (LAN) | ~500 µs | ~500 ms | ~5 s |
+| NFS (slow) | ~5 ms | ~5 s | ~50 s |
+| SMB | ~10 ms | ~10 s | ~100 s |
+
+Codex users frequently host comic libraries on NAS storage with
+custom covers in subdirectories. The slow-NFS row is a real
+scenario.
+
+## Two-tier fix
+
+### Tier A: directory grouping + scandir
+
+Custom covers are typically organized hierarchically (one folder
+per series, one cover per folder). Grouping covers by parent
+directory lets us check existence via `os.scandir(parent)`
+once per directory, then membership-test against an in-memory
+set.
+
+```python
+from collections import defaultdict
+import os
+
+def cleanup_custom_covers(self) -> None:
+    covers = CustomCover.objects.only("pk", "path")
+    status = JanitorCleanupCoversStatus(0, covers.count())
+    delete_pks = []
+    # Group covers by their parent directory.
+    by_dir: dict[str, list[tuple[int, str]]] = defaultdict(list)
+    for cover in covers.iterator():
+        parent = os.path.dirname(cover.path)
+        by_dir[parent].append((cover.pk, os.path.basename(cover.path)))
+    try:
+        self.status_controller.start(status)
+        for parent, entries in by_dir.items():
+            try:
+                with os.scandir(parent) as it:
+                    present = {entry.name for entry in it}
+            except OSError:
+                # Parent directory missing entirely — every cover in
+                # this group is orphan.
+                present = frozenset()
+            for pk, basename in entries:
+                if basename not in present:
+                    delete_pks.append(pk)
+                status.increment_complete()
+            self.status_controller.update(status)
+        # Delete under the lock (sub-plan 01).
+        with self.db_write_lock:
+            count, _ = CustomCover.objects.filter(pk__in=delete_pks).delete()
+            status.complete = count
+    finally:
+        self.status_controller.finish(status)
+```
+
+scandir cost: O(directory size), one syscall + read. For a
+directory with 100 cover files, scandir reads them all in ~one
+NFS round-trip via READDIR. Beats 100 individual stat() calls.
+
+For typical custom-cover layouts (1 cover per series folder),
+this is identical-cost (one scandir per cover). For
+many-covers-per-folder layouts, it's a big win. Worst case is
+exactly the same as before.
+
+### Tier B: thread pool for unavoidable per-cover stats
+
+Some covers might not group well by parent dir (e.g., one cover
+per arbitrary path). For those, stat() in a thread pool. I/O-
+bound, threads work fine; no GIL contention on the syscalls.
+
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+_COVER_STAT_WORKERS = 8
+
+def _check_cover_exists(cover):
+    return cover.pk, Path(cover.path).exists()
+
+with ThreadPoolExecutor(max_workers=_COVER_STAT_WORKERS) as executor:
+    futures = [executor.submit(_check_cover_exists, c) for c in covers]
+    for future in as_completed(futures):
+        pk, exists = future.result()
+        if not exists:
+            delete_pks.append(pk)
+        status.increment_complete()
+        self.status_controller.update(status)
+```
+
+Don't use both A and B together — Tier A is strictly better when
+covers group cleanly, and Tier B is the fallback for the rare
+cases where they don't. Either alone delivers the win.
+
+**Recommendation: Tier A.** Simpler, no concurrency primitives,
+and matches typical layout. If profiling reveals a layout where
+Tier A doesn't help, add Tier B as a follow-up.
+
+## Concurrency budget
+
+If we go with Tier B (thread pool), worker count needs a cap:
+
+- Local SSD: more workers don't help; one syscall per cover is
+  the floor.
+- NFS server with rate limit: 8-16 workers is a reasonable
+  upper bound. Beyond that, the server starts queueing.
+- Slow USB-attached disks: 1-4 workers max — a busy spindle
+  serves stats slower than they queue.
+
+Default 8 is conservative; expose as `IMPORTER_COVER_STAT_WORKERS`
+for tuning.
+
+## Correctness invariants
+
+- **`Path.exists()` semantics preserved**: scandir's `entry.name`
+  membership is equivalent to `Path(parent / name).exists()` for
+  files. Symlinks are followed by both. Permission errors that
+  hide a directory entry from scandir would have failed
+  `Path.exists()` too.
+- **Pre-existing TOCTOU**: a cover file created mid-stat would
+  also race `Path.exists()`. No regression.
+- **Empty-parent directory case**: scandir on a missing parent
+  raises OSError; treat as "nothing exists in that directory" so
+  every cover claiming a path under it gets deleted. Same as
+  pre-fix per-cover behavior for missing parents.
+
+## Risks
+
+- **Permission errors on parent**: scandir requires read access
+  on the directory. If the codex process can stat() individual
+  files but can't readdir() the parent, scandir fails for the
+  whole group while per-file stat would succeed. Mitigation:
+  catch OSError per directory; fall back to per-file stat for
+  that group only.
+- **Symlink-as-directory**: scandir follows the symlink to read
+  entries; behavior matches `Path.exists()`.
+- **Very large directories**: scandir on a 100k-entry directory
+  builds an in-memory set of ~10 MB. Fine.
+
+## Suggested commit shape
+
+One PR. Touches `cleanup.py`. ~80 LOC including the directory-
+grouping helper. No new dependencies.
+
+## Test plan
+
+- **Functional equivalence**: synthetic fixture with covers in
+  various states (present, missing, parent-missing, symlinked).
+  Assert post-cleanup state matches pre-fix code byte-for-byte.
+- **Performance regression test**: time a 5k-cover cleanup on a
+  fixture where all covers share one parent directory. Pre-fix:
+  5k stat() calls. Post-fix: 1 scandir + 5k set lookups. Expect
+  10-100× wall-clock drop on remote storage.
+- **Permission edge cases**: directory readable but not statable
+  (the inverse of normal). Confirm fallback to per-file stat.

--- a/tasks/janitor-perf/04-fk-violations.md
+++ b/tasks/janitor-perf/04-fk-violations.md
@@ -1,0 +1,160 @@
+# 04 — Batch per-rowid UPDATE/DELETE in `fix_foreign_keys`
+
+`integrity/foreign_keys.py:142-158` does one SQL statement per
+violating row. `PRAGMA foreign_key_check` on a corrupt DB can
+return thousands of violations; round-trip overhead dominates.
+
+## Hot path
+
+```python
+for table_name, rows in violations.items():
+    fix_comic_pks |= _collect_comic_ids_for_table(...)
+
+    for rowid, fk_cols in rows.items():
+        all_nullable = all(nullable for _, nullable in fk_cols)
+
+        if all_nullable:
+            set_clauses = ", ".join(f'"{col}" = NULL' for col, _ in fk_cols)
+            cursor.execute(
+                f'UPDATE "{table_name}" SET {set_clauses} WHERE rowid = %s',
+                [rowid],
+            )
+            nulled += cursor.rowcount
+        else:
+            cursor.execute(
+                f'DELETE FROM "{table_name}" WHERE rowid = %s',
+                [rowid],
+            )
+            deleted += cursor.rowcount
+```
+
+For each violating row: one round-trip. On a DB that's been
+unlucky enough to have FK corruption, "thousands of violations"
+isn't unrealistic (e.g., a power-cut during a bulk delete).
+
+## Why this is N+1
+
+The pattern shape:
+- Same SQL template across rows (UPDATE or DELETE)
+- Different rowids per row
+- For UPDATE: same SET clauses per (table, fk_col_set)
+
+Bunching by `(table, fk_col_set, all_nullable)` produces
+`WHERE rowid IN (...)` queries — one per group instead of one
+per row.
+
+## Fix sketch
+
+```python
+from collections import defaultdict
+
+def _fix_fk_violations(
+    cursor, violations: dict[str, dict[int, list[tuple[str, bool]]]]
+) -> tuple[int, int, set[int]]:
+    """Null or delete rows with broken foreign keys.
+
+    Bunches per-row fixes by (table, fk_col_set, all_nullable) so
+    each batch is one ``WHERE rowid IN (...)`` query rather than
+    one round-trip per row.
+    """
+    nulled = 0
+    deleted = 0
+    fix_comic_pks: set[int] = set()
+
+    for table_name, rows in violations.items():
+        fix_comic_pks |= _collect_comic_ids_for_table(
+            cursor, table_name, set(rows.keys())
+        )
+
+        # Group rows by (frozen fk_col_set, all_nullable).
+        groups: dict[tuple, list[int]] = defaultdict(list)
+        for rowid, fk_cols in rows.items():
+            cols = tuple(sorted(col for col, _ in fk_cols))
+            all_nullable = all(nullable for _, nullable in fk_cols)
+            groups[(cols, all_nullable)].append(rowid)
+
+        for (cols, all_nullable), rowids in groups.items():
+            # Stay under SQLite's 32766-variable cap.
+            for start in range(0, len(rowids), _SQLITE_MAX_VARS):
+                batch = rowids[start : start + _SQLITE_MAX_VARS]
+                placeholders = ",".join(["%s"] * len(batch))
+                if all_nullable:
+                    set_clauses = ", ".join(f'"{col}" = NULL' for col in cols)
+                    cursor.execute(
+                        f'UPDATE "{table_name}" SET {set_clauses} '  # noqa: S608
+                        f"WHERE rowid IN ({placeholders})",
+                        batch,
+                    )
+                    nulled += cursor.rowcount
+                else:
+                    cursor.execute(
+                        f'DELETE FROM "{table_name}" '  # noqa: S608
+                        f"WHERE rowid IN ({placeholders})",
+                        batch,
+                    )
+                    deleted += cursor.rowcount
+
+    return nulled, deleted, fix_comic_pks
+```
+
+Where `_SQLITE_MAX_VARS = 32000` (leaves headroom under SQLite's
+32766 variable cap).
+
+## Query count
+
+For a hypothetical 10,000-violation DB across 5 tables:
+
+| | per call |
+| --- | --- |
+| **Before** | 10,000 SQL statements |
+| **After** | ~5-10 SQL statements (one per table×col-set×nullable group, each batched at 32k vars) |
+
+Each statement does the same work in SQL terms — same rows
+updated/deleted. The win is round-trip overhead.
+
+## Correctness invariants
+
+- **Same rows updated/deleted as before**: `WHERE rowid IN (...)`
+  with the same set of rowids hits the same rows as N individual
+  `WHERE rowid = ?` statements.
+- **`cursor.rowcount` accumulates correctly**: with batched
+  statements, `rowcount` returns rows affected by that statement.
+  Sum across batches still equals total rows affected.
+- **Mixed-nullable rows in same table**: a table can have rows
+  whose violations are all-nullable AND rows whose violations
+  include a non-nullable column. The grouping handles this — the
+  nullable group nulls, the non-nullable group deletes. Same
+  per-row decision as before.
+- **`_collect_comic_ids_for_table`** runs once per table before
+  the grouping; comics-to-update set is unchanged.
+
+## Risks
+
+- **Variable count**: stay well under 32766. 32000 leaves headroom
+  for SQLite internal use.
+- **`UPDATE ... SET col=NULL ... WHERE rowid IN (...)`**: SQLite
+  applies the SET to every matching row. Same as N individual
+  UPDATEs.
+- **Partial application on error**: if a batch's UPDATE fails
+  (e.g., constraint violation), the whole batch's rows are
+  unaffected. Same as N individual statements where the failure
+  point would split partial-success. Net behavior is "all or
+  nothing per batch", which is safer.
+
+## Suggested commit shape
+
+One PR. Touches `integrity/foreign_keys.py`. ~50 LOC change. The
+helper logic stays the same; only `_fix_fk_violations` is
+restructured.
+
+## Test plan
+
+- **Functional equivalence**: synthetic DB with 100 violations
+  across 3 tables (mix of nullable / non-nullable columns).
+  Assert post-fix DB state matches the per-row code's output
+  byte-for-byte.
+- **Variable cap**: synthetic DB with 50,000 violations in one
+  table. Assert no `too many SQL variables` error; batching
+  splits at 32000.
+- **`cursor.rowcount` totals match**: assert sum of batch
+  rowcounts equals number of input rowids.

--- a/tasks/janitor-perf/05-misc.md
+++ b/tasks/janitor-perf/05-misc.md
@@ -1,0 +1,207 @@
+# 05 — Miscellaneous correctness + perf cleanups
+
+Three small fixes that don't justify their own sub-plan but are
+worth landing together. Each is independent; pick whichever order
+suits review.
+
+## A — `force_update_all_failed_imports` queue spam
+
+`failed_imports.py:13-20`:
+
+```python
+def _force_update_failed_imports(self, library_id) -> None:
+    failed_import_paths = FailedImport.objects.filter(
+        library=library_id
+    ).values_list("path", flat=True)
+    for path in failed_import_paths:
+        event = FSEvent(src_path=path, change=FSChange.modified)
+        task = FSEventTask(library_id, event)
+        self.librarian_queue.put(task)
+```
+
+For a library with thousands of failed imports (typical: corrupt
+CBRs that the user wants to retry after a comicbox upgrade), this
+puts thousands of `FSEventTask` items on the librarian queue. The
+librarian processes them serially — each fires its own debounce,
+its own filesystem stat, its own database lookup. Per-path
+overhead dominates.
+
+### Fix
+
+`FSEventTask` already exists for single events; adding a
+multi-event variant is one option but the simpler win is to
+short-circuit the per-event handling:
+
+```python
+def _force_update_failed_imports(self, library_id) -> None:
+    failed_import_paths = tuple(
+        FailedImport.objects.filter(library=library_id).values_list(
+            "path", flat=True
+        )
+    )
+    if not failed_import_paths:
+        return
+    # One ImportTask covering all paths instead of N FSEventTasks
+    # routed individually through the watcher debounce.
+    task = ImportTask(
+        library_id=library_id,
+        files_modified=frozenset(failed_import_paths),
+    )
+    self.librarian_queue.put(task)
+```
+
+This dispatches the importer once with all paths, exactly the
+shape the importer expects. The per-task overhead drops from
+O(N paths) to O(1).
+
+**Caveat**: `ImportTask` skips the FS-event debounce that
+`FSEventTask` flows through. For a "force" operation that's the
+correct behavior — the user explicitly requested re-import.
+
+### Risk
+
+If the watcher's debounce was de-duplicating identical
+re-events, that's lost. In practice the FailedImport table only
+contains one row per path, so the debounce wasn't doing
+de-duplication work — it was just adding overhead.
+
+## B — `adopt_orphan_folders` iteration cap
+
+`adopt_folders.py:48-76`:
+
+```python
+def adopt_orphan_folders(self) -> None:
+    self.abort_event.clear()
+    ...
+    for library in libraries.iterator():
+        folders_left = True
+        while folders_left:
+            if self.abort_event.is_set():
+                return
+            folders_left, count = self._adopt_orphan_folders_for_library(library)
+            total_count += count
+```
+
+`while folders_left:` continues as long as
+`_adopt_orphan_folders_for_library` keeps reporting orphans. If
+the importer fails to actually move them (permission errors, FS
+race), this can loop indefinitely.
+
+### Fix
+
+Add an iteration cap. Same shape as sub-plan 02:
+
+```python
+_ADOPT_FOLDERS_MAX_PASSES = 10
+
+for library in libraries.iterator():
+    for pass_num in range(_ADOPT_FOLDERS_MAX_PASSES):
+        if self.abort_event.is_set():
+            return
+        folders_left, count = self._adopt_orphan_folders_for_library(library)
+        total_count += count
+        if not folders_left:
+            break
+    else:
+        self.log.warning(
+            f"Adopt orphan folders for {library.path} hit "
+            f"{_ADOPT_FOLDERS_MAX_PASSES}-pass cap without "
+            "converging — folders may be unreachable or unwriteable."
+        )
+```
+
+10 passes is generous; legitimate orphan-folder graphs converge
+in 1-2 passes (each pass moves orphans to their correct parent
+position; second pass catches the rare case where moving an
+orphan reveals more orphans).
+
+### Risk
+
+Cap firing on a real-world case is unlikely but possible (e.g.,
+a library with thousands of orphan folders all sharing a missing
+parent). The warn-and-continue path lets the next nightly retry;
+no data loss.
+
+## C — `cleanup_sessions` chunked validation
+
+`cleanup.py:175-208`:
+
+```python
+for encoded_session in Session.objects.all():
+    try:
+        signing.loads(...)
+    except Exception:
+        bad_session_keys.add(encoded_session.session_key)
+```
+
+`Session.objects.all()` materializes all sessions. For a long-
+running install with years of accumulated anonymous sessions
+(opens before login, etc.), this can be tens of thousands of
+rows pulled into RAM at once.
+
+### Fix
+
+Use `.iterator()` to stream + validate:
+
+```python
+bad_session_keys = []
+for encoded_session in Session.objects.only("session_key", "session_data").iterator(chunk_size=1000):
+    try:
+        signing.loads(
+            encoded_session.session_data,
+            salt=salt,
+            serializer=serializer,
+        )
+    except Exception:
+        bad_session_keys.append(encoded_session.session_key)
+
+if bad_session_keys:
+    # Batch the delete to stay under SQLite's variable cap.
+    for start in range(0, len(bad_session_keys), 30000):
+        batch = bad_session_keys[start : start + 30000]
+        Session.objects.filter(session_key__in=batch).delete()
+```
+
+`iterator(chunk_size=1000)` keeps memory bounded. The
+`.only("session_key", "session_data")` skips loading
+`expire_date` (already filtered separately).
+
+### Risk
+
+`iterator()` doesn't play with prefetch_related (none used
+here, ✓). On SQLite specifically, iterator with chunk_size still
+works correctly per Django docs.
+
+## Suggested commit shape
+
+Three commits in one PR (each independently revertable):
+
+1. **`failed_imports: dispatch single ImportTask instead of N FSEventTasks`** — A. ~10 LOC change to `failed_imports.py`.
+2. **`adopt_folders: iteration cap with warning`** — B. ~15 LOC change to `adopt_folders.py`.
+3. **`cleanup_sessions: stream + chunk session validation`** — C. ~20 LOC change to `cleanup.py`.
+
+Total ~45-60 LOC across three files. No correctness regression
+in any of them.
+
+## Correctness invariants
+
+- **A — Same paths re-imported**: The ImportTask(files_modified)
+  flow is the established shape for "re-import these specific
+  paths" used by the importer. Honors all the importer's existing
+  per-path handling (mtime check, comicbox extraction, etc.).
+- **B — Cap warning fires loud**: log level `warning`, message
+  references the specific library so the user can investigate.
+  Same level the FK cleanup cap uses.
+- **C — Streaming preserves validation logic**: `signing.loads`
+  is per-row; iteration order doesn't matter; deleted rows don't
+  affect ongoing iteration (Django's `.iterator()` uses a server-
+  side cursor or fetchmany).
+
+## Test plan
+
+- **A — Single-task dispatch**: assert one `ImportTask` queued
+  per library with all failed-import paths in `files_modified`.
+- **B — Cap fires once on synthetic non-converging fixture**.
+- **C — Memory ceiling**: validate 10,000 synthetic sessions
+  under `tracemalloc`; assert peak < 50 MB (chunked) vs ~500 MB
+  (pre-fix all-at-once).


### PR DESCRIPTION
## Summary

Meta-plan + 5 sub-plans for the librarian janitor (~1200 LOC across 11 files at `codex/librarian/scribe/janitor/`). Plan-only — no code changes. Mirrors the [#621](https://github.com/ajslater/codex/pull/621) / [#625](https://github.com/ajslater/codex/pull/625) / [#627](https://github.com/ajslater/codex/pull/627) plan-capture pattern.

## Headline finding (correctness)

`cleanup_fks` / `cleanup_custom_covers` / `cleanup_sessions` / `cleanup_orphan_bookmarks` / `cleanup_orphan_settings` / `vacuum_db` / `backup_db` all write to the DB **without acquiring `db_write_lock`**. The integrity checks (`foreign_key_check`, `integrity_check`, `fts_*`) lock correctly; the cleanup writers are the gap.

Concurrent with a poll-driven import this can race:

1. Importer creates Publisher "Indie Press LLC" in chunk N (visible in DB).
2. Janitor `cleanup_fks` finds it has no inbound `comic_set` refs (because the importer's referencing Comics haven't committed yet) → deletes it.
3. Importer commits Comics referencing the now-deleted Publisher → `IntegrityError`, importer chunk rolls back.

Sub-plan 01 fixes this. **Ship first** — small diff, biggest risk reduction.

## Sub-plans (suggested ship order)

1. **`01-write-lock-correctness.md`** — `db_write_lock` for all cleanup + vacuum + backup writers. ~30 LOC. Correctness fix.
2. **`02-fk-cleanup.md`** — `cleanup_fks` transaction wrap + 10-pass cap with warning. ~40 LOC.
3. **`04-fk-violations.md`** — Batch per-rowid UPDATE/DELETE in `fix_foreign_keys` to `WHERE rowid IN (...)`. ~50 LOC.
4. **`03-cover-cleanup-fs.md`** — Per-cover `Path.exists()` → directory-grouped `os.scandir` (orders-of-magnitude wall-clock drop on NFS/SMB). ~80 LOC.
5. **`05-misc.md`** — Failed-imports re-queue (N FSEventTasks → 1 ImportTask), adopt_folders iteration cap, cleanup_sessions chunked validation. ~60 LOC across three small fixes.

## Test plan
- [ ] Review `00-meta.md` for accuracy of surface map and findings
- [ ] Confirm sub-plan ordering matches your priorities
- [ ] Flag any sub-plan that needs more detail or has a wrong premise
- [ ] Approve as planning artifact (no code changes); implementation lands in follow-up PRs per sub-plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)