### PR TITLE
Janitor misc: failed-imports batching, adopt_folders cap, sessions streaming

### DIFF
--- a/codex/librarian/scribe/janitor/adopt_folders.py
+++ b/codex/librarian/scribe/janitor/adopt_folders.py
@@ -11,6 +11,14 @@ from codex.librarian.scribe.search.tasks import SearchIndexSyncTask
 from codex.librarian.worker import WorkerStatusAbortableBase
 from codex.models import Folder, Library
 
+# Iteration cap on the per-library orphan-adopt loop. Real orphan-
+# folder graphs converge in 1-2 passes (each pass moves orphans to
+# their correct parent position; a second pass catches the case
+# where moving an orphan reveals more orphans). 10 is generous; a
+# library that legitimately needs more passes is exotic and should
+# be investigated, not loop forever waiting for an abort_event.
+_ADOPT_FOLDERS_MAX_PASSES = 10
+
 
 class OrphanFolderAdopter(WorkerStatusAbortableBase):
     """A worker to handle all bulk database updates."""
@@ -55,15 +63,27 @@ class OrphanFolderAdopter(WorkerStatusAbortableBase):
             self.status_controller.start_many((status, moved_status))
             libraries = Library.objects.filter(covers_only=False).only("path")
             for library in libraries.iterator():
-                folders_left = True
-                while folders_left:
+                converged = False
+                # Capped convergence loop. Pre-fix this was a bare
+                # ``while folders_left:`` that could run forever if the
+                # importer kept failing to actually move folders
+                # (permission errors, FS races, etc.) — only the
+                # external abort_event broke the loop.
+                for _ in range(_ADOPT_FOLDERS_MAX_PASSES):
                     if self.abort_event.is_set():
                         return
-                    # Run until there are no orphan folders
                     folders_left, count = self._adopt_orphan_folders_for_library(
                         library
                     )
                     total_count += count
+                    if not folders_left:
+                        converged = True
+                        break
+                if not converged and not self.abort_event.is_set():
+                    cap = _ADOPT_FOLDERS_MAX_PASSES
+                    self.log.warning(
+                        f"Adopt orphan folders for {library.path} hit {cap}-pass cap without converging — folders may be unreachable or unwriteable."
+                    )
         finally:
             self.status_controller.finish_many((moved_status, status))
             if total_count:

--- a/codex/librarian/scribe/janitor/cleanup.py
+++ b/codex/librarian/scribe/janitor/cleanup.py
@@ -125,6 +125,13 @@ _SETTINGS_ORPHAN_FILTER = dict.fromkeys(
 # data-integrity bug worth investigating, not a fix-by-bumping-the-cap
 # problem.
 _FK_CLEANUP_MAX_PASSES = 10
+# Streaming chunk size for the session-validation pass. ``iterator``
+# fetches in this many rows at a time to keep memory bounded on
+# long-running installs with years of accumulated anonymous sessions.
+_SESSION_VALIDATE_CHUNK_SIZE = 1000
+# Batch size for the corrupt-session DELETE. Stays under SQLite's
+# 32766 parameter cap per ``WHERE session_key__in (...)`` query.
+_SESSION_DELETE_BATCH_SIZE = 30000
 
 
 class JanitorCleanup(JanitorUpdateFailedImports):
@@ -297,11 +304,18 @@ class JanitorCleanup(JanitorUpdateFailedImports):
             # Read-only signature validation phase. Holding the lock
             # across this loop would block the importer for as long as
             # the validation takes; release between the two phases.
-            bad_session_keys = set()
+            # ``iterator(chunk_size=...)`` streams rows so a long-
+            # running install with years of accumulated anonymous
+            # sessions doesn't materialize tens of thousands of rows
+            # into RAM at once.
+            bad_session_keys: list[str] = []
             store = Session.get_session_store_class()()
             salt = store.key_salt  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
             serializer = store.serializer
-            for encoded_session in Session.objects.all():
+            session_qs = Session.objects.only("session_key", "session_data").iterator(
+                chunk_size=_SESSION_VALIDATE_CHUNK_SIZE
+            )
+            for encoded_session in session_qs:
                 # Session.get_decoded() swallows decode errors and returns
                 # an empty dict, which is also the legitimate state for an
                 # anonymous session with no stored data — so we can't use
@@ -314,15 +328,26 @@ class JanitorCleanup(JanitorUpdateFailedImports):
                         serializer=serializer,
                     )
                 except Exception:
-                    bad_session_keys.add(encoded_session.session_key)
+                    bad_session_keys.append(encoded_session.session_key)
 
             if bad_session_keys:
+                # Batch the DELETE under the lock. Per-batch cap keeps
+                # the ``session_key__in (...)`` parameter list under
+                # SQLite's 32766 limit on pathologically large bad-
+                # session counts.
+                deleted = 0
                 with self.db_write_lock:
