### PR TITLE
Folder default: BROWSER_DEFAULT_GROUP admin flag

### DIFF
--- a/codex/choices/admin.py
+++ b/codex/choices/admin.py
@@ -12,6 +12,7 @@ class AdminFlagChoices(TextChoices):
     AGE_RATING_DEFAULT = "AR"
     AUTO_UPDATE = "AU"
     BANNER_TEXT = "BT"
+    BROWSER_DEFAULT_GROUP = "BG"
     FOLDER_VIEW = "FV"
     IMPORT_METADATA = "IM"
     LAZY_IMPORT_METADATA = "LI"
@@ -26,6 +27,7 @@ ADMIN_FLAG_CHOICES = MappingProxyType(
         AdminFlagChoices.AGE_RATING_DEFAULT.value: "Age Rating Default",
         AdminFlagChoices.AUTO_UPDATE.value: "Auto Update",
         AdminFlagChoices.BANNER_TEXT.value: "Banner Text",
+        AdminFlagChoices.BROWSER_DEFAULT_GROUP.value: "Default View",
         AdminFlagChoices.FOLDER_VIEW.value: "Folder View",
         AdminFlagChoices.IMPORT_METADATA.value: "Import Metadata on Library Scan",
         AdminFlagChoices.LAZY_IMPORT_METADATA.value: "Import Metadata on Demand",

--- a/codex/choices/browser.py
+++ b/codex/choices/browser.py
@@ -64,6 +64,26 @@ BROWSER_CHOICES = MappingProxyType(
 )
 
 DEFAULT_BROWSER_ROUTE = MappingProxyType({"group": "r", "pks": (0,), "page": 1})
+
+# Top-group values that own a dedicated browser route. For these,
+# the URL ``group`` matches the ``top_group``. Everything else
+# (publishers / imprints / series / volumes / issues) routes through
+# the canonical ``r`` (Root) URL — the per-user ``top_group`` setting
+# is what selects the displayed view inside that URL.
+_FLAG_GROUP_HAS_OWN_ROUTE = frozenset({"f", "a"})
+
+
+def admin_default_route_for(top_group: str) -> dict:
+    """
+    Translate a ``BROWSER_DEFAULT_GROUP`` flag value into a route dict.
+
+    Used by :class:`codex.views.frontend.IndexView` to redirect the bare
+    ``/`` URL when no per-user ``last_route`` row exists.
+    """
+    group = top_group if top_group in _FLAG_GROUP_HAS_OWN_ROUTE else "r"
+    return {"group": group, "pks": (0,), "page": 1}
+
+
 _DEFAULT_SHOW = MappingProxyType({"i": False, "p": True, "s": True, "v": False})
 _DEFAULT_FILTERS = MappingProxyType(
     {

--- a/codex/migrations/0043_adminflag_browser_default_group.py
+++ b/codex/migrations/0043_adminflag_browser_default_group.py
@@ -1,0 +1,72 @@
+"""Add the BROWSER_DEFAULT_GROUP admin flag."""
+
+from django.db import migrations, models
+
+# Sorted alphabetically by code so future additions can keep the
+# pattern. Mirrors ``codex.choices.admin.AdminFlagChoices`` plus the
+# new ``BG`` entry.
+_ADMIN_FLAG_KEY_CHOICES = [
+    ("AA", "Anonymous User Age Rating"),
+    ("AR", "Age Rating Default"),
+    ("AU", "Auto Update"),
+    ("BG", "Default View"),
+    ("BT", "Banner Text"),
+    ("FV", "Folder View"),
+    ("IM", "Import Metadata"),
+    ("LI", "Lazy Import Metadata"),
+    ("NU", "Non Users"),
+    ("RG", "Registration"),
+    ("ST", "Send Telemetry"),
+]
+# Mirrors ``SettingsBrowser.top_group``'s model default. The
+# ``admin_default_route_for("p")`` helper resolves this to the
+# canonical ``/r/0/1`` redirect target — upgrade-day no-op for
+# every existing install.
+_DEFAULT_BROWSER_DEFAULT_GROUP_VALUE = "p"
+
+
+def _seed_browser_default_group_flag(apps, _schema_editor) -> None:
+    """
+    Insert the BG row with the default top-group value.
+
+    ``get_or_create`` so a re-run of the migration (or running it
+    against a DB that already had the row) is idempotent.
+    """
+    admin_flag = apps.get_model("codex", "AdminFlag")
+    admin_flag.objects.get_or_create(
+        key="BG",
+        defaults={
+            "on": True,
+            "value": _DEFAULT_BROWSER_DEFAULT_GROUP_VALUE,
+        },
+    )
+
+
+def _delete_browser_default_group_flag(apps, _schema_editor) -> None:
+    """Reverse the seed insert."""
+    admin_flag = apps.get_model("codex", "AdminFlag")
+    admin_flag.objects.filter(key="BG").delete()
+
+
+class Migration(migrations.Migration):
+    """Add the BROWSER_DEFAULT_GROUP flag and seed its row."""
+
+    dependencies = [
+        ("codex", "0042_alter_adminflag_id_alter_agerating_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="adminflag",
+            name="key",
+            field=models.CharField(
+                choices=_ADMIN_FLAG_KEY_CHOICES,
+                db_index=True,
+                max_length=2,
+            ),
+        ),
+        migrations.RunPython(
+            _seed_browser_default_group_flag,
+            _delete_browser_default_group_flag,
+        ),
+    ]

--- a/codex/serializers/admin/flags.py
+++ b/codex/serializers/admin/flags.py
@@ -1,7 +1,9 @@
 """Admin flag serializers."""
 
-from rest_framework.serializers import PrimaryKeyRelatedField
+from rest_framework.serializers import PrimaryKeyRelatedField, ValidationError
 
+from codex.choices.admin import AdminFlagChoices
+from codex.choices.browser import BROWSER_TOP_GROUP_CHOICES
 from codex.models import AdminFlag, AgeRatingMetron
 from codex.serializers.models.base import BaseModelSerializer
 
@@ -16,6 +18,28 @@ class AdminFlagSerializer(BaseModelSerializer):
         allow_null=True,
         required=False,
     )
+
+    def validate(self, attrs):
+        """
+        Per-flag value validation.
+
+        ``BROWSER_DEFAULT_GROUP`` constrains ``value`` to one of the
+        ``BROWSER_TOP_GROUP_CHOICES`` keys; the route URL is derived
+        from the value at read time via ``admin_default_route_for``.
+        Note we validate against the top-group set, not
+        ``BROWSER_ROUTE_CHOICES`` — the ``r`` (Root) pseudo-group is
+        not a valid flag value, only a derived URL.
+        """
+        if (
+            self.instance
+            and self.instance.key == AdminFlagChoices.BROWSER_DEFAULT_GROUP.value
+        ):
+            value = attrs.get("value", self.instance.value)
+            if value not in BROWSER_TOP_GROUP_CHOICES:
+                valid = tuple(BROWSER_TOP_GROUP_CHOICES)
+                reason = f"value must be one of {valid}"
+                raise ValidationError({"value": reason})
+        return attrs
 
     class Meta(BaseModelSerializer.Meta):
         """Specify Model."""

--- a/codex/startup/__init__.py
+++ b/codex/startup/__init__.py
@@ -82,6 +82,15 @@ def init_admin_flags() -> None:
         ),
         AdminFlagChoices.AGE_RATING_DEFAULT.value: DEFAULT_AGE_RATING,
     }
