### PR TITLE
Frontend perf: request dedup + abort + WS backoff + admin cache + boot tidy

### DIFF
--- a/frontend/src/api/v3/abortable.js
+++ b/frontend/src/api/v3/abortable.js
@@ -1,0 +1,69 @@
+/*
+ * Helpers for cancelling stale in-flight requests and deduplicating
+ * concurrent identical fetches.
+ *
+ * ``useAbortable(key)`` — single-flight per key. Calling it again
+ * with the same key aborts the previous AbortController and returns
+ * a fresh signal. Adopt at API call sites where rapid user input
+ * (rapid clicks, debounced filter changes) can fire overlapping
+ * requests; the late-arriving response from a prior call is
+ * effectively dropped because the caller's abort handler suppresses
+ * it.
+ *
+ * ``dedupedFetch(key, fetcher)`` — same-key callers share an
+ * in-flight promise rather than each firing their own request. Use
+ * for read-only endpoints where multiple components want the same
+ * data fast (mtime checks, choice menus). The cache clears on
+ * settle so a stuck promise can't pin the dedup forever.
+ */
+
+const _controllers = new Map();
+const _pending = new Map();
+
+/**
+ * Get an AbortSignal for the keyed request, aborting any prior one.
+ *
+ * @param {string} key Stable per-call-site identifier (e.g.
+ *   ``"browser:loadBrowserPage"``). Two callers using the same key
+ *   participate in the same single-flight slot.
+ * @returns {AbortSignal}
+ */
+export function useAbortable(key) {
+  const previous = _controllers.get(key);
+  if (previous) previous.abort();
+  const controller = new AbortController();
+  _controllers.set(key, controller);
+  return controller.signal;
+}
+
+/**
+ * True if an error came from an aborted request.
+ *
+ * Both xior (CanceledError) and the platform fetch (AbortError)
+ * surface the same intent under different names. Catch broadly and
+ * suppress at the call site so the late-arriving aborted response
+ * doesn't ``$patch`` stale state.
+ */
+export function isAbortError(error) {
+  if (!error) return false;
+  return error.name === "AbortError" || error.name === "CanceledError";
+}
+
+/**
+ * Share an in-flight promise across same-key callers.
+ *
+ * @param {string} key Stable identifier shared by callers that want
+ *   to coalesce.
+ * @param {() => Promise<T>} fetcher Invoked only when no pending
+ *   promise exists for ``key``.
+ * @returns {Promise<T>}
+ */
+export function dedupedFetch(key, fetcher) {
+  const existing = _pending.get(key);
+  if (existing) return existing;
+  const promise = Promise.resolve()
+    .then(fetcher)
+    .finally(() => _pending.delete(key));
+  _pending.set(key, promise);
+  return promise;
+}

