### PR TITLE
Janitor correctness: acquire db_write_lock for cleanup / vacuum / backup

### DIFF
--- a/codex/librarian/scribe/janitor/cleanup.py
+++ b/codex/librarian/scribe/janitor/cleanup.py
@@ -142,10 +142,16 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         try:
             self.status_controller.start(status)
             self.log.debug("Cleaning up orphan tags...")
-            count = 1
-            while count:
-                # Keep churning until we stop finding orphan tags.
-                count = self._cleanup_fks_one_level(status)
+            # Hold ``db_write_lock`` across all passes so a concurrent
+            # importer can't re-introduce a parent FK between the
+            # check that found it orphaned and the DELETE that removes
+            # it. The integrity-check writers in ``integrity/`` use the
+            # same pattern; cleanup was previously missing it.
+            with self.db_write_lock:
+                count = 1
+                while count:
+                    # Keep churning until we stop finding orphan tags.
+                    count = self._cleanup_fks_one_level(status)
             level = "INFO" if status.complete else "DEBUG"
             self.log.log(level, f"Cleaned up {status.complete} unused tags.")
         finally:
@@ -162,13 +168,22 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         try:
             self.status_controller.start(status)
             self.log.debug("Cleaning up db custom covers with no source images...")
+            # Read-only phase: per-cover filesystem stat to identify
+            # orphans. Lock not held — the importer may continue to
+            # write, and the slow-storage stat loop (NFS / SMB) would
+            # otherwise block the importer for seconds-to-minutes.
             for cover in covers.iterator():
                 if not Path(cover.path).exists():
                     delete_pks.append(cover.pk)
                 status.increment_complete()
-            delete_qs = CustomCover.objects.filter(pk__in=delete_pks)
-            count, _ = delete_qs.delete()
-            status.complete = count
+            # Write phase: the DELETE goes through under the lock so a
+            # concurrent importer can't be mid-bulk_create on the same
+            # rows. TOCTOU window is acceptable: a cover re-created
+            # between stat and delete just gets re-discovered next poll.
+            with self.db_write_lock:
+                delete_qs = CustomCover.objects.filter(pk__in=delete_pks)
+                count, _ = delete_qs.delete()
+                status.complete = count
         finally:
             self.status_controller.finish(status)
 
@@ -177,10 +192,15 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         status = JanitorCleanupSessionsStatus()
         try:
             self.status_controller.start(status)
-            qs = Session.objects.filter(expire_date__lt=Now())
-            count, _ = qs.delete()
+            # Expired-session DELETE under the lock.
+            with self.db_write_lock:
+                qs = Session.objects.filter(expire_date__lt=Now())
+                count, _ = qs.delete()
             if count:
                 self.log.info(f"Deleted {count} expired sessions.")
+            # Read-only signature validation phase. Holding the lock
+            # across this loop would block the importer for as long as
+            # the validation takes; release between the two phases.
             bad_session_keys = set()
             store = Session.get_session_store_class()()
             salt = store.key_salt  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
@@ -201,8 +221,11 @@ class JanitorCleanup(JanitorUpdateFailedImports):
                     bad_session_keys.add(encoded_session.session_key)
 
             if bad_session_keys:
-                bad_sessions = Session.objects.filter(session_key__in=bad_session_keys)
-                count, _ = bad_sessions.delete()
+                with self.db_write_lock:
+                    bad_sessions = Session.objects.filter(
+                        session_key__in=bad_session_keys
+                    )
+                    count, _ = bad_sessions.delete()
                 self.log.info(f"Deleted {count} corrupt sessions.")
         finally:
             self.status_controller.finish(status)
@@ -212,8 +235,9 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         status = JanitorCleanupBookmarksStatus()
         try:
             self.status_controller.start(status)
-            orphan_bms = Bookmark.objects.filter(**_BOOKMARK_FILTER)
-            count, _ = orphan_bms.delete()
+            with self.db_write_lock:
+                orphan_bms = Bookmark.objects.filter(**_BOOKMARK_FILTER)
+                count, _ = orphan_bms.delete()
             level = "INFO" if count else "DEBUG"
             self.log.log(level, f"Deleted {count} orphan bookmarks.")
         finally:
@@ -225,10 +249,11 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         try:
             self.status_controller.start(status)
             total = 0
