### PR TITLE
Frontend correctness: 10 bug fixes from sub-plan 01

### DIFF
--- a/frontend/src/api/v3/browser.js
+++ b/frontend/src/api/v3/browser.js
@@ -89,11 +89,15 @@ const resetSettings = () => {
 
 export const getGroupDownloadURL = ({ group, pks }, fn, settings, ts) => {
   const base = globalThis.CODEX.API_V3_PATH;
-  delete settings.show;
+  // Strip ``show`` without mutating the caller's settings object;
+  // the previous ``delete settings.show`` was a silent side-effect
+  // that broke any caller relying on its settings object surviving
+  // a download-URL build.
+  const { show: _show, ...query } = settings;
   const { hrefPath, queryString } = getBrowserHrefPath({
     group,
     pks,
-    query: settings,
+    query,
     ts,
   });
   fn = encodeURIComponent(fn);

--- a/frontend/src/api/v3/common.js
+++ b/frontend/src/api/v3/common.js
@@ -109,10 +109,16 @@ export const getDownloadIOSPWAFix = (href, filename) => {
       const blob = new Blob([response.data], {
         type: "application/octet-stream",
       });
-      link.href = globalThis.URL.createObjectURL(blob);
+      // ``createObjectURL`` returns a string ``blob:...`` URL;
+      // ``revokeObjectURL`` must be called on that same string,
+      // not on the underlying Blob. The original code passed the
+      // Blob, which silently no-op'd and leaked the object URL on
+      // every iOS PWA download.
+      const objectUrl = globalThis.URL.createObjectURL(blob);
+      link.href = objectUrl;
       link.download = filename;
       link.click();
-      globalThis.URL.revokeObjectURL(response.data);
+      globalThis.URL.revokeObjectURL(objectUrl);
       return link.remove();
     })
     .catch(console.warn);

--- a/frontend/src/components/admin/tabs/job-tab.vue
+++ b/frontend/src/components/admin/tabs/job-tab.vue
@@ -118,11 +118,16 @@
               </span>
             </button>
             <v-expand-transition>
-              <div
-                v-if="isExpanded(job)"
-                class="statusRows"
-                @click="loadAllStatuses"
-              >
+              <!--
+                No click handler on the expanded panel. The previous
+                version fired ``loadAllStatuses`` on every click
+                anywhere inside this div — even unrelated clicks on
+                child elements bubbled and re-fetched the entire
+                status map. Status updates are pushed through the
+                websocket already; no manual refresh needed when the
+                user interacts with the panel.
+              -->
+              <div v-if="isExpanded(job)" class="statusRows">
                 <div
                   v-for="status in jobStatuses(job)"
                   :key="status.statusType"

--- a/frontend/src/components/browser/toolbars/top/filter-sub-menu.vue
+++ b/frontend/src/components/browser/toolbars/top/filter-sub-menu.vue
@@ -52,9 +52,16 @@
           class="filterGroup overflow-y-auto"
           density="compact"
           multiple
-          :items="vuetifyItems"
           @update:selected="selected"
         >
+          <!--
+            Manual ``v-for`` to render list items so the per-item
+            slot (``#append`` for ``metronName``) can fire. The
+            previous version also passed ``:items="vuetifyItems"``
+            to ``v-list``; Vuetify renders the items prop directly,
+            so each row was being emitted twice — once by the prop,
+            once by this ``v-for``. Drop the prop to render once.
+          -->
           <v-list-item
             v-for="item of vuetifyItems"
             :key="item.value"

--- a/frontend/src/components/metadata/metadata-dialog.vue
+++ b/frontend/src/components/metadata/metadata-dialog.vue
@@ -132,10 +132,17 @@ export default {
       if (this.progress >= 100 || this.md) {
         return;
       }
-      setTimeout(() => {
+      // Stash the timer ID so ``beforeUnmount`` can clear it.
+      // Without that, closing the dialog mid-progress lets the
+      // chained setTimeout fire on a torn-down component, writing
+      // ``this.progress`` and re-scheduling against null refs.
+      this._progressTimer = setTimeout(() => {
         this.updateProgress();
       }, UPDATE_INTERVAL);
     },
+  },
+  beforeUnmount() {
+    clearTimeout(this._progressTimer);
   },
 };
 </script>

--- a/frontend/src/components/metadata/metadata-dialog.vue
+++ b/frontend/src/components/metadata/metadata-dialog.vue
@@ -106,6 +106,9 @@ export default {
       this.dialog = true;
     }
   },
+  beforeUnmount() {
+    clearTimeout(this._progressTimer);
+  },
   methods: {
     ...mapActions(useMetadataStore, ["clearMetadata", "loadMetadata"]),
     close() {
@@ -132,17 +135,16 @@ export default {
       if (this.progress >= 100 || this.md) {
         return;
       }
-      // Stash the timer ID so ``beforeUnmount`` can clear it.
-      // Without that, closing the dialog mid-progress lets the
-      // chained setTimeout fire on a torn-down component, writing
-      // ``this.progress`` and re-scheduling against null refs.
+      /*
+       * Stash the timer ID so ``beforeUnmount`` can clear it.
+       * Without that, closing the dialog mid-progress lets the
+       * chained setTimeout fire on a torn-down component, writing
+       * ``this.progress`` and re-scheduling against null refs.
+       */
       this._progressTimer = setTimeout(() => {
         this.updateProgress();
       }, UPDATE_INTERVAL);
     },
-  },
-  beforeUnmount() {
-    clearTimeout(this._progressTimer);
   },
 };
 </script>

--- a/frontend/src/components/reader/pager/page/page.vue
+++ b/frontend/src/components/reader/pager/page/page.vue
@@ -101,11 +101,31 @@ export default {
     },
   },
   mounted() {
-    setTimeout(function () {
+    /*
+     * Show the spinner only if the image is still loading after
+     * ``PROGRESS_DELAY_MS``. Two corrections from the original:
+     *
+     * 1. Arrow function preserves ``this``. The original
+     *    ``setTimeout(function () { ... })`` ran with the timer's
+     *    context, not the component's, so ``this.loaded`` and the
+     *    write below were no-ops.
+     * 2. ``this.showProgress`` is what the template binds; the
+     *    original wrote to ``this.loading`` which has never been a
+     *    data field on this component, so the spinner literally
+     *    never appeared.
+     *
+     * Stash the timer ID so ``beforeUnmount`` can clear it — a
+     * fast page swap mid-delay would otherwise fire the write on a
+     * torn-down component.
+     */
+    this._loadingTimer = setTimeout(() => {
       if (!this.loaded) {
-        this.loading = true;
+        this.showProgress = true;
       }
     }, PROGRESS_DELAY_MS);
+  },
+  beforeUnmount() {
+    clearTimeout(this._loadingTimer);
   },
   methods: {
     ...mapActions(useReaderStore, ["getBookSettings"]),

--- a/frontend/src/components/reader/pager/pager.vue
+++ b/frontend/src/components/reader/pager/pager.vue
@@ -1,5 +1,13 @@
 <template>
-  <component :is="component" :book="book" />
+  <!--
+    ``:key="component.name"`` forces a full unmount + remount
+    when the user toggles reading direction. Without it Vue
+    reuses the existing pager instance — the orientation swap
+    keeps the previous mode's scroll listeners attached and the
+    new mode's setup runs against stale state. Keying on the
+    component identity scopes lifecycle correctly.
+  -->
+  <component :is="component" :key="component.name" :book="book" />
 </template>
 
 <script>

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -78,13 +78,26 @@ export const useAuthStore = defineStore("auth", {
         })
         .catch(commonStore.setErrors);
     },
-    logout() {
-      API.logout()
-        .then(() => {
-          this.user = undefined;
-          return true;
-        })
-        .catch(console.error);
+    async logout() {
+      /*
+       * The user clicked "log out" — clear client-side state
+       * unconditionally so the menu and routes reflect the logged-
+       * out state immediately. Surface API errors to the console
+       * but don't let them block the local clear; the next
+       * server-side request will either succeed against a fresh
+       * session or 401 and prompt re-login.
+       *
+       * ``async`` so callers can ``await`` (they currently fire-
+       * and-forget, but the menu's UI feedback would benefit from
+       * knowing when the call resolves).
+       */
+      try {
+        await API.logout();
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.user = undefined;
+      }
     },
     async changePassword(credentials) {
       const changedCredentials = {

--- a/frontend/src/stores/reader.js
+++ b/frontend/src/stores/reader.js
@@ -482,8 +482,11 @@ export const useReaderStore = defineStore("reader", {
         }
       }
       if (!arcs.length) {
-        // No arcs is a 500 from the mtime api
-        arcs.push({ r: "0" });
+        // No arcs is a 500 from the mtime api. Use the same
+        // ``{ group, pks }`` shape the loop above produces — the
+        // earlier ``{ r: "0" }`` was a typo that itself returned
+        // 500 from the API, so the fallback never actually worked.
+        arcs.push({ group: "r", pks: "0" });
       }
       return await COMMON_API.getMtime(arcs, {})
         .then((response) => {

--- a/frontend/src/stores/reader.js
+++ b/frontend/src/stores/reader.js
@@ -374,10 +374,20 @@ export const useReaderStore = defineStore("reader", {
         state.routes.prev = this._getRouteParams(book, page, "prev");
         state.routes.next = this._getRouteParams(book, page, "next");
       });
-      await this._setBookmarkPage(page).then(() => {
+      try {
+        await this._setBookmarkPage(page);
         this.bookChange = undefined;
-        return true;
-      });
+      } catch (error) {
+        /*
+         * Don't revert the local page — the user is reading
+         * forward; the bookmark catches up on the next call. But
+         * surface the failure to the console rather than letting
+         * it become an unhandled rejection: the previous code
+         * neither caught nor logged here, so a network blip
+         * silently lost the bookmark write.
+         */
+        console.warn("Bookmark write failed:", error);
+      }
     },
     setActivePage(page, reactWithScroll = true) {
       if (page < 0) {


### PR DESCRIPTION
## Summary

Implements the 10 high-confidence bugs from `tasks/frontend-perf/01-correctness-bugs.md` (PR #645). Two findings (B4, B5 — AbortController for `loadBooks` / `loadBrowserPage`) are deferred to sub-plan 02 where the shared abort helper lives. One (B9 — search history cap) was a false positive; the cap is already applied via `slice(0, MAX_ITEMS)`.

## What's broken (and now fixed)

### Headline: the reader's load-progress spinner has never worked

```js
// page.vue:104 (before)
mounted() {
  setTimeout(function () {       // non-arrow → `this` is the timer
    if (!this.loaded) {
      this.loading = true;       // ALSO wrong: template binds `showProgress`
    }
  }, PROGRESS_DELAY_MS);
}
```

Two stacked bugs in the same `setTimeout`. Even with the arrow function, the write targets `this.loading` — which has never been a data field on this component. The template (line 15) binds the spinner to `showProgress`. So `LoadingPage` has been dead code for slow image loads since the file was written.

### The reader's no-arcs mtime fallback fails the same 500 it was added to avoid

```js
// reader.js:486 (before)
if (!arcs.length) {
  // No arcs is a 500 from the mtime api
  arcs.push({ r: "0" });   // wrong shape — sibling code uses { group, pks }
}
```

The fallback existed specifically to dodge the 500 the comment describes — but the fallback's shape itself returns 500. Now uses `{ group: "r", pks: "0" }`.

## Full commit list

| Commit | Bug | What |
| --- | --- | --- |
| 46a5f8d6 | B1 | Reader page spinner: arrow function + correct property + cleanup |
| c1d05ec4 | B2 | Reader arc-mtime fallback: correct shape |
| 7bb25fb3 | B6 | iOS PWA download: pass object URL string to `revokeObjectURL`, not the Blob |
| ced6be33 | B8 | Browser API: stop mutating caller's `settings.show` |
| 118de37d | B7 | Auth store: `logout` awaitable + clear state in `finally` |
| dc811b44 | B10 | Filter sub-menu: stop double-rendering each row (`<v-list>` had `:items` AND v-for) |
| babeddb3 | B11 | Admin job-tab: remove API-fetching click handler from expanded panel |
| ed7a6ee5 | B3 | Reader store: handle bookmark-write errors instead of silently rejecting |
| 42a6abaf | B12 | Metadata dialog: clear progress timer on unmount |
| fbcc49c7 | B13 | Reader pager: `:key` on `<component :is>` so swap is a true unmount |
| 53dd6522 | (lint) | Metadata dialog: option-ordering + block-comment cleanup |

## Test plan
- [x] `bunx prettier --check .` clean
- [x] `bunx eslint .` clean (with `NODE_OPTIONS=--max-old-space-size=4096`; see note below)
- [x] `bun run test:ci` — 1 passed (existing reader-nav-button test still green)
- [ ] Manual: open a slow-loading page in the reader; verify spinner appears after `PROGRESS_DELAY_MS`
- [ ] Manual: download a comic on iOS PWA; verify Safari memory tools show no accumulating object URLs
- [ ] Manual: log out; verify the menu state changes to logged-out even if the API errors
- [ ] Manual: open a filter sub-menu with many choices; verify each row appears once
- [ ] Manual: expand and collapse a job row; verify no API call fires

## Note on eslint_d

The local `eslint_d` daemon was misbehaving during testing (`Failed to start daemon`). Falling back to direct `bunx eslint .` worked but required `NODE_OPTIONS=--max-old-space-size=4096` to avoid an OOM — likely independent of these changes (the codebase is large and Node 25's defaults are tight). CI should not see this issue with its own setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)