### PR TITLE
Librarian: release DB connection during long-idle waits

### DIFF
--- a/codex/librarian/covers/create.py
+++ b/codex/librarian/covers/create.py
@@ -111,6 +111,13 @@ def _render_cover_thumb(args: tuple) -> tuple[int, str, str | None]:
 class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
     """Create methods for covers."""
 
+    # Cover bursts fire from import + cleanup tasks; between imports
+    # the queue idles. The ProcessPoolExecutor workers own the heavy
+    # CPU work, so the main thread's DB conn is mostly used to fetch
+    # ``pk -> path`` maps before dispatch — quick to reopen on the
+    # next burst, and not worth pinning across the idle gap.
+    CLOSE_DB_BETWEEN_TASKS = True
+
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the lazy-built worker pool slot."""
         super().__init__(*args, **kwargs)

--- a/codex/librarian/cron/crond.py
+++ b/codex/librarian/cron/crond.py
@@ -5,6 +5,7 @@ from time import sleep
 from types import MappingProxyType
 from typing import override
 
+from django.db import connections
 from django.utils import timezone as django_timezone
 
 from codex.librarian.scribe.janitor.scheduled_time import get_janitor_time
@@ -70,6 +71,13 @@ class CronThread(NamedThread):
                     self._create_task_times()
                     sleep(2)  # try to fix double jobs
                     timeout = self._get_timeout()
+                    # Idle gaps between scheduled tasks are typically
+                    # hours-to-days. Release the conn so the next
+                    # ``cond.wait`` doesn't pin a file handle + a few
+                    # tens of KiB of in-process state through that
+                    # whole window. Reopen on the next query is
+                    # ~5-20 ms, invisible against the wait.
+                    connections.close_all()
                     self._cond.wait(timeout=timeout)
                     if self._stop_event.is_set():
                         break

--- a/codex/librarian/fs/poller/poller.py
+++ b/codex/librarian/fs/poller/poller.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from threading import Condition, Event
 from typing import override
 
+from django.db import connections
 from django.db.models.functions import Now
 from django.utils import timezone
 from humanize import naturaldelta
@@ -271,6 +272,12 @@ class LibraryPollerThread(NamedThread, WorkerStatusMixin):
                 # Sleep until next poll or until woken
                 if timeout is not None:
                     self.log.debug(f"Next poll in {naturaldelta(timeout)}.")
+                # Poll intervals on a typical install are hours; the
+                # ``poll=False`` "manual poll only" case is unbounded.
+                # Release the conn so the wait doesn't pin a file
+                # handle through the entire interval. Reopen on the
+                # next poll is ~5-20 ms, invisible against the work.
+                connections.close_all()
                 with self._cond:
                     self._cond.wait(timeout)
 

--- a/codex/librarian/scribe/scribed.py
+++ b/codex/librarian/scribe/scribed.py
@@ -41,6 +41,12 @@ class ScribeThread(QueuedThread):
     """A worker to handle all bulk database updates."""
 
     SHUTDOWN_MSG = (0, QueuedThread.SHUTDOWN_MSG)
+    # Importer / janitor / search bursts are minutes-to-hours apart on
+    # a typical install. Releasing the conn between bursts saves an
+    # open file handle + ~50 KiB pinned for the entire idle gap; the
+    # ~5-20 ms reopen cost on the next task is invisible against the
+    # work that follows.
+    CLOSE_DB_BETWEEN_TASKS = True
 
     def __init__(self, *args, **kwargs) -> None:
         """Initialize abort event."""

--- a/codex/librarian/threads.py
+++ b/codex/librarian/threads.py
@@ -8,7 +8,7 @@ from threading import Thread
 from time import monotonic
 from typing import TYPE_CHECKING, override
 
-from django.db import close_old_connections
+from django.db import close_old_connections, connections
 from setproctitle import setproctitle
 
 from codex.librarian.worker import WorkerStatusMixin
@@ -66,6 +66,14 @@ class NamedThread(Thread, WorkerStatusMixin, ABC):
 class QueuedThread(NamedThread, ABC):
     """Abstract Thread worker for doing queued tasks."""
 
+    # When True, close the thread-local DB connection after each task
+    # so the next ``queue.get()`` doesn't hold it through the wait.
+    # Subclasses with long idle gaps between tasks (ScribeThread,
+    # CoverCreateThread) opt in. Heavy-throughput threads where the
+    # ~5-20ms reopen cost outweighs the resource savings keep the
+    # default and rely on Django's CONN_MAX_AGE-based ``close_old_connections``.
+    CLOSE_DB_BETWEEN_TASKS: bool = False
+
     def __init__(self, *args, **kwargs) -> None:
         """Initialize with overridden name and as a daemon thread."""
         self.queue = kwargs.pop("queue", SimpleQueue())
@@ -94,13 +102,32 @@ class QueuedThread(NamedThread, ABC):
         except Empty:
             self.timed_out()
 
+    def _release_db_connection(self) -> None:
+        """
+        Release the thread-local DB connection between tasks.
+
+        ``close_old_connections`` only closes connections older than
+        ``CONN_MAX_AGE`` (10 min in codex), and only fires at the top
+        of a loop iteration — by which point a thread that blocked on
+        ``queue.get(timeout=None)`` for hours has already held its
+        connection for that whole period. ``CLOSE_DB_BETWEEN_TASKS``
+        subclasses elect to close eagerly so an open file handle and
+        ~50 KiB of in-process state aren't pinned through the next
+        long idle. The reopen cost on the next task (~5-20 ms incl.
+        ``init_command`` PRAGMAs) is amortized away by the wait time.
+        """
+        if self.CLOSE_DB_BETWEEN_TASKS:
+            connections.close_all()
+        else:
+            close_old_connections()
+
     @override
     def run(self) -> None:
         """Run thread loop."""
         self.run_start()
         while True:
             try:
-                close_old_connections()
+                self._release_db_connection()
                 self._check_item()
             except BreakLoopError:
                 break


### PR DESCRIPTION
## Summary

Long-idle librarian threads were holding open DB connections through their wait periods. Django's `close_old_connections` only closes connections older than `CONN_MAX_AGE` (10 min in codex), and `QueuedThread.run` runs it at the top of each loop iteration — by which point a thread that blocked on `queue.get(timeout=None)` for hours has already held its connection through that whole window. Same shape on `CronThread` / `LibraryPollerThread`: `cond.wait` spans hours-to-days between scheduled work with the conn pinned for the entire wait.

## Change

New `CLOSE_DB_BETWEEN_TASKS` opt-in flag on `QueuedThread`. When True, `_release_db_connection` calls `connections.close_all()` eagerly instead of `close_old_connections`.

| Thread | Wake shape | Idle scale | Treatment |
| --- | --- | --- | --- |
| **ScribeThread** | `queue.get(timeout=None)` | Hours between import / janitor / search bursts | `CLOSE_DB_BETWEEN_TASKS = True` |
| **CoverCreateThread** + subclasses | `queue.get(timeout=None)` | Idle between import bursts | `CLOSE_DB_BETWEEN_TASKS = True` |
| **CronThread** | `_cond.wait(timeout)` until next scheduled task | Hours-to-days | Explicit `connections.close_all()` before each `wait` |
| **LibraryPollerThread** | `_cond.wait(timeout)` until next library poll | Hours; unbounded for `poll=False` libraries | Explicit `connections.close_all()` before each `wait` |
| **NotifierThread** / **BookmarkThread** / **FSEventBatcherThread** | `AggregateMessageQueuedThread` | Bursty + frequent | Keep default — per-task reopen cost (~5-20 ms) would dominate |
| **LibraryWatcherThread** | `watchfiles.watch()` (kernel inotify) | Event-driven | No change — wait isn't on a DB conn |

## What's saved

Per-thread, per-idle-window: 1 file handle for the DB + 1 for WAL + 1 for SHM, plus ~10-50 KiB of in-process state. Real on Pi-class hosts where file-handle headroom is tight and idle days outnumber active hours.

## What's paid

~5-20 ms reopen cost on the next task (incl. `init_command` PRAGMAs). Invisible against the wait that preceded it; that's why only long-idle threads opt in.

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] Smoke test: run codex with all four threads idle for 30+ min, observe `lsof -p <codex_pid> | grep codex.sqlite3` shows no DB file handles held by the four threads
- [ ] Reopen cost: assert next task on each thread completes successfully (the new conn picks up the codex `_SQLITE_PRAGMAS` `init_command` correctly, including importer-scoped overrides via the `connection_created` signal from PR #631)

🤖 Generated with [Claude Code](https://claude.com/claude-code)