-                    bad_sessions = Session.objects.filter(
-                        session_key__in=bad_session_keys
-                    )
-                    count, _ = bad_sessions.delete()
-                self.log.info(f"Deleted {count} corrupt sessions.")
+                    for start in range(
+                        0, len(bad_session_keys), _SESSION_DELETE_BATCH_SIZE
+                    ):
+                        batch = bad_session_keys[
+                            start : start + _SESSION_DELETE_BATCH_SIZE
+                        ]
+                        count, _ = Session.objects.filter(
+                            session_key__in=batch
+                        ).delete()
+                        deleted += count
+                self.log.info(f"Deleted {deleted} corrupt sessions.")
         finally:
             self.status_controller.finish(status)
 

--- a/codex/librarian/scribe/janitor/failed_imports.py
+++ b/codex/librarian/scribe/janitor/failed_imports.py
@@ -1,7 +1,6 @@
 """Force update events for failed imports."""
 
-from codex.librarian.fs.events import FSChange, FSEvent
-from codex.librarian.fs.tasks import FSEventTask
+from codex.librarian.scribe.importer.tasks import ImportTask
 from codex.librarian.scribe.janitor.vacuum import JanitorVacuum
 from codex.models import FailedImport, Library
 
@@ -10,14 +9,31 @@ class JanitorUpdateFailedImports(JanitorVacuum):
     """Methods for updating failed imports."""
 
     def _force_update_failed_imports(self, library_id) -> None:
-        """Force update events for failed imports in a library."""
-        failed_import_paths = FailedImport.objects.filter(
-            library=library_id
-        ).values_list("path", flat=True)
-        for path in failed_import_paths:
-            event = FSEvent(src_path=path, change=FSChange.modified)
-            task = FSEventTask(library_id, event)
-            self.librarian_queue.put(task)
+        """
+        Force update events for failed imports in a library.
+
+        Dispatches one ``ImportTask(files_modified=...)`` covering every
+        failed-import path instead of one ``FSEventTask`` per path.
+        For libraries with thousands of failed imports (corrupt CBRs
+        users want to retry post-comicbox-upgrade) the librarian queue
+        previously received thousands of items, each routed through
+        the per-event debounce + filesystem stat + DB lookup pipeline.
+
+        ``ImportTask`` skips the FS-event debounce — that is the
+        intended behavior for an explicit "force re-import" action.
+        """
+        failed_import_paths = frozenset(
+            FailedImport.objects.filter(library=library_id).values_list(
+                "path", flat=True
+            )
+        )
+        if not failed_import_paths:
+            return
+        task = ImportTask(
+            library_id=library_id,
+            files_modified=failed_import_paths,
+        )
+        self.librarian_queue.put(task)
 
     def force_update_all_failed_imports(self) -> None:
         """Force update events for failed imports in every library."""


### PR DESCRIPTION
## Summary

Implements `tasks/janitor-perf/05-misc.md` from PR #635. Final entry in the janitor series after #636 / #637 / #638 / #639.

Three small independent fixes, one commit each:

### `78b1ead0` — failed_imports: dispatch single ImportTask per library
`_force_update_failed_imports` was queueing one `FSEventTask` per failed-import path. For libraries with thousands of failed imports (corrupt CBRs the user wants to retry post-comicbox-upgrade) the librarian queue received thousands of items each routed through the per-event debounce + filesystem stat + DB lookup pipeline. Per-task overhead dominated the actual re-import work.

Build one `ImportTask(files_modified=...)` covering every failed-import path; queue once. The importer's existing per-path handling takes over from there. ImportTask skips the FS-event debounce — that's the right behavior for an explicit "force re-import" action.

### `c7abdc69` — adopt_orphan_folders: 10-pass iteration cap
The per-library orphan-adopt loop was a bare `while folders_left:` that could run indefinitely if the importer kept failing to move folders (permission errors, FS races, NFS hiccups). Only the external `abort_event` broke it.

Cap iterations at 10 (real graphs converge in 1-2 passes). Cap-hit warning includes the library path so the user knows where to investigate. Same `for/else` idiom as `cleanup_fks`.

### `8de8c7e8` — cleanup_sessions: stream + chunk validation and delete
The signature-validation loop fetched `Session.objects.all()` into memory. Long-running installs accumulate years of anonymous sessions; tens of thousands of rows held simultaneously is wasteful when the loop only needs one row at a time.

Switch to `.iterator(chunk_size=1000)` for streaming. Batch the corrupt-session DELETE at 30000 keys per query to stay under SQLite's 32766 parameter cap on pathologically corrupt DBs.

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] A: assert one ImportTask queued per library with all failed-import paths in `files_modified`
- [ ] B: synthetic non-converging fixture → exactly one warning fires
- [ ] C: 10k-session fixture under tracemalloc — peak memory should be ~1k-row footprint, not 10k

🤖 Generated with [Claude Code](https://claude.com/claude-code)