+    # Initial ``value`` strings for flags that ship with a non-empty
+    # default. Heals the row to a sensible state if an admin deletes
+    # it; the migration that introduced the flag does the same insert.
+    value_defaults = {
+        # Mirrors the ``SettingsBrowser.top_group`` model default so
+        # ``admin_default_route_for("p")`` resolves to the historical
+        # ``DEFAULT_BROWSER_ROUTE`` (``/r/0/1``) — upgrade-day no-op.
+        AdminFlagChoices.BROWSER_DEFAULT_GROUP.value: "p",
+    }
     # Resolve seed FK targets in one query.
     metron_by_name = {
         name: pk
@@ -90,16 +99,18 @@ def init_admin_flags() -> None:
         ).values_list("pk", "name")
     }
     for key, title in AdminFlagChoices.choices:
-        # ``defaults`` spans ``bool`` (``on``) and the optional FK id
-        # (``age_rating_metron_id``) — annotate so the conditional FK
-        # insert doesn't narrow pyright's inferred value type.
-        defaults: dict[str, bool | int | None] = {
+        # ``defaults`` spans ``bool`` (``on``), ``str`` (``value``) and
+        # the optional FK id (``age_rating_metron_id``) — annotate so
+        # the conditional inserts don't narrow pyright's inferred type.
+        defaults: dict[str, bool | int | str | None] = {
             "on": key not in AdminFlag.FALSE_DEFAULTS,
         }
         if key in age_rating_defaults:
             defaults["age_rating_metron_id"] = metron_by_name.get(
                 age_rating_defaults[key]
             )
+        if key in value_defaults:
+            defaults["value"] = value_defaults[key]
         flag, created = AdminFlag.objects.get_or_create(defaults=defaults, key=key)
         if created:
             logger.info(f"Created AdminFlag: {title} = {flag.on}")

--- a/codex/views/admin/flag.py
+++ b/codex/views/admin/flag.py
@@ -14,9 +14,10 @@ from codex.views.admin.auth import AdminModelViewSet
 _REFRESH_LIBRARY_FLAGS = frozenset(
     flag.value
     for flag in (
+        AdminFlagChoices.BANNER_TEXT,
+        AdminFlagChoices.BROWSER_DEFAULT_GROUP,
         AdminFlagChoices.FOLDER_VIEW,
         AdminFlagChoices.NON_USERS,
-        AdminFlagChoices.BANNER_TEXT,
     )
 )
 

--- a/codex/views/settings.py
+++ b/codex/views/settings.py
@@ -8,7 +8,12 @@ from types import MappingProxyType
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from loguru import logger
 
-from codex.choices.browser import DEFAULT_BROWSER_ROUTE
+from codex.choices.admin import AdminFlagChoices
+from codex.choices.browser import (
+    BROWSER_TOP_GROUP_CHOICES,
+    admin_default_route_for,
+)
+from codex.models import AdminFlag
 from codex.models.settings import (
     ClientChoices,
     SettingsBase,
@@ -20,6 +25,12 @@ from codex.models.settings import (
 )
 from codex.views.auth import AuthFilterGenericAPIView
 from codex.views.const import FOLDER_GROUP, STORY_ARC_GROUP
+
+# Fallback top-group when the BG flag row is missing, off, or holds
+# an invalid value. Mirrors ``SettingsBrowser.top_group``'s model
+# default; ``admin_default_route_for("p")`` yields the historical
+# ``/r/0/1`` redirect target.
+_FALLBACK_DEFAULT_TOP_GROUP = "p"
 
 CREDIT_PERSON_UI_FIELD = "credits"
 STORY_ARC_UI_FIELD = "story_arcs"
@@ -123,20 +134,57 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
         return instance
 
     @staticmethod
-    def _create_browser_settings(user, session_key, client, create_args):
-        """Create a SettingsBrowser with its related show/filters/last_route."""
+    def _get_admin_default_top_group() -> str:
+        """
+        Read the admin-configured default top group.
+
+        Returns the validated ``BROWSER_DEFAULT_GROUP`` flag value,
+        falling back to ``"p"`` if the row is missing, the flag is
+        off, or the value is out of range (defense against a
+        hand-edited DB / pre-migration state). ``"p"`` mirrors the
+        ``SettingsBrowser.top_group`` model default and resolves to
+        the historical ``/r/0/1`` redirect target.
+        """
+        try:
+            flag = AdminFlag.objects.only("on", "value").get(
+                key=AdminFlagChoices.BROWSER_DEFAULT_GROUP.value
+            )
+        except AdminFlag.DoesNotExist:
+            return _FALLBACK_DEFAULT_TOP_GROUP
+        if flag.on and flag.value in BROWSER_TOP_GROUP_CHOICES:
+            return flag.value
+        return _FALLBACK_DEFAULT_TOP_GROUP
+
+    @classmethod
+    def _get_admin_default_route(cls) -> Mapping:
+        """Translate the admin default top group into a redirect target."""
+        return admin_default_route_for(cls._get_admin_default_top_group())
+
+    @classmethod
+    def _create_browser_settings(cls, user, session_key, client, create_args):
+        """
+        Create a SettingsBrowser with its related show/filters/last_route.
+
+        Sets ``top_group`` from the admin-configured default unless
+        the caller already supplied one. The override applies only on
+        row creation; ``_get_or_create_settings`` returns existing
+        rows before reaching this branch, so a returning user's
+        pinned ``top_group`` is never overwritten.
+        """
         show, _ = SettingsBrowserShow.objects.get_or_create(
             p=True,
             i=False,
             s=True,
             v=False,
         )
+        create_kwargs = dict(create_args)
+        create_kwargs.setdefault("top_group", cls._get_admin_default_top_group())
         instance = SettingsBrowser.objects.create(
             user=user,
             session_id=session_key,
             client=client,
             show=show,
-            **create_args,
+            **create_kwargs,
         )
         SettingsBrowserFilters.objects.create(browser=instance)
         SettingsBrowserLastRoute.objects.create(browser=instance)
@@ -275,10 +323,16 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
         return field.default
 
     def get_last_route(self) -> Mapping:
-        """Get the last route from the browser session."""
+        """
+        Get the last route from the browser session.
+
+        Returns the user's persisted last_route when available; falls
+        through to the admin-configured default for new users /
+        cleared-cookie users / anonymous-pre-navigation requests.
+        """
         if last_route := self.get_from_settings("last_route", browser=True):
             return last_route
-        return DEFAULT_BROWSER_ROUTE
+        return self._get_admin_default_route()
 
     @classmethod
     def get_browser_default_params(cls) -> dict:

--- a/frontend/src/components/admin/tabs/flag-descriptions.json
+++ b/frontend/src/components/admin/tabs/flag-descriptions.json
@@ -8,5 +8,6 @@
   "IM": "If disabled, Codex will not bulk import metadata from comic libraries when they are scanned and only import folders and filenames. This makes importing comics fast, but disables most of the metadata browser and search functionality for lack of data, making codex mostly a file tree browser.",
   "LI": "Import metadata for books that have none one at a time when you hover over the 🏷 button. On many systems this will happen fast enough that clicking the button will show populated metadata. This gives users individual metadata on demand for setups that have Bulk Import Metadata disabled above and lets them slowly populate the database. Eventually there might be enough data for search and filtering to be useful.",
   "ST": "Anonymously send the contents of the Admin Stats tab once a week to understand how people use Codex and improve the software. The server collecting the stats does not log or store your IP. The author considers all personally identifying information and the names and metadata of your comics to be a radioactive privacy violation and will never be exposed to it. Only the information you see on the stats page is collected. Your API Key is not sent. Stats are not sent for the first 24 hours to allow opt-out.",
-  "BT": "A customized text headline that appears at the top of every codex page."
+  "BT": "A customized text headline that appears at the top of every codex page.",
+  "BG": "View shown to anonymous and new users when they have no saved preference. Existing users keep whatever they last navigated to."
 }

--- a/frontend/src/components/admin/tabs/flag-tab.vue
+++ b/frontend/src/components/admin/tabs/flag-tab.vue
@@ -57,6 +57,23 @@
             @update:model-value="changeCol(item.key, 'ageRatingMetron', $event)"
           />
         </td>
+        <!--
+          ``BG`` (Default View) reuses the existing ``TOP_GROUP``
+          choices JSON so the seven labels stay in sync with the
+          rest of the browser UI. Persisted on the flag's ``value``
+          string column; the route-URL derivation happens server-
+          side in ``admin_default_route_for``.
+        -->
+        <td v-else-if="item.key === 'BG'" class="topGroupField">
+          <v-select
+            :model-value="item.value"
+            :items="topGroupChoices"
+            label="Default View"
+            hide-details="auto"
+            :error-messages="errors[item.key]"
+            @update:model-value="changeCol(item.key, 'value', $event)"
+          />
+        </td>
         <td>
           <v-btn
             v-if="item.key === 'BT'"
@@ -66,7 +83,11 @@
             title="Save Banner"
             @click="changeCol(item.key, 'value', banner)"
           />
-          <template v-else-if="item.key === 'AR' || item.key === 'AA'" />
+          <template
+            v-else-if="
+              item.key === 'AR' || item.key === 'AA' || item.key === 'BG'
+            "
+          />
           <v-checkbox
             v-else
             :model-value="item.on"
@@ -86,6 +107,7 @@ import { mdiContentSaveOutline } from "@mdi/js";
 import { mapActions, mapState } from "pinia";
 
 import ADMIN_FLAGS from "@/choices/admin-flag-choices.json";
+import BROWSER_CHOICES from "@/choices/browser-choices.json";
 import DESC from "@/components/admin/tabs/flag-descriptions.json";
 import { useAdminStore } from "@/stores/admin";
 import { useCommonStore } from "@/stores/common";
@@ -129,6 +151,16 @@ export default {
        */
       return this.ageRatingMetrons || [];
     },
+    topGroupChoices() {
+      /*
+       * Reuse the existing ``TOP_GROUP`` choices JSON so the labels
+       * stay in sync with the rest of the browser UI. The 7 entries
+       * (Folders / Story Arcs / Publishers / Imprints / Series /
+       * Volumes / Issues) are the legitimate values for the BG flag;
+       * the route-URL derivation runs server-side.
+       */
+      return BROWSER_CHOICES.TOP_GROUP || [];
+    },
   },
   watch: {
     storeBanner(to) {
@@ -162,9 +194,7 @@ export default {
       return ADMIN_FLAGS[item.key];
     },
     colspan(item) {
-      return item.key === "BT" || item.key === "AR" || item.key === "AA"
-        ? 1
-        : 2;
+      return ["BT", "AR", "AA", "BG"].includes(item.key) ? 1 : 2;
     },
   },
 };
