### PR TITLE
Janitor cleanup_custom_covers: directory-grouped scandir

### DIFF
--- a/codex/librarian/scribe/janitor/cleanup.py
+++ b/codex/librarian/scribe/janitor/cleanup.py
@@ -1,5 +1,7 @@
 """Clean up the database after moves or imports."""
 
+import os
+from collections import defaultdict
 from pathlib import Path
 from types import MappingProxyType
 
@@ -191,26 +193,89 @@ class JanitorCleanup(JanitorUpdateFailedImports):
             self.abort_event.clear()
             self.status_controller.finish(status)
 
+    @staticmethod
+    def _group_covers_by_parent(covers) -> dict[str, list[tuple[int, str]]]:
+        """
+        Bunch (pk, basename) entries by parent directory.
+
+        Cover layouts are typically one-cover-per-series-folder, so
+        each parent ends up with one entry. For installs that share a
+        directory across many covers, this groups them so the parent
+        gets one ``scandir`` instead of N ``stat`` calls.
+        """
+        by_dir: dict[str, list[tuple[int, str]]] = defaultdict(list)
+        for cover in covers:
+            cover_path = Path(cover.path)
+            by_dir[str(cover_path.parent)].append((cover.pk, cover_path.name))
+        return by_dir
+
+    @staticmethod
+    def _scan_parent_for_present_names(parent: str) -> frozenset[str] | None:
+        """
+        Return the set of filenames in ``parent``, or None on read failure.
+
+        ``None`` is the "fall back to per-file ``Path.exists()``" signal;
+        callers handle it by treating each cover in the group as
+        unverified rather than guessing at orphan-vs-present.
+        """
+        try:
+            with os.scandir(parent) as it:
+                return frozenset(entry.name for entry in it)
+        except FileNotFoundError:
+            # Parent directory itself is gone — every cover claiming a
+            # path under it is orphan. Empty set is correct.
+            return frozenset()
+        except OSError:
+            # Permission error, transient FS hiccup, etc. — fall back.
+            return None
+
+    def _collect_orphan_cover_pks(
+        self, by_dir: dict[str, list[tuple[int, str]]], status
+    ) -> list[int]:
+        """Walk parent directories once via scandir and flag orphans."""
+        delete_pks: list[int] = []
+        for parent, entries in by_dir.items():
+            present = self._scan_parent_for_present_names(parent)
+            for pk, basename in entries:
+                if present is None:
+                    # scandir failed for this parent; preserve
+                    # pre-fix behavior with a per-file Path.exists().
+                    if not Path(parent, basename).exists():
+                        delete_pks.append(pk)
+                elif basename not in present:
+                    delete_pks.append(pk)
+                status.increment_complete()
+            self.status_controller.update(status)
+        return delete_pks
+
     def cleanup_custom_covers(self) -> None:
-        """Clean up unused custom covers."""
-        covers = CustomCover.objects.only("path")
-        status = JanitorCleanupCoversStatus(0, covers.count())
-        delete_pks = []
+        """
+        Clean up unused custom covers.
+
+        Replaces the prior per-cover ``Path.exists()`` loop with a
+        directory-grouped ``os.scandir`` pass. For typical cover
+        layouts one parent ↔ one cover, the wall-clock is identical;
+        for any layout with multiple covers per parent (or for
+        many covers under sibling directories), the parent's
+        ``readdir`` round-trip replaces N individual ``stat``
+        round-trips. Big win on NFS / SMB / cloud-mounted media
+        where each ``stat`` is single-digit milliseconds.
+        """
+        # Materialize once so we can group by parent directory before
+        # the FS pass. ``only`` keeps the load lean.
+        covers = list(CustomCover.objects.only("pk", "path"))
+        status = JanitorCleanupCoversStatus(0, len(covers))
         try:
             self.status_controller.start(status)
             self.log.debug("Cleaning up db custom covers with no source images...")
-            # Read-only phase: per-cover filesystem stat to identify
-            # orphans. Lock not held — the importer may continue to
-            # write, and the slow-storage stat loop (NFS / SMB) would
-            # otherwise block the importer for seconds-to-minutes.
-            for cover in covers.iterator():
-                if not Path(cover.path).exists():
-                    delete_pks.append(cover.pk)
-                status.increment_complete()
-            # Write phase: the DELETE goes through under the lock so a
-            # concurrent importer can't be mid-bulk_create on the same
-            # rows. TOCTOU window is acceptable: a cover re-created
-            # between stat and delete just gets re-discovered next poll.
+            by_dir = self._group_covers_by_parent(covers)
+            # Read-only phase: lock not held — importer can keep writing
+            # while we walk slow storage.
+            delete_pks = self._collect_orphan_cover_pks(by_dir, status)
+            # Write phase under the lock so a concurrent importer can't
+            # be mid-bulk_create on the same rows. TOCTOU window is
+            # acceptable: a cover re-created between scan and delete
+            # just gets re-discovered next poll.
             with self.db_write_lock:
                 delete_qs = CustomCover.objects.filter(pk__in=delete_pks)
                 count, _ = delete_qs.delete()


### PR DESCRIPTION
## Summary

Implements `tasks/janitor-perf/03-cover-cleanup-fs.md` from PR #635. Fourth in the janitor series after #636 / #637 / #638.

The per-cover `Path.exists()` loop is fine on local SSD (microseconds per stat) but painful on NFS / SMB / cloud-mounted media (up to single-digit milliseconds per stat). For a library with 5,000 custom covers on remote storage that's tens of seconds of pure I/O wait per janitor run.

## Change

Group covers by parent directory once, then walk parents with `os.scandir` — one `readdir` round-trip per parent, with set membership in Python instead of a syscall per cover.

Three new private helpers:
- `_group_covers_by_parent` — builds `{parent_dir: [(pk, basename), ...]}`
- `_scan_parent_for_present_names` — returns present-set or `None` on read failure
- `_collect_orphan_cover_pks` — walks the grouped covers using each parent's present-set, falling back to per-file `Path.exists()` for parents that fail to scandir

## Behavior preserved

| Scenario | Pre-fix | Post-fix |
| --- | --- | --- |
| Cover present | not deleted | not deleted |
| Cover missing | deleted | deleted |
| Parent dir missing | per-cover stat fails → cover deleted | scandir → empty present-set → cover deleted |
| Parent unreadable, cover statable | cover-level stat decides | per-cover `Path.exists()` fallback |
| TOCTOU between scan and DELETE | re-discovered next poll | re-discovered next poll |

## Wall-clock impact

| Layout | covers / parent | Pre-fix syscalls | Post-fix syscalls |
| --- | --- | --- | --- |
| One cover per series folder | 1 | 1 stat | 1 readdir (same) |
| Shared cover dir | 50 | 50 stats | 1 readdir |
| Library-wide cover dir | 5000 | 5000 stats | 1 readdir |

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] Functional equivalence: synthetic fixture with covers in various states (present, missing, parent-missing, parent-unreadable). Assert post-cleanup DB matches pre-fix output byte-for-byte
- [ ] Performance: 5k-cover fixture sharing one parent. Pre-fix 5k stats; post-fix 1 readdir; expect ~50× wall-clock drop on simulated remote storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)