### PR TITLE
OPDS auth: 401 with WWW-Authenticate and opds-authentication+json

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ border-radius: 128px;
 
 - Fixes
     - Various small frontend fixes
+    - OPDS auth challenges now include the WWW-Authenticate header and the
+      application/opds-authentication+json Content-Type so clients like Panels
+      reliably prompt for credentials.
 
 ## v1.10.13
 

--- a/codex/views/opds/authentication/v1.py
+++ b/codex/views/opds/authentication/v1.py
@@ -1,6 +1,5 @@
 """OPDS Authentication 1.0."""
 
-from re import DEBUG
 from types import MappingProxyType
 
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -10,10 +9,13 @@ from rest_framework import status
 from rest_framework.generics import GenericAPIView
 
 from codex.serializers.opds.authentication import OPDSAuthentication1Serializer
+from codex.settings import DEBUG
 from codex.views.opds.const import MimeType, UserAgentNames
 from codex.views.opds.user_agent import get_user_agent_name
 
 _LOGO_SIZE = 180
+_BASIC_AUTH_REALM = "Codex OPDS"
+_WWW_AUTHENTICATE_BASIC = f'Basic realm="{_BASIC_AUTH_REALM}"'
 _DOC = MappingProxyType(
     {
         "id": reverse_lazy("opds:auth:v1"),
@@ -72,7 +74,15 @@ class OPDSAuthentication1View(GenericAPIView):
         else:
             doc = _DOC
         serializer = cls.serializer_class(doc)  # pyright: ignore[reportOptionalCall]
-        return JsonResponse(serializer.data, status=status_code)
+        response = JsonResponse(
+            serializer.data,
+            status=status_code,
+            content_type=MimeType.AUTHENTICATION,
+        )
+        if status_code == status.HTTP_401_UNAUTHORIZED:
+            # RFC 7235: 401 must include WWW-Authenticate; some OPDS clients require it to trigger an auth prompt.
+            response["WWW-Authenticate"] = _WWW_AUTHENTICATE_BASIC
+        return response
 
     def get(self, *args, **kwargs) -> JsonResponse:
         """Get authentication response."""

--- a/codex/views/opds/error.py
+++ b/codex/views/opds/error.py
@@ -14,11 +14,12 @@ from codex.views.opds.authentication.v1 import OPDSAuthentication1View
 OPDS_PATH_PREFIX = "opds/v"
 _OPDS_V2_PATH_PREFIX = OPDS_PATH_PREFIX + "2"
 _RESET_TOP_GROUP_QUERY = "?topGroup=p"
-_OPDS_REDIRECT_TO_AUTH_CODES = frozenset({status.HTTP_401_UNAUTHORIZED})
+_OPDS_REDIRECT_TO_AUTH_CODES = frozenset(
+    {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}
+)
 _OPDS_REDIRECT_TO_TOP_CODES = frozenset(
     {
         status.HTTP_400_BAD_REQUEST,
-        status.HTTP_403_FORBIDDEN,
         status.HTTP_404_NOT_FOUND,
         status.HTTP_405_METHOD_NOT_ALLOWED,
         status.HTTP_410_GONE,
@@ -53,11 +54,11 @@ def codex_opds_exception_handler(
         name = _get_url_name(request, "feed")
         response = exc.get_response(name)
     elif status_code := getattr(exc, "status_code", None):
-        if status_code == status.HTTP_403_FORBIDDEN:
-            # Codex presents 403 sometimes when it should be presenting 401
-            status_code = status.HTTP_401_UNAUTHORIZED
         if status_code in _OPDS_REDIRECT_TO_AUTH_CODES:
-            response = OPDSAuthentication1View.static_get(request, status_code)
+            # OPDS clients (e.g. Panels) require 401 + auth doc to trigger an auth prompt; 403 stays a forbidden state otherwise.
+            response = OPDSAuthentication1View.static_get(
+                request, status.HTTP_401_UNAUTHORIZED
+            )
         elif (
             not request.path.endswith("progression")
             and status_code in _OPDS_REDIRECT_TO_TOP_CODES


### PR DESCRIPTION
## Summary

- The Panels OPDS reader fails to trigger an auth prompt when no credentials
  are sent. Investigation showed the existing exception handler was already
  converting 403 → 401 with the auth doc body for ``/opds/v*`` paths, but
  was bypassing DRF's natural 401 response and dropping the
  ``WWW-Authenticate`` header and the OPDS auth content type. Strict clients
  (Panels, URLSession-based iOS clients) treat a 401 without
  ``WWW-Authenticate`` as a forbidden state and never prompt the user — which
  matches the symptom the Panels developer reported.
- Fix [codex/views/opds/authentication/v1.py](codex/views/opds/authentication/v1.py)
  so the auth document response sets
  ``Content-Type: application/opds-authentication+json`` and, on 401, the
  ``WWW-Authenticate: Basic realm="Codex OPDS"`` header. Also replace the
  stray ``from re import DEBUG`` (which imported ``re.DEBUG = 128``, always
  truthy) with the Django settings ``DEBUG``.
- Tighten [codex/views/opds/error.py](codex/views/opds/error.py) so 401 and 403
  share one auth-redirect set; the handler always emits 401 when serving the
  auth document and no longer mutates a local ``status_code``.

## What changed

| File | Change |
| --- | --- |
| ``codex/views/opds/authentication/v1.py`` | Set proper Content-Type; add WWW-Authenticate on 401; fix DEBUG import. |
| ``codex/views/opds/error.py`` | Move 403 into the auth-redirect set; always emit 401; drop now-redundant local-var mutation. |
| ``NEWS.md`` | Note the fix under v1.10.14. |

## Why

- RFC 7235 requires a ``WWW-Authenticate`` header on 401 responses.
- OPDS Authentication 1.0 recommends the same header plus
  ``application/opds-authentication+json`` Content-Type.
- DRF's default ``exception_handler`` sets WWW-Authenticate from
  ``exc.auth_header``; Codex's custom handler bypasses that path, so it had
  to set the header itself.

## Verified end-to-end (Django test client)

| URL | Auth | Status | Content-Type | WWW-Authenticate |
| --- | --- | --- | --- | --- |
| ``/opds/v1.2/`` | none | 401 | ``application/opds-authentication+json`` | ``Basic realm="Codex OPDS"`` |
| ``/opds/v2.0/r/0/1`` | none | 401 | ``application/opds-authentication+json`` | ``Basic realm="Codex OPDS"`` |
| ``/opds/v1.2/`` | wrong creds | 401 | ``application/opds-authentication+json`` | ``Basic realm="Codex OPDS"`` |
| ``/opds/v1.2/`` | valid creds | 200 | ``application/xml`` | — |
| ``/opds/auth/v1`` (direct) | none | 200 | ``application/opds-authentication+json`` | — (success, no challenge) |
| ``/opds/bin/c/1/0/page.jpg`` | none | 401 | (DRF default) | ``Basic realm="api"`` (DRF native) |

## Test plan

- [ ] ``ruff check codex/views/opds/ codex/views/error.py`` passes
- [ ] ``ruff format --check`` passes
- [ ] Existing pytest suite passes
- [ ] Manually verify with Panels (or any OPDS reader) that adding a Codex
      server with no/expired credentials prompts for credentials instead of
      silently failing
- [ ] Confirm a logged-in browser session can still browse OPDS feeds
- [ ] Confirm wrong credentials produce the auth challenge (not a hard error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)