-            for model in (SettingsBrowser, SettingsReader):
-                orphans = model.objects.filter(**_SETTINGS_ORPHAN_FILTER)
-                count, _ = orphans.delete()
-                total += count
+            with self.db_write_lock:
+                for model in (SettingsBrowser, SettingsReader):
+                    orphans = model.objects.filter(**_SETTINGS_ORPHAN_FILTER)
+                    count, _ = orphans.delete()
+                    total += count
             level = "INFO" if total else "DEBUG"
             self.log.log(level, f"Deleted {total} orphan settings rows.")
         finally:

--- a/codex/librarian/scribe/janitor/vacuum.py
+++ b/codex/librarian/scribe/janitor/vacuum.py
@@ -22,7 +22,11 @@ class JanitorVacuum(JanitorIntegrity):
         try:
             self.status_controller.start(status)
             old_size = DB_PATH.stat().st_size
-            with connection.cursor() as cursor:
+            # ``VACUUM`` takes an exclusive lock at the SQLite level.
+            # Acquire ``db_write_lock`` so a concurrent importer (or
+            # any other Python-level writer) waits cleanly instead of
+            # surfacing "database is locked" mid-bulk_create.
+            with self.db_write_lock, connection.cursor() as cursor:
                 cursor.execute("PRAGMA optimize")
                 cursor.execute("VACUUM")
                 cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -42,7 +46,12 @@ class JanitorVacuum(JanitorIntegrity):
             if backup_path.is_file():
                 backup_path.replace(_OLD_BACKUP_PATH)
             path = str(backup_path)
-            with connection.cursor() as cursor:
+            # ``VACUUM INTO`` reads the entire DB and would race with
+            # an in-flight writer. Same lock-acquisition pattern as
+            # ``vacuum_db`` above. The OS-level ``replace`` /
+            # ``unlink`` of the old backup file does not need the lock
+            # — those are filesystem ops on the backup, not the DB.
+            with self.db_write_lock, connection.cursor() as cursor:
                 cursor.execute(f"VACUUM INTO {path!r}")
             _OLD_BACKUP_PATH.unlink(missing_ok=True)
             self.log.info(f"Backed up database to {path}")


### PR DESCRIPTION
## Summary

Implements `tasks/janitor-perf/01-write-lock-correctness.md` from PR #635. The headline correctness finding from the janitor plan; ships first since the rest of the sub-plans are perf wins on top of correct foundations.

## The bug

The integrity checks (`foreign_key_check`, `integrity_check`, `fts_*`) correctly wrap their writes in `with self.db_write_lock`. The cleanup writers and VACUUM-style operations do not. Without that lock the janitor races a concurrent poll-driven import:

```
T+0  Importer creates Publisher "Indie Press LLC" in chunk N
     (committed by the chunk's atomic block).
T+1  Janitor cleanup_fks queries Publisher for orphans. The
     referencing Comics haven't reached their atomic block yet —
     the Publisher looks orphaned.
T+2  Janitor DELETEs the Publisher.
T+3  Importer's bulk_create for Comics referencing it raises
     IntegrityError; the whole importer chunk rolls back.
```

VACUUM / VACUUM INTO take SQLite-level exclusive locks; without the Python-level lock, the importer's next `bulk_create` surfaces `database is locked` instead of waiting cleanly.

## Lock-scope decisions

| Site | Scope |
| --- | --- |
| `cleanup_fks` | Full while-count loop (releasing between passes would re-open the race) |
| `cleanup_custom_covers` | DELETE only — leave the per-cover `Path.exists()` loop unlocked so NFS/SMB stat latency doesn't block the importer |
| `cleanup_sessions` | Expired-DELETE + corrupt-DELETE; validation loop is read-only and stays unlocked |
| `cleanup_orphan_bookmarks` | Single DELETE |
| `cleanup_orphan_settings` | Single DELETE per model, all under one lock |
| `vacuum_db` | `PRAGMA optimize` + `VACUUM` + `wal_checkpoint` under one acquisition |
| `backup_db` | `VACUUM INTO` only; backup-file rename/unlink stay outside (filesystem ops on the backup, not the DB) |

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] Concurrent-load integration test: kick off an import + janitor in parallel against a fixture; without the fix, expect IntegrityError on a small fraction of runs. With the fix, expect zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)