### PR TITLE
Frontend perf: hot-path renders + reader Set-clone fix

### DIFF
--- a/frontend/src/components/browser/card/card.vue
+++ b/frontend/src/components/browser/card/card.vue
@@ -121,9 +121,26 @@ export default {
   mounted() {
     this.scrollToMe();
   },
+  beforeUnmount() {
+    /*
+     * Cancel any pending scroll-restore timers. Without this,
+     * a card that unmounts during the 100-200ms window (rapid
+     * filter change, live-reload, route transition) still
+     * fires ``scrollIntoView`` on a detached node and the
+     * inner ``window.scrollBy`` runs against the wrong page.
+     */
+    if (this._scrollOuterTimer) {
+      globalThis.clearTimeout(this._scrollOuterTimer);
+      this._scrollOuterTimer = 0;
+    }
+    if (this._scrollInnerTimer) {
+      globalThis.clearTimeout(this._scrollInnerTimer);
+      this._scrollInnerTimer = 0;
+    }
+  },
   methods: {
     ...mapActions(useBrowserSelectManyStore, ["toggleItem"]),
-    scrollToMe: function () {
+    scrollToMe() {
       if (
         !this.$route.hash ||
         this.$route.hash.split("-")[1] !== String(this.ids)
@@ -135,21 +152,24 @@ export default {
         console.warn("No element found to scroll to!");
         return;
       }
-      setTimeout(
-        function () {
-          // This works while nextTick() does not.
-          el.scrollIntoView();
-          /*
-           * Adjust for toolbars
-           * For some reason with vue3 i need another delay.
-           */
-          setTimeout(function () {
-            window.scrollBy(0, HEADER_OFFSET);
-          }, SCROLL_DELAY);
-        },
-        // A little hacky delay makes it work even more frequently.
-        SCROLL_DELAY,
-      );
+      /*
+       * Two stacked timers: the outer one waits for the card to
+       * lay out, then ``scrollIntoView``; the inner one waits
+       * for any toolbar reflow, then nudges the scroll up by
+       * ``HEADER_OFFSET``. The empirical 100ms delays were
+       * tuned against Vue 3's mount timing and ``nextTick``
+       * doesn't reliably substitute, so keep the timer shape.
+       * Track the IDs so ``beforeUnmount`` can cancel them.
+       */
+      this._scrollOuterTimer = globalThis.setTimeout(() => {
+        this._scrollOuterTimer = 0;
+        // This works while nextTick() does not.
+        el.scrollIntoView();
+        this._scrollInnerTimer = globalThis.setTimeout(() => {
+          this._scrollInnerTimer = 0;
+          globalThis.scrollBy(0, HEADER_OFFSET);
+        }, SCROLL_DELAY);
+      }, SCROLL_DELAY);
     },
   },
 };

--- a/frontend/src/components/browser/card/order-by-caption.vue
+++ b/frontend/src/components/browser/card/order-by-caption.vue
@@ -39,30 +39,36 @@ export default {
       topGroup: (state) => state.settings.topGroup,
     }),
     orderValue() {
-      let ov = this.item.orderValue;
+      const ov = this.item.orderValue;
+      /*
+       * Hot path: this computed runs once per card per render
+       * (typically 100 cards on a browser page) and the
+       * overwhelmingly common case is ``orderBy`` = ``sort_name``
+       * which produces an empty caption. Bail before allocating
+       * a try/catch frame and walking the type-specific dispatch
+       * below.
+       */
+      if (HIDE_ORDER_BYS.has(this.orderBy)) return "";
+      if (HIDE_ORDER_VALUES.has(ov)) return "";
+      if (this.orderBy === "filename" && this.item.group !== "c") return "";
+      if (this.orderBy === "story_arc_number" && this.item.group === "a") {
+        return "";
+      }
       try {
-        if (
-          HIDE_ORDER_BYS.has(this.orderBy) ||
-          (this.orderBy === "filename" && this.item.group !== "c") ||
-          (this.orderBy === "story_arc_number" && this.item.group === "a") ||
-          HIDE_ORDER_VALUES.has(ov)
-        ) {
-          ov = "";
-        } else if (DATE_SORT_BY.has(this.orderBy)) {
+        if (DATE_SORT_BY.has(this.orderBy)) {
           const date = new Date(ov);
-          ov = DATE_FORMAT.format(date);
-        } else if (this.orderBy == "search_score") {
-          ov = this.format_search_score(ov);
+          return DATE_FORMAT.format(date);
+        } else if (this.orderBy === "search_score") {
+          return this.format_search_score(ov);
         } else if (TIME_SORT_BY.has(this.orderBy)) {
-          // this is what needs v-html to work with the embedded break.
-          ov = getDateTime(ov, this.twentyFourHourTime, true);
-        } else if (this.orderBy == "page_count") {
-          const human = NUMBER_FORMAT.format(ov);
-          ov = `${human} pages`;
-        } else if (this.orderBy == "size") {
-          ov = prettyBytes(Number.parseInt(ov, 10));
+          // This is what needs v-html to work with the embedded break.
+          return getDateTime(ov, this.twentyFourHourTime, true);
+        } else if (this.orderBy === "page_count") {
+          return `${NUMBER_FORMAT.format(ov)} pages`;
+        } else if (this.orderBy === "size") {
+          return prettyBytes(Number.parseInt(ov, 10));
         } else if (STAR_SORT_BY.has(this.orderBy)) {
-          ov = `★  ${ov}`;
+          return `★  ${ov}`;
         }
       } catch (error) {
         // Often orderBy gets updated before orderValue gets returned.

--- a/frontend/src/components/browser/main.vue
+++ b/frontend/src/components/browser/main.vue
@@ -58,10 +58,24 @@ export default {
             (this.librariesExist == undefined || !state.browserPageLoaded))
         );
       },
-      cards: (state) => [
-        ...(state.page.groups ?? []),
-        ...(state.page.books ?? []),
-      ],
+      cards(state) {
+        /*
+         * Skip the spread when one of the lists is empty. The
+         * typical browser page is either all groups (publishers,
+         * series, volumes) or all books — never a mix — so the
+         * common case is "spread an array against an empty
+         * array", which still allocates a fresh wrapper per
+         * render even though the contents are identical to the
+         * non-empty input. Returning the reference directly when
+         * we can lets Vue's diff cache shortcut to "same array,
+         * same items" and the v-for stays stable across renders.
+         */
+        const groups = state.page.groups;
+        const books = state.page.books;
+        if (!groups || groups.length === 0) return books ?? [];
+        if (!books || books.length === 0) return groups;
+        return [...groups, ...books];
+      },
       numPages: (state) => state.page.numPages,
       search: (state) => state.settings.search,
       isSearchOpen: (state) => state.isSearchOpen,

--- a/frontend/src/components/metadata/metadata-chip.vue
+++ b/frontend/src/components/metadata/metadata-chip.vue
@@ -90,8 +90,17 @@ export default {
       return this.highlight ? "flat" : "tonal";
     },
     color() {
-      const colors = this.$vuetify.theme.current.colors;
-      return this.highlight ? colors["primary-darken-1"] : "";
+      /*
+       * v-chip's ``:color`` prop accepts Vuetify theme tokens
+       * directly. The previous code drilled through
+       * ``this.$vuetify.theme.current.colors`` per chip per
+       * render to resolve the hex string, which forced the
+       * theme proxy to traverse on every chip in a
+       * 50-chip-per-dialog metadata view. Returning the token
+       * lets Vuetify resolve it once at the chip level via
+       * its theme machinery instead.
+       */
+      return this.highlight ? "primary-darken-1" : "";
     },
     linkGroup() {
       let linkGroup;

--- a/frontend/src/components/metadata/metadata-text.vue
+++ b/frontend/src/components/metadata/metadata-text.vue
@@ -72,7 +72,7 @@ export default {
     return {
       mdiOpenInNew,
       expanded: false,
-      mounted: false,
+      isOverflow: false,
     };
   },
   computed: {
@@ -113,16 +113,6 @@ export default {
     textValueRefName() {
       const name = "mdTextValue" + this.label.replaceAll(" ", "");
       return name;
-    },
-    isOverflow() {
-      if (!this.mounted) {
-        return false;
-      }
-      const el = this.$refs[this.textValueRefName];
-      if (!el) {
-        return false;
-      }
-      return el.clientHeight < el.scrollHeight;
     },
     showExpandButton() {
       return !this.expanded && this.maxHeight > 0 && this.isOverflow;
@@ -186,7 +176,30 @@ export default {
     },
   },
   mounted() {
-    this.mounted = true;
+    /*
+     * Defer the overflow measurement to the next frame. The
+     * previous code computed ``isOverflow`` from a getter that
+     * read ``clientHeight`` and ``scrollHeight`` — measurement
+     * properties that force a synchronous layout flush. Reading
+     * them during render mixes the measurement into Vue's
+     * commit phase; deferring to ``requestAnimationFrame`` runs
+     * after the browser's natural layout pass and lets every
+     * sibling field in the metadata dialog batch into one
+     * reflow rather than each forcing its own.
+     */
+    this._overflowFrame = globalThis.requestAnimationFrame(() => {
+      this._overflowFrame = 0;
+      const el = this.$refs[this.textValueRefName];
+      if (el) {
+        this.isOverflow = el.clientHeight < el.scrollHeight;
+      }
+    });
+  },
+  beforeUnmount() {
+    if (this._overflowFrame) {
+      globalThis.cancelAnimationFrame(this._overflowFrame);
+      this._overflowFrame = 0;
+    }
   },
   methods: {
     ...mapActions(useBrowserStore, ["routeWithSettings", "getTopGroup"]),

--- a/frontend/src/stores/reader.js
+++ b/frontend/src/stores/reader.js
@@ -190,8 +190,20 @@ export const useReaderStore = defineStore("reader", {
         return {};
       }
       if (!(book.pk in this.bookSettings)) {
-        // Mask the book settings over intermediate over global settings.
-        const resultSettings = structuredClone(SETTINGS_NULL_VALUES);
+        /*
+         * Mask the book settings over intermediate over global
+         * settings into a fresh accumulator. The previous code
+         * cloned ``SETTINGS_NULL_VALUES`` here, but that
+         * constant is a ``Set`` of null-ish sentinels used by
+         * the loop below to filter — not a defaults object.
+         * Cloning it produced a ``Set`` with extra string keys
+         * tacked on, which worked by accident because JS lets
+         * you add fields to any object and ``Object.entries``
+         * iterates the bag-like properties. Replace with an
+         * empty object: same behavior, no per-call clone, no
+         * shape confusion.
+         */
+        const resultSettings = {};
         let bookSettings = book?.settings || {};
         bookSettings = this.setReadRTLInReverse(bookSettings);
         const allSettings = [


### PR DESCRIPTION
## Summary

Sub-plan 03 of the frontend perf series. Six focused commits hitting
hot-path render allocations, plus one accidental-Set-clone fix in
the reader store that the audit caught.

The plan originally suggested splitting browser-side and metadata-
side into two PRs. The actual changes turned out to be tightly
contained (each commit touches one file) and modest in size, so
they're shipped together for review economy.

The plan listed 19 candidate items. After verifying each against
the codebase I shipped only the ones that were genuinely on a hot
path — several of the original candidates turned out to have
overstated costs (Object.freeze is shallow, not deep; per-card
double timer fires only on the matched route-hash card; etc.) and
were dropped pending measurement.

### Browser-side hot paths

- **`order-by-caption`** — early-return at the top of the computed
  for the cases that produce an empty caption (the common
  ``sort_name`` orderBy and null/undefined values). This computed
  runs once per card per render across 100-card pages; the
  previous code allocated a try/catch frame and walked the
  type-dispatch ladder for every card every time.
- **Browser `cards`** — skip the array spread when one of
  ``groups`` / ``books`` is empty. The browser page is always one
  or the other, never a mix; the previous getter unconditionally
  spread both into a fresh array, allocating against an empty
  side. Returning the populated reference lets Vue's v-for diff
  short-circuit.
- **Browser card `scrollToMe`** — cancel the stacked 100ms
  scroll-restore timers in ``beforeUnmount``. Without cleanup,
  a card that unmounts mid-window fires ``scrollIntoView`` on
  a detached node and ``scrollBy`` against the wrong page.

### Reader store

- **``getBookSettings``** — replace
  ``structuredClone(SETTINGS_NULL_VALUES)`` with ``{}``.
  ``SETTINGS_NULL_VALUES`` is a ``Set`` of null-ish sentinels used
  by the inner loop to filter, not a defaults object — cloning it
  produced a Set with extra string-keyed properties tacked on,
  which worked by accident. The fix drops a per-call clone and
  removes the shape confusion.

### Metadata dialog

- **`metadata-chip`** — pass the theme token (``primary-darken-1``)
  directly to v-chip's ``:color`` prop instead of resolving it
  through ``this.$vuetify.theme.current.colors[...]`` per chip per
  render. Vuetify caches the resolution at the component level.
- **`metadata-text`** — move overflow measurement
  (``clientHeight``/``scrollHeight``) out of a computed and into
  a one-shot ``requestAnimationFrame`` at mount. The reads now
  happen after the browser's natural layout pass so sibling
  fields batch into one reflow instead of each forcing its own.
  Pending rAF is cancelled on unmount.

### Items deliberately deferred

- **P5 (Object.freeze → markRaw)**: the audit assumed
  ``Object.freeze`` was deep. It's shallow, and Vue 3 already
  skips proxying frozen objects, so the perf claim was overblown
  relative to the migration risk.
- **P4 (deep settings watcher)**: fires on mutation, not render —
  not a hot-path issue.
- **P8 (`card.ids.join`)**: Vue's computed memoizes on the
  ``ids`` array reference, which is stable across renders.
- **P11/P13/P15-P17**: same pattern — the alleged "rebuilds per
  render" turned out to be Pinia getters that already memoize on
  state changes.
- **P6 (`_mappedCredits` chain)**: the chain of two getters share
  the same ``state.md.credits`` dependency and only re-run on
  metadata load, not on render.

## Test plan

- [x] `bunx eslint --no-warn-ignored frontend/` — 0 errors
- [x] `bunx prettier --check frontend/` — clean
- [x] `bunx vitest run` — 1 pass
- [x] `bunx vite build` — succeeds
- [ ] Manual: open metadata dialog with many chips, verify
      highlight color renders correctly (theme token resolves)
- [ ] Manual: open metadata dialog with long-text fields, verify
      expand button appears for overflowing fields
- [ ] Manual: scroll-restore on browser back-navigation still
      lands on the originating card

🤖 Generated with [Claude Code](https://claude.com/claude-code)