@@ -196,6 +226,10 @@ export default {
 }
 
 .ageRatingField {
+  min-width: 12em;
+}
+
+.topGroupField {
   min-width: 12em;
 }
 


### PR DESCRIPTION
## Summary

Implements `tasks/folder-default/01-admin-default-group.md` from PR #642. New admin flag `BROWSER_DEFAULT_GROUP` (key `BG`, label "Default View") drives the bare-`/` redirect target and the `top_group` default for newly-created `SettingsBrowser` rows.

Existing users keep their persisted `last_route` and `top_group` — the flag only fires on the no-saved-row fallback path.

## Three commits

### `0eb90e06` — flag + migration + helper
- `AdminFlagChoices.BROWSER_DEFAULT_GROUP = "BG"` enum + label "Default View"
- `admin_default_route_for(top_group)` helper in `codex/choices/browser.py` — maps `f→f`, `a→a`, anything else `→r` (the canonical groups-view URL)
- Migration `0043` adds `BG` to `AdminFlag.key` choices and seeds the row with `value="p"` (mirrors `SettingsBrowser.top_group` default; `admin_default_route_for("p")` yields `/r/0/1` — upgrade-day no-op)
- `init_admin_flags` extended with a `value_defaults` map for parity (heals the row to `value="p"` if an admin deletes it)
- `AdminFlagSerializer.validate` rejects out-of-range BG values; validates against `BROWSER_TOP_GROUP_CHOICES` (the seven legitimate values), not `BROWSER_ROUTE_CHOICES` — `r` is a derived URL group, not a storable flag value