--- a/frontend/src/api/v3/admin.js
+++ b/frontend/src/api/v3/admin.js
@@ -16,9 +16,14 @@ const makeAdminCRUD = (entity) => {
 const userCRUD = makeAdminCRUD("user");
 const groupCRUD = makeAdminCRUD("group");
 const libraryCRUD = makeAdminCRUD("library");
-// Read-only lookup for the AgeRatingMetron dropdown. Uses the same CRUD
-// factory but we only expose ``getAll`` below.
-const ageRatingMetronCRUD = makeAdminCRUD("age-rating-metron");
+// Read-only lookup for the AgeRatingMetron dropdown.
+// AgeRatingMetron is an effectively-static enum table — rows
+// don't change at runtime — so we skip the ``serializeParams()``
+// cache-buster the CRUD factory adds by default. Letting the
+// browser cache this response saves the round-trip on every
+// admin tab visit. The store layer also keeps a sticky cache
+// to short-circuit the refetch entirely once we've seen it.
+const getAgeRatingMetrons = () => HTTP.get("/admin/age-rating-metron");
 
 // ONE-OFF ENDPOINTS
 
@@ -85,7 +90,7 @@ export default {
   updateLibrary: libraryCRUD.update,
   deleteLibrary: libraryCRUD.destroy,
   // Irregular plural; the admin store looks up API["get" + pluralTable].
-  getAgeRatingMetrons: ageRatingMetronCRUD.getAll,
+  getAgeRatingMetrons,
   getActiveLibrarianStatuses,
   getAllLibrarianStatuses,
   getFailedImports,

--- a/frontend/src/api/v3/base.js
+++ b/frontend/src/api/v3/base.js
@@ -62,12 +62,30 @@ HTTP.interceptors.response.use(
       typeof error.response.data === "string" &&
       error.response.data.includes("CSRF")
     ) {
-      // CSRF failure — drop the cached token so the next request
-      // forces a fresh cookie read, then delete the sessionid
-      // cookie so the user is logged out cleanly.
+      /*
+       * CSRF failure — drop the cached token so the next request
+       * forces a fresh cookie read, then delete the sessionid
+       * cookie so the user is logged out cleanly. Surface a
+       * snackbar so the user knows why the page just stopped
+       * working; without this every subsequent API call returns
+       * 401 silently and the UI appears broken.
+       *
+       * Lazy-import the common store to avoid a load-time cycle:
+       * ``stores/common.js`` imports ``api/v3/common.js`` which
+       * imports this module. The handler runs at request time,
+       * by which point the store has been fully evaluated.
+       */
       invalidateCSRFCache();
       await cookieStore.delete("sessionid");
       console.error("CSRF response error. Deleted login cookie.");
+      try {
+        const { useCommonStore } = await import("@/stores/common");
+        useCommonStore().setSessionError(
+          "Your session expired. Please reload the page.",
+        );
+      } catch (notifyError) {
+        console.error("Failed to surface CSRF error toast:", notifyError);
+      }
     }
     return Promise.reject(error);
   },

--- a/frontend/src/api/v3/base.js
+++ b/frontend/src/api/v3/base.js
@@ -10,9 +10,36 @@ const COOKIE_NAME = "csrftoken";
 const CSRF_HEADER = "X-CSRFToken";
 const CSRF_COOKIE_REGEX = RegExp("(?:^|;)\\s*" + COOKIE_NAME + "=([^;]*)");
 
+// Cookie-string cache: we re-run the regex only when
+// ``document.cookie`` actually changes. The previous code matched
+// the regex against the full cookie string on every single API
+// request — a cheap operation per call, but multiplied across the
+// many requests a single page navigation fires (browser page +
+// available filters + per-field choices + mtime poll), it added up
+// to noticeable redundant work. Caching the token string and the
+// cookie snapshot it was extracted from lets us hit a constant-time
+// string equality check in the common case while still picking up
+// rotated tokens automatically (the cookie string changes whenever
+// Django rotates the CSRF cookie).
+let _cachedCookieSnapshot = "";
+let _cachedToken = "";
+
+function readCSRFToken() {
+  const cookie = document.cookie;
+  if (cookie === _cachedCookieSnapshot) return _cachedToken;
+  _cachedCookieSnapshot = cookie;
+  const match = cookie.match(CSRF_COOKIE_REGEX);
+  _cachedToken = match ? match[1] : "";
+  return _cachedToken;
+}
+
+function invalidateCSRFCache() {
+  _cachedCookieSnapshot = "";
+  _cachedToken = "";
+}
+
 HTTP.interceptors.request.use((config) => {
-  const match = document.cookie.match(CSRF_COOKIE_REGEX);
-  const token = match ? match[1] : "";
+  const token = readCSRFToken();
   if (!token) return config;
 
   return merge(config, {
@@ -35,7 +62,10 @@ HTTP.interceptors.response.use(
       typeof error.response.data === "string" &&
       error.response.data.includes("CSRF")
     ) {
-      // CSRF failure — delete the sessionid cookie
+      // CSRF failure — drop the cached token so the next request
+      // forces a fresh cookie read, then delete the sessionid
+      // cookie so the user is logged out cleanly.
+      invalidateCSRFCache();
       await cookieStore.delete("sessionid");
       console.error("CSRF response error. Deleted login cookie.");
     }

--- a/frontend/src/api/v3/browser.js
+++ b/frontend/src/api/v3/browser.js
@@ -47,19 +47,30 @@ export const getPlaceholderSrc = (group) => {
   return `${globalThis.CODEX.STATIC}img/${name}.svg`;
 };
 
-const getAvailableFilterChoices = ({ group, pks }, data, ts) => {
+const getAvailableFilterChoices = ({ group, pks }, data, ts, options = {}) => {
   const params = serializeParams(data, ts);
-  return HTTP.get(`/${group}/${pks}/choices_available`, { params });
+  return HTTP.get(`/${group}/${pks}/choices_available`, { params, ...options });
 };
 
-const getFilterChoices = ({ group, pks }, fieldName, data, ts) => {
+/* eslint-disable max-params */
+const getFilterChoices = (
+  { group, pks },
+  fieldName,
+  data,
+  ts,
+  options = {},
+) => {
   const params = serializeParams(data, ts);
-  return HTTP.get(`/${group}/${pks}/choices/${fieldName}`, { params });
+  return HTTP.get(`/${group}/${pks}/choices/${fieldName}`, {
+    params,
+    ...options,
+  });
 };
+/* eslint-enable max-params */
 
-const getBrowserPage = ({ group, pks, page }, data, ts) => {
+const getBrowserPage = ({ group, pks, page }, data, ts, options = {}) => {
   const params = serializeParams(data, ts, false);
-  return HTTP.get(`/${group}/${pks}/${page}`, { params });
+  return HTTP.get(`/${group}/${pks}/${page}`, { params, ...options });
 };
 
 const getMetadata = ({ group, pks }, settings) => {

--- a/frontend/src/api/v3/common.js
+++ b/frontend/src/api/v3/common.js
@@ -124,9 +124,9 @@ export const getDownloadIOSPWAFix = (href, filename) => {
     .catch(console.warn);
 };
 
-const getMtime = (groups, settings) => {
+const getMtime = (groups, settings, options = {}) => {
   const params = serializeParams({ groups, ...settings }, Date.now());
-  return HTTP.get("/mtime", { params });
+  return HTTP.get("/mtime", { params, ...options });
 };
 const getOPDSURLs = () => {
   return HTTP.get("/opds-urls");

--- a/frontend/src/api/v3/reader.js
+++ b/frontend/src/api/v3/reader.js
@@ -24,10 +24,10 @@ const resetSettings = (data) => {
   return HTTP.delete("c/settings", { data });
 };
 
-const getReaderInfo = (pk, data, ts) => {
+const getReaderInfo = (pk, data, ts, options = {}) => {
   const params = serializeParams(data, ts);
   const bookPath = _getBookPath(pk);
-  return HTTP.get(bookPath, { params });
+  return HTTP.get(bookPath, { params, ...options });
 };
 
 const _getReaderAPIPath = (pk) => {

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -16,15 +16,38 @@ export default {
   computed: {
     ...mapState(useAuthStore, {
       user: (state) => state.user,
+      /*
+       * Kiosk mode: no per-user account but the server still
+       * wants the visitor's timezone for display. Watching this
+       * flag alongside ``user`` lets us cover both auth paths
+       * without double-firing setTimezone on first authenticated
+       * load.
+       */
+      nonUsers: (state) => state.adminFlags?.nonUsers,
     }),
   },
   watch: {
-    user(to) {
-      if (to) {
-        this.setTimezone();
-        // If the user changes resubscribe to channels.
-        useSocketStore().reopen();
-      }
+    user: {
+      immediate: true,
+      handler(to) {
+        if (to) {
+          this.setTimezone();
+          /* If the user changes resubscribe to channels. */
+          useSocketStore().reopen();
+        }
+      },
+    },
+    nonUsers: {
+      immediate: true,
+      handler(to) {
+        /*
+         * Kiosk path only — when there's a real user the
+         * ``user`` watcher above already covers setTimezone.
+         */
+        if (to && !this.user) {
+          this.setTimezone();
+        }
+      },
     },
   },
   async created() {
@@ -36,12 +59,13 @@ export default {
      * round-trip when the user clicks the button. ``allSettled``
      * (rather than ``all``) so a failure in one — e.g. the
      * /opds-urls endpoint returning 401 before auth lands —
-     * doesn't suppress the others.
+     * doesn't suppress the others. ``setTimezone`` was previously
+     * chained off ``loadProfile`` here, but the ``user`` /
+     * ``nonUsers`` watchers cover both paths and avoid the
+     * double-fire that the chain caused on every authenticated
+     * boot.
      */
-    Promise.allSettled([
-      this.loadProfile().then(() => this.setTimezone()),
-      this.loadOPDSURLs(),
-    ]);
+    Promise.allSettled([this.loadProfile(), this.loadOPDSURLs()]);
   },
   methods: {
     ...mapActions(useAuthStore, [

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,18 +1,23 @@
 <template>
   <v-app>
     <router-view />
+    <SessionErrorSnackbar />
   </v-app>
 </template>
 
 <script>
 import { mapActions, mapState } from "pinia";
 
+import SessionErrorSnackbar from "@/components/session-error-snackbar.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useCommonStore } from "@/stores/common";
 import { useSocketStore } from "@/stores/socket";
 
 export default {
   name: "App",
+  components: {
+    SessionErrorSnackbar,
+  },
   computed: {
     ...mapState(useAuthStore, {
       user: (state) => state.user,

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -8,6 +8,7 @@
 import { mapActions, mapState } from "pinia";
 
 import { useAuthStore } from "@/stores/auth";
+import { useCommonStore } from "@/stores/common";
 import { useSocketStore } from "@/stores/socket";
 
 export default {
@@ -28,9 +29,19 @@ export default {
   },
   async created() {
     this.loadAdminFlags();
-    this.loadProfile().then(() => {
-      this.setTimezone();
-    });
+    /*
+     * Boot phase: kick off the independent network requests in
+     * parallel. Pre-warming ``loadOPDSURLs`` here means the OPDS
+     * dialog opens against cached state instead of waiting on a
+     * round-trip when the user clicks the button. ``allSettled``
+     * (rather than ``all``) so a failure in one — e.g. the
+     * /opds-urls endpoint returning 401 before auth lands —
+     * doesn't suppress the others.
+     */
+    Promise.allSettled([
+      this.loadProfile().then(() => this.setTimezone()),
+      this.loadOPDSURLs(),
+    ]);
   },
   methods: {
     ...mapActions(useAuthStore, [
@@ -38,6 +49,7 @@ export default {
       "loadProfile",
       "setTimezone",
     ]),
+    ...mapActions(useCommonStore, ["loadOPDSURLs"]),
   },
 };
 </script>

--- a/frontend/src/components/session-error-snackbar.vue
+++ b/frontend/src/components/session-error-snackbar.vue
@@ -1,0 +1,48 @@
+<template>
+  <v-snackbar
+    v-model="show"
+    color="error"
+    timeout="-1"
+    location="top"
+    multi-line
+  >
+    {{ message }}
+    <template #actions>
+      <v-btn variant="text" @click="reload"> Reload </v-btn>
+      <v-btn variant="text" @click="dismiss"> Dismiss </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+<script>
+import { mapActions, mapState } from "pinia";
+
+import { useCommonStore } from "@/stores/common";
+
+export default {
+  name: "SessionErrorSnackbar",
+  computed: {
+    ...mapState(useCommonStore, {
+      message: (state) => state.sessionError,
+    }),
+    show: {
+      get() {
+        return Boolean(this.message);
+      },
+      set(value) {
+        if (!value) {
+          this.clearSessionError();
+        }
+      },
+    },
+  },
+  methods: {
+    ...mapActions(useCommonStore, ["clearSessionError"]),
+    dismiss() {
+      this.clearSessionError();
+    },
+    reload() {
+      globalThis.location.reload();
+    },
+  },
+};
+</script>

--- a/frontend/src/stores/admin.js
+++ b/frontend/src/stores/admin.js
@@ -1,3 +1,4 @@
+import { dequal } from "dequal";
 import { defineStore } from "pinia";
 
 import API from "@/api/v3/admin";
@@ -231,15 +232,41 @@ export const useAdminStore = defineStore("admin", {
       await API.getAllLibrarianStatuses()
         .then((response) => {
           if (Array.isArray(response.data)) {
-            const map = {};
+            const next = {};
             for (const status of response.data) {
-              map[status.statusType] = status;
+              next[status.statusType] = status;
             }
-            this.allLibrarianStatuses = map;
+            this._patchAllLibrarianStatuses(next);
           }
           return true;
         })
         .catch(console.warn);
+    },
+    _patchAllLibrarianStatuses(next) {
+      // Diff-based update. The previous code reassigned
+      // ``allLibrarianStatuses`` to a brand-new object on every
+      // poll, forcing every computed/watcher subscribing to the
+      // map (job-tab progress bars, status-list rows) to
+      // re-evaluate even when nothing actually moved. The
+      // websocket-driven LIBRARIAN_STATUS fan-out can fire many
+      // times a second during an active import, so this
+      // dominated job-tab render time.
+      //
+      // Mutate keys in place: Pinia's reactivity then notifies
+      // only watchers that touch the specific keys we changed.
+      const current = this.allLibrarianStatuses;
+      // Remove keys that vanished from the latest payload.
+      for (const key of Object.keys(current)) {
+        if (!(key in next)) {
+          delete current[key];
+        }
+      }
+      // Add or replace keys whose values actually changed.
+      for (const [key, value] of Object.entries(next)) {
+        if (!dequal(current[key], value)) {
+          current[key] = value;
+        }
+      }
     },
     async updateAPIKey() {
       if (this._requireAdmin()) return false;

--- a/frontend/src/stores/admin.js
+++ b/frontend/src/stores/admin.js
@@ -13,6 +13,19 @@ const IRREGULAR_PLURALS = Object.freeze({
   // would work but we spell it out so nobody tacks on "s" by surprise.
   AgeRatingMetron: "AgeRatingMetrons",
 });
+
+// Sticky-cache TTL for admin table reads. Tab-swap navigation
+// inside the admin panel re-fires ``loadTables`` on mount; the
+// previous code refetched every time. With a short window we
+// serve the existing state for redundant reads while still
+// picking up changes from explicit invalidators (CRUD mutations
+// and websocket fan-out both pass ``{ force: true }``).
+const DYNAMIC_TTL_MS = 5_000;
+// AgeRatingMetron is a static enum lookup; once loaded it never
+// needs refreshing for the session.
+const TABLE_TTL_MS = Object.freeze({
+  AgeRatingMetron: Number.POSITIVE_INFINITY,
+});
 export const TABS = Object.freeze([
   "Users",
   "Groups",
@@ -86,8 +99,20 @@ export const useAdminStore = defineStore("admin", {
     _requireAdmin() {
       return !this.isUserAdmin;
     },
-    async loadTable(table) {
+    async loadTable(table, { force = false } = {}) {
       if (this._requireAdmin()) return false;
+      // Sticky-cache gate. Skip if we've loaded this table within
+      // the TTL window and the caller didn't explicitly demand a
+      // fresh read. CRUD mutations and websocket-driven refetches
+      // pass ``{ force: true }`` because they know the data
+      // changed underneath us.
+      if (!force) {
+        const ttl = TABLE_TTL_MS[table] ?? DYNAMIC_TTL_MS;
+        const last = this.timestamps[table] || 0;
+        if (last && Date.now() - last < ttl) {
+          return true;
+        }
+      }
       const pluralTable = getTablePlural(table);
       const apiFn = "get" + pluralTable;
       await API[apiFn]()
@@ -96,6 +121,7 @@ export const useAdminStore = defineStore("admin", {
             pluralTable.charAt(0).toLowerCase() + pluralTable.slice(1);
           if (Array.isArray(response.data)) {
             this[stateField] = response.data;
+            this.timestamps[table] = Date.now();
             return true;
           } else {
             console.warn(stateField, "response not an array");
@@ -104,10 +130,10 @@ export const useAdminStore = defineStore("admin", {
         })
         .catch(warnError);
     },
-    loadTables(tables) {
+    loadTables(tables, options) {
       if (this._requireAdmin()) return false;
       for (const table of tables) {
-        this.loadTable(table);
+        this.loadTable(table, options);
       }
     },
     async loadFolders(path, showHidden) {
@@ -130,7 +156,7 @@ export const useAdminStore = defineStore("admin", {
       await API[apiFn](data)
         .then(() => {
           commonStore.clearErrors();
-          return this.loadTable(table);
+          return this.loadTable(table, { force: true });
         })
         .catch(commonStore.setErrors);
     },
@@ -141,7 +167,7 @@ export const useAdminStore = defineStore("admin", {
       await API[apiFn](pk, data)
         .then(() => {
           commonStore.clearErrors();
-          return this.loadTable(table);
+          return this.loadTable(table, { force: true });
         })
         .catch(commonStore.setErrors);
     },
@@ -162,7 +188,7 @@ export const useAdminStore = defineStore("admin", {
       await API[apiFn](pk)
         .then(() => {
           commonStore.clearErrors();
-          return this.loadTable(table);
+          return this.loadTable(table, { force: true });
         })
         .catch(commonStore.setErrors);
     },

--- a/frontend/src/stores/admin.js
+++ b/frontend/src/stores/admin.js
@@ -130,11 +130,17 @@ export const useAdminStore = defineStore("admin", {
         })
         .catch(warnError);
     },
-    loadTables(tables, options) {
+    async loadTables(tables, options) {
       if (this._requireAdmin()) return false;
-      for (const table of tables) {
-        this.loadTable(table, options);
-      }
+      // ``Promise.all`` so every fetch runs concurrently and the
+      // returned promise resolves only once they've all settled.
+      // Previously this was a fire-and-forget for-loop: callers
+      // that awaited it received a synchronous ``undefined`` and
+      // could observe an admin tab's state mid-load (some tables
+      // populated, some still empty), which presented as flicker.
+      return await Promise.all(
+        tables.map((table) => this.loadTable(table, options)),
+      );
     },
     async loadFolders(path, showHidden) {
       if (this._requireAdmin()) return false;

--- a/frontend/src/stores/browser.js
+++ b/frontend/src/stores/browser.js
@@ -1,6 +1,7 @@
 import { dequal } from "dequal";
 import { defineStore } from "pinia";
 import { toRaw } from "vue";
+import { dedupedFetch, isAbortError, useAbortable } from "@/api/v3/abortable";
 import API from "@/api/v3/browser";
 import COMMON_API from "@/api/v3/common";
 import BROWSER_CHOICES from "@/choices/browser-choices.json";
@@ -576,55 +577,73 @@ export const useBrowserStore = defineStore("browser", {
       } else {
         return this.loadSettings();
       }
-      await API.getBrowserPage(route.params, this.settings, mtime)
-        .then((response) => {
-          const { breadcrumbs, ...page } = response.data;
-          this.$patch((state) => {
-            state.settings.breadcrumbs = Object.freeze(breadcrumbs);
-            state.page = Object.freeze(page);
-            if (
-              (state.settings.orderBy === "search_score" && !page.fts) ||
-              (state.settings.orderBy === "child_count" &&
-                page.modelGroup === "c")
-            ) {
-              state.settings.orderBy = "sort_name";
-            }
-            state.choices.dynamic = undefined;
-            state.browserPageLoaded = true;
-          });
-          return true;
-        })
-        .catch(this.handlePageError);
+      // Single-flight: a rapid group switch aborts the previous
+      // fetch so its late-arriving response can't ``$patch`` stale
+      // state over the current route's data.
+      const signal = useAbortable("browser:loadBrowserPage");
+      try {
+        const response = await API.getBrowserPage(
+          route.params,
+          this.settings,
+          mtime,
+          { signal },
+        );
+        const { breadcrumbs, ...page } = response.data;
+        this.$patch((state) => {
+          state.settings.breadcrumbs = Object.freeze(breadcrumbs);
+          state.page = Object.freeze(page);
+          if (
+            (state.settings.orderBy === "search_score" && !page.fts) ||
+            (state.settings.orderBy === "child_count" &&
+              page.modelGroup === "c")
+          ) {
+            state.settings.orderBy = "sort_name";
+          }
+          state.choices.dynamic = undefined;
+          state.browserPageLoaded = true;
+        });
+      } catch (error) {
+        if (isAbortError(error)) return;
+        this.handlePageError(error);
+      }
       if (updateSettings) {
         API.updateSettings(this.settings);
       }
     },
     async loadAvailableFilterChoices() {
-      return await API.getAvailableFilterChoices(
-        router.currentRoute.value.params,
-        this.filterOnlySettings,
-        this.page.mtime,
-      )
-        .then((response) => {
-          this.choices.dynamic = response.data;
-          return true;
-        })
-        .catch(console.error);
+      const signal = useAbortable("browser:loadAvailableFilterChoices");
+      try {
+        const response = await API.getAvailableFilterChoices(
+          router.currentRoute.value.params,
+          this.filterOnlySettings,
+          this.page.mtime,
+          { signal },
+        );
+        this.choices.dynamic = response.data;
+        return true;
+      } catch (error) {
+        if (isAbortError(error)) return;
+        console.error(error);
+      }
     },
     async loadFilterChoices(fieldName) {
-      return await API.getFilterChoices(
-        router.currentRoute.value.params,
-        fieldName,
-        this.filterOnlySettings,
-        this.page.mtime,
-      )
-        .then((response) => {
-          this.choices.dynamic[fieldName] = Object.freeze(
-            response.data.choices,
-          );
-          return true;
-        })
-        .catch(console.error);
+      // Per-field key so different filter menus opening in parallel
+      // don't abort each other.
+      const signal = useAbortable(`browser:loadFilterChoices:${fieldName}`);
+      try {
+        const response = await API.getFilterChoices(
+          router.currentRoute.value.params,
+          fieldName,
+          this.filterOnlySettings,
+          this.page.mtime,
+          { signal },
+        );
+        this.choices.dynamic[fieldName] = Object.freeze(response.data.choices);
+        return true;
+      } catch (error) {
+        if (isAbortError(error)) return;
+        console.error(error);
+      }
     },
     async loadMtimes() {
       const params = router?.currentRoute?.value?.params;
@@ -633,16 +652,23 @@ export const useBrowserStore = defineStore("browser", {
         routeGroup && routeGroup != "r" ? routeGroup : this.page.modelGroup;
       const pks = params?.pks || "0";
       const arcs = [{ group, pks }];
-      return await COMMON_API.getMtime(arcs, this.filterOnlySettings)
-        .then((response) => {
-          const newMtime = response?.data?.maxMtime;
-          if (newMtime !== this.page.mtime) {
-            this.choices.dynamic = undefined;
-            this.loadBrowserPage(newMtime);
-          }
-          return true;
-        })
-        .catch(console.error);
+      // Dedup so concurrent callers (websocket fan-out across the
+      // browser + reader stores, rapid notifications) share one
+      // request instead of stampeding.
+      const dedupKey = `browser:loadMtimes:${group}:${pks}`;
+      try {
+        const response = await dedupedFetch(dedupKey, () =>
+          COMMON_API.getMtime(arcs, this.filterOnlySettings),
+        );
+        const newMtime = response?.data?.maxMtime;
+        if (newMtime !== this.page.mtime) {
+          this.choices.dynamic = undefined;
+          this.loadBrowserPage(newMtime);
+        }
+        return true;
+      } catch (error) {
+        console.error(error);
+      }
     },
     routeWithSettings(settings, route) {
       if (!route) {

--- a/frontend/src/stores/common.js
+++ b/frontend/src/stores/common.js
@@ -47,6 +47,14 @@ export const useCommonStore = defineStore("common", {
     timestamp: Date.now(),
     isSettingsDrawerOpen: false,
     opdsURLs: undefined,
+    /*
+     * Global app-level error string surfaced via a v-snackbar in
+     * the root component. Reserved for problems that aren't tied
+     * to a specific form (where ``form.errors`` would suffice) —
+     * e.g. an expired CSRF cookie that leaves the session in a
+     * silently-broken state and needs a user-visible nudge.
+     */
+    sessionError: "",
   }),
   actions: {
     async loadVersions() {
@@ -76,6 +84,12 @@ export const useCommonStore = defineStore("common", {
         state.form.errors = [];
         state.form.success = "";
       });
+    },
+    setSessionError(message) {
+      this.sessionError = message;
+    },
+    clearSessionError() {
+      this.sessionError = "";
     },
     setTimestamp() {
       this.timestamp = Date.now();

--- a/frontend/src/stores/reader.js
+++ b/frontend/src/stores/reader.js
@@ -2,6 +2,7 @@ import { mdiBookArrowDown, mdiBookArrowUp } from "@mdi/js";
 import { defineStore } from "pinia";
 import { capitalCase } from "text-case";
 
+import { dedupedFetch, isAbortError, useAbortable } from "@/api/v3/abortable";
 import BROWSER_API from "@/api/v3/browser";
 import COMMON_API from "@/api/v3/common";
 import READER_API, { getComicPageSource } from "@/api/v3/reader";
@@ -436,52 +437,58 @@ export const useReaderStore = defineStore("reader", {
           mtime = this.mtime;
         }
       }
-      await READER_API.getReaderInfo(pk, settings, mtime)
-        .then((response) => {
-          const data = response.data;
-          const books = data.books;
-
-          // Undefined settings breaks code.
-          const allBooks = [books?.prev, books?.current, books?.next];
-          for (const book of allBooks) {
-            if (book && !book.settings) {
-              book.settings = {};
-            }
-          }
-          // Generate routes.
-          const routesBooks = this._getBookRoutes(books.prev, books.next);
-
-          this.$patch((state) => {
-            state.books = books;
-            state.arcs = data.arcs;
-            state.arc = data.arc;
-            state.routes.prev = this._getRouteParams(
-              state.books.current,
-              params.page,
-              "prev",
-            );
-            state.routes.next = this._getRouteParams(
-              state.books.current,
-              params.page,
-              "next",
-            );
-            state.routes.books = routesBooks;
-            state.routes.close = data.closeRoute;
-            state.empty = false;
-            state.mtime = data.mtime;
-            state.bookSettings = {};
-          });
-
-          // Load all three settings layers for the current comic.
-          if (books.current?.pk) {
-            this.loadAllSettings(+books.current.pk);
-          }
-          return true;
-        })
-        .catch((error) => {
-          console.debug(error);
-          this.empty = true;
+      // Single-flight: rapid Next-Book clicks abort the previous
+      // fetch so its late response can't merge stale book settings
+      // over the new book's state.
+      const signal = useAbortable("reader:loadBooks");
+      try {
+        const response = await READER_API.getReaderInfo(pk, settings, mtime, {
+          signal,
         });
+        const data = response.data;
+        const books = data.books;
+
+        // Undefined settings breaks code.
+        const allBooks = [books?.prev, books?.current, books?.next];
+        for (const book of allBooks) {
+          if (book && !book.settings) {
+            book.settings = {};
+          }
+        }
+        // Generate routes.
+        const routesBooks = this._getBookRoutes(books.prev, books.next);
+
+        this.$patch((state) => {
+          state.books = books;
+          state.arcs = data.arcs;
+          state.arc = data.arc;
+          state.routes.prev = this._getRouteParams(
+            state.books.current,
+            params.page,
+            "prev",
+          );
+          state.routes.next = this._getRouteParams(
+            state.books.current,
+            params.page,
+            "next",
+          );
+          state.routes.books = routesBooks;
+          state.routes.close = data.closeRoute;
+          state.empty = false;
+          state.mtime = data.mtime;
+          state.bookSettings = {};
+        });
+
+        // Load all three settings layers for the current comic.
+        if (books.current?.pk) {
+          this.loadAllSettings(+books.current.pk);
+        }
+        return true;
+      } catch (error) {
+        if (isAbortError(error)) return;
+        console.debug(error);
+        this.empty = true;
+      }
     },
     async loadMtimes() {
       const arcs = [];
@@ -498,15 +505,26 @@ export const useReaderStore = defineStore("reader", {
         // 500 from the API, so the fallback never actually worked.
         arcs.push({ group: "r", pks: "0" });
       }
-      return await COMMON_API.getMtime(arcs, {})
-        .then((response) => {
-          const newMtime = response.data.maxMtime;
-          if (newMtime !== this.mtime) {
-            return this.loadBooks({ mtime: newMtime });
-          }
-          return true;
-        })
-        .catch(console.error);
+      // Dedup so concurrent callers (websocket fan-out across the
+      // browser + reader stores, rapid notifications) share one
+      // request. Key on the sorted arc list so distinct arc sets
+      // don't collide; same-shape concurrent calls coalesce.
+      const dedupKey = `reader:loadMtimes:${arcs
+        .map((a) => `${a.group}/${a.pks}`)
+        .sort()
+        .join(",")}`;
+      try {
+        const response = await dedupedFetch(dedupKey, () =>
+          COMMON_API.getMtime(arcs, {}),
+        );
+        const newMtime = response.data.maxMtime;
+        if (newMtime !== this.mtime) {
+          return this.loadBooks({ mtime: newMtime });
+        }
+        return true;
+      } catch (error) {
+        console.error(error);
+      }
     },
     async _setBookmarkPage(page) {
       const groupParams = { group: "c", ids: [+this.books.current.pk] };

--- a/frontend/src/stores/socket.js
+++ b/frontend/src/stores/socket.js
@@ -17,8 +17,14 @@ const USER_GROUP_ROUTES = Object.freeze([
 ]);
 
 const HEARTBEAT_INTERVAL_MS = 5_000;
-const RECONNECT_RETRIES = Infinity;
-const RECONNECT_DELAY_MS = 3_000;
+// Exponential backoff: 1s, 2s, 4s, 8s, 16s, then 30s cap. Avoids
+// hammering a momentarily-down server (the previous fixed 3s delay
+// pinned us to ~20 reconnect attempts/min while the server was
+// unreachable) while still reconnecting quickly after a transient
+// blip. Counter resets on successful connect so a long-lived
+// session that drops once doesn't pay the full backoff next time.
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
 
 // TODO move to some generic util.
 function currentRouteName() {
@@ -30,6 +36,8 @@ function currentRouteName() {
 // received within its pongTimeout (default 1000ms), which breaks servers
 // that silently consume the ping without echoing anything back.
 let heartbeatTimer = 0;
+let reconnectTimer = 0;
+let reconnectAttempts = 0;
 
 function startHeartbeat(ws) {
   stopHeartbeat();
@@ -45,17 +53,39 @@ function stopHeartbeat() {
   heartbeatTimer = 0;
 }
 
+function clearReconnectTimer() {
+  globalThis.clearTimeout(reconnectTimer);
+  reconnectTimer = 0;
+}
+
+function scheduleReconnect(open) {
+  // Coalesce: a duplicate ``onDisconnected`` (or a stray error
+  // before the scheduled reconnect fires) shouldn't double-schedule.
+  if (reconnectTimer) return;
+  const delay = Math.min(
+    RECONNECT_BASE_MS * 2 ** reconnectAttempts,
+    RECONNECT_MAX_MS,
+  );
+  reconnectAttempts += 1;
+  console.debug(
+    `[socket] Reconnecting in ${delay}ms (attempt ${reconnectAttempts}).`,
+  );
+  reconnectTimer = globalThis.setTimeout(() => {
+    reconnectTimer = 0;
+    open();
+  }, delay);
+}
+
 export const useSocketStore = defineStore("socket", () => {
+  // ``autoReconnect: false`` disables vueuse's fixed-delay loop;
+  // we drive reconnect ourselves from ``onDisconnected`` so we can
+  // back off exponentially.
   const { status, open } = useWebSocket(WS_URL, {
     immediate: true,
-    autoReconnect: {
-      retries: RECONNECT_RETRIES,
-      delay: RECONNECT_DELAY_MS,
-      onFailed() {
-        console.error("[socket] Failed to reconnect after all retries");
-      },
-    },
+    autoReconnect: false,
     onConnected(ws) {
+      clearReconnectTimer();
+      reconnectAttempts = 0;
       startHeartbeat(ws);
       console.debug("[socket] Connected.");
     },
@@ -73,6 +103,7 @@ export const useSocketStore = defineStore("socket", () => {
         "reason:",
         event.reason || "(none)",
       );
+      scheduleReconnect(open);
     },
   });
 
@@ -190,6 +221,11 @@ export const useSocketStore = defineStore("socket", () => {
   const reopen = () => {
     // Don't force a reopen if we're in the middle of connecting.
     if (status.value == "CONNECTING") return;
+    // Cancel any pending backoff-scheduled reconnect; the user
+    // change is an authoritative trigger and we want to attempt
+    // immediately, not wait out the previous failure's window.
+    clearReconnectTimer();
+    reconnectAttempts = 0;
     open(true);
   };
 

--- a/frontend/src/stores/socket.js
+++ b/frontend/src/stores/socket.js
@@ -120,7 +120,10 @@ export const useSocketStore = defineStore("socket", () => {
 
   async function adminLoadTables(tables) {
     const adminStore = await getAdminStore();
-    adminStore?.loadTables(tables);
+    // Force-skip the admin store's sticky cache: a websocket
+    // fan-out fires precisely because the data changed on the
+    // server, so cached state is by definition stale.
+    adminStore?.loadTables(tables, { force: true });
   }
 
   async function adminLoadAllStatuses() {


### PR DESCRIPTION
## Summary

Sub-plan 02 of the frontend perf series — ten focused commits that
cut redundant network work across the navigation, websocket, admin,
and boot paths.

- **Request dedup helpers** (`useAbortable` + `dedupedFetch` in
  `api/v3/abortable.js`) and adoption at the navigation-driven call
  sites (`loadBrowserPage`, `loadBooks`, `loadFilterChoices`,
  `loadAvailableFilterChoices`, `loadMtimes`). Rapid group/book
  switches now abort their in-flight predecessors so late
  responses can't ``$patch`` stale state, and same-shape concurrent
  mtime polls share a single in-flight promise.
- **WebSocket exponential backoff** (1s → 30s cap, reset on
  connect). The previous fixed 3s loop hammered the server on
  outage and never amortized.
- **CSRF token cache** keyed on the cookie snapshot. Token regex
  now runs only when ``document.cookie`` actually changes; cache
  invalidates on the existing 403/CSRF handler.
- **Admin sticky cache + AgeRatingMetron static**. ``loadTable``
  serves cached state within a 5s window so admin tab swaps don't
  refetch; the AgeRatingMetron enum lookup is treated as
  session-static and the ``ts`` cache-buster is dropped from its
  request. CRUD mutations and websocket fan-out pass
  ``{ force: true }`` to bypass.
- **Admin loadTables Promise.all**. Was a fire-and-forget for-loop
  that resolved before the underlying loads, letting the UI
  observe mid-load tabs as flicker.
- **Admin loadAllStatuses diff**. Mutates only the status keys
  whose values actually changed instead of swapping the whole map
  on every websocket-driven poll. Stops job-tab progress bars
  from re-rendering on no-op pushes.
- **OPDS URL pre-fetch on boot** so the dialog opens against
  cached state.
- **Single setTimezone path** via `immediate: true` watcher; the
  previous flow fired the timezone API twice on every
  authenticated boot. A second watcher on
  `adminFlags.nonUsers` covers kiosk mode.
- **CSRF 403 user surfacing** via a new
  `SessionErrorSnackbar` reading from `useCommonStore.sessionError`.
  Previously the cookie was dropped silently and every subsequent
  request 401'd with no UI feedback.

## Test plan

- [x] `bunx eslint --no-warn-ignored frontend/` — 0 errors
- [x] `bunx prettier --check frontend/` — clean
- [x] `bunx vitest run` — 1 pass
- [x] `bunx vite build` — succeeds (the Vite chunking warning on
      the lazy `useCommonStore` import is intentional — static
      import would create a load-time cycle through
      `api/v3/base.js → stores/common.js → api/v3/common.js`)
- [ ] Manual: rapid group switch fires only the latest payload
- [ ] Manual: WS reconnect cadence visible in console (1s, 2s,
      4s, 8s, 16s, 30s, 30s…)
- [ ] Manual: admin tab swap doesn't refetch within 5s window
- [ ] Manual: simulate CSRF 403 (rotate `csrftoken` cookie),
      observe snackbar with Reload action

🤖 Generated with [Claude Code](https://claude.com/claude-code)