### `b432d97b` — view-layer wiring
- `IndexView.get_last_route` falls back to `_get_admin_default_route()` when no per-user `last_route` exists. User's persisted state still wins.
- `_create_browser_settings.setdefault("top_group", _get_admin_default_top_group())` — for `p/i/s/v/c` flag values the URL stays at `/r/0/1` and `top_group` is what selects the displayed view, so the propagation is necessary for those choices to actually take effect for new users
- Defensive read: missing flag, `on=False`, or invalid value all fall back to `"p"` (matches model default)
- `AdminFlagViewSet._REFRESH_LIBRARY_FLAGS` includes BG so changes broadcast `ADMIN_FLAGS_CHANGED_TASK`

### `9eee9d76` — admin tab UI
- `<v-select>` on the BG row populated from the existing `TOP_GROUP` entries in `browser-choices.json` — labels stay in sync with the rest of the browser UI
- Description string clarifies the "new and anonymous users only" semantics
- `admin-flag-choices.json` regenerated automatically by `make build-choices` from the updated Django enum

## Test plan
- [x] `make fix` clean
- [x] `make lint-python` clean (0 errors, 0 warnings)
- [x] Frontend `bun run lint` clean
- [x] `pytest tests/importer/ tests/test_search_fts.py` — 7 passed
- [ ] Run migration on a fresh DB; assert BG row created with `value="p"`
- [ ] Set `value="f"` via admin UI; new browser session redirects `/` → `/f/0/1`
- [ ] Set `value="s"`; new session lands on `/r/0/1` and the SettingsBrowser row has `top_group="s"`
- [ ] Set `value="z"` via direct DB edit; serializer + view fallback still keep things working (defaults to `"p"`)
- [ ] Logged-in user with `last_route={group: "a", ...}` keeps that route regardless of BG flag value

🤖 Generated with [Claude Code](https://claude.com/claude-code)