### PR TITLE
Admin Flags + Jobs tabs: unify visual language

### DIFF
--- a/frontend/src/components/admin/tabs/admin-section.scss
+++ b/frontend/src/components/admin/tabs/admin-section.scss
@@ -1,0 +1,70 @@
+// Shared chrome for the admin Flags and Jobs tabs. Both render
+// the same shape — titled sections of item cards — and use
+// these primitives so the visual language stays unified.
+//
+// Tab-specific decoration (active-state left border, action
+// buttons, expand panels) layers on top from each tab's own
+// scoped styles.
+
+.adminContainer {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.adminGroup + .adminGroup {
+  margin-top: 1.5em;
+}
+
+.adminGroupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25em;
+}
+
+.adminGroupHeader > h3 {
+  margin: 0;
+}
+
+.adminCard {
+  padding: 12px;
+  margin: 8px 0;
+  border-radius: 5px;
+  background-color: rgb(var(--v-theme-surface-light));
+  border-left: 3px solid transparent;
+  transition: border-color 0.3s ease;
+}
+
+.adminCardActive {
+  border-left-color: rgb(var(--v-theme-primary));
+}
+
+.adminCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.adminCardInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.adminCardTitle {
+  font-weight: 500;
+}
+
+.adminCardDesc {
+  color: rgb(var(--v-theme-textSecondary));
+  font-size: 0.85em;
+  padding-top: 2px;
+}
+
+.adminCardActions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  align-items: center;
+}

--- a/frontend/src/components/admin/tabs/flag-tab.vue
+++ b/frontend/src/components/admin/tabs/flag-tab.vue
@@ -1,38 +1,55 @@
 <template>
-  <v-table id="flags-table" striped="odd">
-    <thead>
-      <tr>
-        <th>Description</th>
-        <th>Value</th>
-        <th>Enabled</th>
-      </tr>
-    </thead>
-    <tbody
-      v-for="group in groupedFlags"
-      :key="`g${group.title}`"
-      class="flagGroup"
-    >
-      <tr class="flagGroupHeader">
-        <th colspan="3">{{ group.title }}</th>
-      </tr>
-      <tr v-for="item in group.items" :key="`f${item.key}`">
-        <td class="nameCol" :colspan="colspan(item)">
-          <div class="text-title-small title">{{ title(item) }}</div>
-          <p class="desc">
-            {{ DESC[item.key] }}
-          </p>
-        </td>
-        <td v-if="item.key === 'BT'" class="bannerTextField">
+  <div id="flags" class="adminContainer">
+    <div v-for="group in groupedFlags" :key="group.title" class="adminGroup">
+      <div class="adminGroupHeader">
+        <h3>{{ group.title }}</h3>
+      </div>
+      <div v-for="item in group.items" :key="`f${item.key}`" class="adminCard">
+        <div class="adminCardHeader">
+          <div class="adminCardInfo">
+            <div class="adminCardTitle">
+              {{ title(item) }}
+            </div>
+            <div class="adminCardDesc">
+              {{ DESC[item.key] }}
+            </div>
+          </div>
+          <div class="adminCardActions">
+            <v-checkbox
+              v-if="!hasValueControl(item)"
+              :model-value="item.on"
+              :true-value="true"
+              :error-messages="errors[item.key]"
+              hide-details="auto"
+              @update:model-value="changeCol(item.key, 'on', $event)"
+            />
+          </div>
+        </div>
+        <!--
+          Value-bearing flags (banner text, age-rating defaults,
+          default browser view) render their control in the card
+          body so the input/select gets the full card width without
+          jamming up against the title in the header.
+        -->
+        <div v-if="item.key === 'BT'" class="flagValueRow">
           <v-text-field
             :model-value="banner"
             label="Banner"
             clearable
             hide-details="auto"
+            density="compact"
             :error-messages="errors[item.key]"
             @update:model-value="banner = $event"
             @click:clear="banner = ''"
           />
-        </td>
+          <v-btn
+            variant="plain"
+            class="flagSaveButton"
+            :icon="mdiContentSaveOutline"
+            title="Save Banner"
+            @click="changeCol(item.key, 'value', banner)"
+          />
+        </div>
         <!--
           ``AA`` and ``AR`` bind to the typed FK (``ageRatingMetron``)
           on the flag row, not the legacy ``value`` string. The
@@ -40,7 +57,7 @@
           list loaded via the admin store — same source used on the
           Users tab — so there is no parallel static choices JSON.
         -->
-        <td v-else-if="item.key === 'AR'" class="ageRatingField">
+        <div v-else-if="item.key === 'AR'" class="flagValueRow">
           <v-select
             :model-value="item.ageRatingMetron"
             :items="ageRatingChoices"
@@ -48,11 +65,12 @@
             item-value="pk"
             label="Age Rating Default"
             hide-details="auto"
+            density="compact"
             :error-messages="errors[item.key]"
             @update:model-value="changeCol(item.key, 'ageRatingMetron', $event)"
           />
-        </td>
-        <td v-else-if="item.key === 'AA'" class="ageRatingField">
+        </div>
+        <div v-else-if="item.key === 'AA'" class="flagValueRow">
           <v-select
             :model-value="item.ageRatingMetron"
             :items="ageRatingChoices"
@@ -60,10 +78,11 @@
             item-value="pk"
             label="Anonymous Age Rating"
             hide-details="auto"
+            density="compact"
             :error-messages="errors[item.key]"
             @update:model-value="changeCol(item.key, 'ageRatingMetron', $event)"
           />
-        </td>
+        </div>
         <!--
           ``BG`` (Default View) reuses the existing ``TOP_GROUP``
           choices JSON so the seven labels stay in sync with the
@@ -71,42 +90,20 @@
           string column; the route-URL derivation happens server-
           side in ``admin_default_route_for``.
         -->
-        <td v-else-if="item.key === 'BG'" class="topGroupField">
+        <div v-else-if="item.key === 'BG'" class="flagValueRow">
           <v-select
             :model-value="item.value"
             :items="topGroupChoices"
             label="Default View"
             hide-details="auto"
+            density="compact"
             :error-messages="errors[item.key]"
             @update:model-value="changeCol(item.key, 'value', $event)"
           />
-        </td>
-        <td>
-          <v-btn
-            v-if="item.key === 'BT'"
-            variant="plain"
-            class="flagSaveButton"
-            :icon="mdiContentSaveOutline"
-            title="Save Banner"
-            @click="changeCol(item.key, 'value', banner)"
-          />
-          <template
-            v-else-if="
-              item.key === 'AR' || item.key === 'AA' || item.key === 'BG'
-            "
-          />
-          <v-checkbox
-            v-else
-            :model-value="item.on"
-            :true-value="true"
-            :error-messages="errors[item.key]"
-            hide-details="auto"
-            @update:model-value="changeCol(item.key, 'on', $event)"
-          />
-        </td>
-      </tr>
-    </tbody>
-  </v-table>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -119,6 +116,8 @@ import DESC from "@/components/admin/tabs/flag-descriptions.json";
 import ADMIN_FLAG_GROUPS from "@/components/admin/tabs/flag-groups.json";
 import { useAdminStore } from "@/stores/admin";
 import { useCommonStore } from "@/stores/common";
+
+const VALUE_CONTROL_KEYS = new Set(["BT", "AR", "AA", "BG"]);
 
 export default {
   name: "AdminFlagsTab",
@@ -243,63 +242,31 @@ export default {
     title(item) {
       return ADMIN_FLAGS[item.key];
     },
-    colspan(item) {
-      return ["BT", "AR", "AA", "BG"].includes(item.key) ? 1 : 2;
+    hasValueControl(item) {
+      /*
+       * Banner-text, age-rating, and default-view flags render
+       * their input or select inside the card body. Their card
+       * suppresses the trailing checkbox in the header.
+       */
+      return VALUE_CONTROL_KEYS.has(item.key);
     },
   },
 };
 </script>
 
 <style scoped lang="scss">
-#flags-table {
-  max-width: 100vw !important;
-  margin-bottom: 24px;
-  background-color: inherit;
-}
+@use "@/components/admin/tabs/admin-section.scss";
 
-.flagGroup + .flagGroup {
-  /* Margin between groups so the section breaks read clearly. */
-  margin-top: 1.5em;
-}
-
-.flagGroupHeader > th {
-  /* Section heading row spans the full table width. */
-  padding-top: 1.5em !important;
-  font-size: 1.05em;
-  font-weight: bolder;
-  color: rgb(var(--v-theme-textPrimary));
-  border-bottom: 1px solid rgb(var(--v-theme-textSecondary));
-}
-
-.nameCol {
-  padding-top: 1em !important;
-}
-
-.title {
-  font-weight: bolder;
-}
-
-.desc {
-  margin-top: 1em;
-  margin-bottom: 0.5em;
-  color: rgb(var(--v-theme-textSecondary));
-}
-
-.bannerTextField {
-  min-width: 16em;
-}
-
-.ageRatingField {
-  min-width: 12em;
-}
-
-.topGroupField {
-  min-width: 12em;
+.flagValueRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
 }
 
 .flagSaveButton {
   color: rgb(var(--v-theme-textSecondary));
-  padding-right: 12px;
+  flex-shrink: 0;
 }
 
 .flagSaveButton:hover {

--- a/frontend/src/components/admin/tabs/job-tab.vue
+++ b/frontend/src/components/admin/tabs/job-tab.vue
@@ -1,6 +1,6 @@
 <template>
-  <div id="jobs">
-    <div class="jobCard">
+  <div id="jobs" class="adminContainer">
+    <div class="adminCard">
       <div id="lastTaskLabel">Last Job Queued</div>
       <div id="lastJobResult">
         <span v-if="formSuccess" id="success">{{ formSuccess }}</span>
@@ -10,8 +10,8 @@
         <span v-else id="noRecentTask">No recent job</span>
       </div>
     </div>
-    <div v-for="group in ADMIN_JOBS" :key="group.title" class="jobGroup">
-      <div class="groupHeader">
+    <div v-for="group in ADMIN_JOBS" :key="group.title" class="adminGroup">
+      <div class="adminGroupHeader">
         <h3>{{ group.title }}</h3>
         <v-btn
           v-if="group.abort && isGroupActive(group)"
@@ -22,7 +22,7 @@
         />
       </div>
       <!-- Select-style group (Notify) -->
-      <div v-if="isSelectGroup(group.title)" class="jobCard">
+      <div v-if="isSelectGroup(group.title)" class="adminCard">
         <v-select
           :items="group.jobs"
           :model-value="groupSelectValues[group.title]"
@@ -38,7 +38,7 @@
             )
           "
         />
-        <div class="jobDesc">
+        <div class="adminCardDesc">
           {{ groupSelectAttr(group.title, "desc") }}
         </div>
       </div>
@@ -47,12 +47,12 @@
         <div
           v-for="job in group.jobs"
           :key="job.value"
-          class="jobCard"
-          :class="{ jobCardActive: isJobActive(job) }"
+          class="adminCard"
+          :class="{ adminCardActive: isJobActive(job) }"
         >
-          <div class="jobHeader">
-            <div class="jobInfo">
-              <div class="jobTitle">
+          <div class="adminCardHeader">
+            <div class="adminCardInfo">
+              <div class="adminCardTitle">
                 {{ job.title }}
               </div>
               <!-- Variant selector -->
@@ -67,16 +67,16 @@
                   :model-value="selectedVariant(job)"
                   @update:model-value="variantSelections[job.value] = $event"
                 />
-                <div class="jobDesc">
+                <div class="adminCardDesc">
                   {{ activeVariant(job).desc }}
                 </div>
               </div>
               <!-- Simple desc for non-variant jobs -->
-              <div v-else class="jobDesc">
+              <div v-else class="adminCardDesc">
                 {{ job.desc }}
               </div>
             </div>
-            <div class="jobActions">
+            <div class="adminCardActions">
               <span v-if="jobLastRun(job)" class="jobLastRun">
                 {{ jobLastRun(job) }}
               </span>
@@ -443,11 +443,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-#jobs {
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
-}
+@use "@/components/admin/tabs/admin-section.scss";
 
 #lastTaskLabel {
   display: inline-flex;
@@ -476,56 +472,11 @@ export default {
   color: rgb(var(--v-theme-textDisabled));
 }
 
-.jobGroup {
-  margin-top: 1em;
-}
-
-.groupHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.jobCard {
-  padding: 12px;
-  margin: 8px 0;
-  border-radius: 5px;
-  background-color: rgb(var(--v-theme-surface-light));
-  border-left: 3px solid transparent;
-  transition: border-color 0.3s ease;
-}
-
-.jobCardActive {
-  border-left-color: rgb(var(--v-theme-primary));
-}
-
-.jobHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.jobInfo {
-  flex: 1;
-  min-width: 0;
-}
-
-.jobTitle {
-  font-weight: 500;
-}
-
 .jobLastRun {
   font-weight: normal;
   font-size: 0.8em;
   color: rgb(var(--v-theme-textDisabled));
   margin-left: 8px;
-}
-
-.jobDesc {
-  color: rgb(var(--v-theme-textSecondary));
-  font-size: 0.85em;
-  padding-top: 2px;
 }
 
 .variantRow {
@@ -534,13 +485,6 @@ export default {
 
 .variantSelect {
   max-width: 320px;
-}
-
-.jobActions {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
-  align-items: center;
 }
 
 .abortBtn {

--- a/tasks/admin-tabs-unify/00-plan.md
+++ b/tasks/admin-tabs-unify/00-plan.md
@@ -1,0 +1,222 @@
+# Admin Flags + Jobs tabs — visual unification
+
+## Current state
+
+The two tabs render the same shape of content — a list of titled
+sections containing rows of items — in completely different visual
+languages.
+
+### Jobs tab (`components/admin/tabs/job-tab.vue`)
+
+- Top-level `<div id="jobs">` capped at `max-width: 700px`,
+  centered.
+- Each section is a `<div class="jobGroup">` with a `<h3>` header
+  (`.groupHeader`, optional Stop button next to it).
+- Each row is a `<div class="jobCard">`:
+  - 12px padding, 8px vertical margin
+  - 5px border-radius
+  - `surface-light` background
+  - 3px transparent left border that goes primary when active
+  - flex layout: title/desc on the left, action buttons on the
+    right
+- Sub-status panel expands inside the card with its own divider
+  (`border-top` + 6px padding) and progress bars.
+
+The visual hierarchy reads cleanly: page → section heading →
+clearly-bounded item card → action.
+
+### Flags tab (`components/admin/tabs/flag-tab.vue`)
+
+- Top-level `<v-table id="flags-table" striped="odd">` with a
+  `<thead>` (Description / Value / Enabled) and one `<tbody>` per
+  group.
+- Each section header is `<tr class="flagGroupHeader"><th
+  colspan="3">…</th></tr>` — a row inside the table.
+- Each flag is a `<tr>` with three `<td>`s:
+  - col 1 — name + description text
+  - col 2 — value control (text field for banner, select for age
+    ratings, select for default view; some rows skip this and let
+    col 1 colspan=2)
+  - col 3 — enabled checkbox / save button / nothing
+- No card chrome. Stripes alternate background, but rows
+  blend into one another.
+
+The section header looks like just another row of the table —
+bolder, slightly more padding, a thin bottom border. There's no
+visual "lift" or grouping beyond the bold text. The next data row
+abuts it immediately; rows inside a group flow continuously into
+rows of the next group.
+
+### The problems
+
+1. **Two completely different design languages** for the same
+   shape of content (sections of items). Anyone bouncing between
+   the two tabs feels the visual whiplash.
+2. **Flags' section headers don't read as headers** — they're
+   styled like rows because they *are* rows. The `colspan="3"`
+   trick gives them the full width but the row context glues them
+   to the data immediately below.
+3. **Flag rows have no boundary** — the table-stripe pattern is
+   the only thing distinguishing one flag from the next, and it's
+   weak compared to the Jobs cards.
+
+## Proposed unified design
+
+Adopt the Jobs tab's visual language for both. Concretely:
+
+- **Section header**: outside any card, an `<h3>` left-aligned
+  with optional action button(s) on the right. Matches today's
+  Jobs `.groupHeader`.
+- **Item card**: `<div>` with the same chrome as Jobs'
+  `.jobCard` — surface-light bg, padding, rounded corners.
+  Optional left-border accent stays a Jobs-only feature
+  (signals "active" — Flags has no equivalent state).
+- **Container width**: 700px max, centered. Flags are short rows;
+  capping the width keeps a comfortable line length for the
+  description text and prevents form controls from stretching to
+  unreadable widths.
+
+Both tabs share the same:
+
+- Section spacing (`margin-top` between groups)
+- Header typography (h3 size + weight)
+- Card chrome (background, padding, radius)
+- Description text style (textSecondary, 0.85em)
+
+Tabs differ only where their *content* differs:
+
+- Jobs cards have an action area (Start/Stop) and an
+  expand-to-status panel.
+- Flag cards have a value control (input/select/checkbox)
+  inside the card body.
+
+## Implementation
+
+### Shape of the change
+
+One PR. No behavioral changes to either tab — pure markup +
+styles. Touches three files:
+
+1. **New** `components/admin/tabs/admin-section.scss` (or just a
+   new top-level scope in the Jobs file's existing styles
+   `@use`'d from Flags). Holds the shared chrome:
+
+   ```scss
+   .adminGroup { margin-top: 1em; }
+   .adminGroupHeader {
+     display: flex;
+     align-items: center;
+     justify-content: space-between;
+   }
+   .adminCard {
+     padding: 12px;
+     margin: 8px 0;
+     border-radius: 5px;
+     background-color: rgb(var(--v-theme-surface-light));
+   }
+   .adminCardActive {
+     border-left: 3px solid rgb(var(--v-theme-primary));
+   }
+   .adminContainer {
+     max-width: 700px;
+     margin-left: auto;
+     margin-right: auto;
+   }
+   ```
+
+   Also lifts the shared item-row internals (title +
+   description text styles).
+
+2. **Edit** `flag-tab.vue`:
+   - Drop `<v-table>` entirely.
+   - Top-level: `<div class="adminContainer">`.
+   - Per group: `<div class="adminGroup">` with a `.adminGroupHeader`
+     (h3 inside).
+   - Per flag: `<div class="adminCard">`. Inside the card:
+     - Header row: title + (when applicable) the value control
+       and/or the checkbox aligned right.
+     - Body: description text.
+
+   Layout sketch for a flag card:
+
+   ```
+   ┌────────────────────────────────────────────────┐
+   │ Flag Title                          [✓ enable] │
+   │ Description text on the next line.             │
+   │ (when applicable: input or select control)     │
+   └────────────────────────────────────────────────┘
+   ```
+
+   For the four "value-bearing" flags (BT banner, AR/AA age
+   ratings, BG default view) the control replaces the checkbox;
+   the checkbox slot sits empty for those.
+
+3. **Edit** `job-tab.vue` only to rename classes to the shared
+   names (`jobCard` → `adminCard`, `jobGroup` → `adminGroup`,
+   etc.) and pull from the shared scss. The `jobCardActive`,
+   `jobHeader`, `jobInfo`, `jobActions`, `jobStatusSection`, and
+   `statusRow*` styles stay job-local since Flags has no
+   equivalent.
+
+### Step-by-step
+
+1. Land the shared styles file with the basic chrome.
+2. Migrate Jobs to use the shared classes. Should be a no-op
+   visual change — verify by side-by-side screenshot.
+3. Rewrite Flags' template to use the new card layout. This is
+   the only step that's user-visible.
+4. Confirm both tabs render correctly across the existing flag
+   and job inventory:
+   - Flags: 9 keys across 4 groups (Access & Privacy, Browser
+     Display, Metadata Import, System) plus the orphan-collector
+     "Other" group.
+   - Jobs: 6 groups (Libraries, Search, Covers, Notify, Janitor,
+     Library Maintenance) including the Notify select-style
+     group and the variant-bearing Update Libraries / Update
+     Custom Covers cards.
+5. Lint, test, build.
+
+### Risks / open questions
+
+- **The 700px cap on Flags**: today's Flags table is full-width.
+  Capping it does shrink content area on a wide monitor, but
+  the line lengths it produces match Jobs (which already uses
+  the cap and reads fine). If real-world feedback is "I want
+  the wider table back", we can opt the wide controls (banner
+  text field) out of the cap.
+- **Mobile layout**: the table flows on small screens because
+  it's a table. The card layout will stack title/desc/control
+  vertically; should look better on narrow viewports than the
+  table did, but worth a manual check.
+- **The "Other" orphan group on Flags**: stays in place — it's a
+  defensive fallback for server-released flags the frontend
+  doesn't know about. The unified design surfaces it the same
+  way as a normal group.
+- **No behavior changes**: change is pure presentation. The
+  ``changeCol`` action wiring, error binding, ``loadTables``
+  call, etc. all stay identical.
+
+### Out of scope
+
+- Keyboard navigation parity between tabs.
+- Reordering or regrouping flags / jobs (sub-plan was already
+  shipped for Flags grouping in PR #644).
+- Vuetify component swaps (e.g. moving from native checkbox to
+  v-switch). Save those for the `js-vue-quality-pass.md`
+  cleanup.
+
+## Test plan
+
+- Manual: open `/admin/flags`, verify section headers stand
+  apart from item cards, the BT/AR/AA/BG cards render their
+  controls, the standard checkbox cards toggle, and changes
+  persist via the API.
+- Manual: open `/admin/jobs`, verify nothing changed visually
+  vs. main.
+- Manual: shrink the viewport to mobile width, verify both tabs
+  still read cleanly.
+- `bun run lint`, `bun run test:ci`, `bun run build`.
+
+Total work: ~150 LOC change in `flag-tab.vue` (mostly template
+restructure), ~30 LOC in `job-tab.vue` (class renames), ~40 LOC
+in the new shared styles file.


### PR DESCRIPTION
## Summary

The Flags and Jobs tabs render the same shape — titled sections
of items — in completely different visual languages. Jobs uses
``surface-light`` cards on ``<h3>`` section headers; Flags
renders the whole thing as a ``<v-table>`` with section headers
as ``<th colspan=\"3\">`` rows that read like just another row of
the table.

This PR adopts the Jobs design language for both. The shared
chrome lives in a new ``admin-section.scss`` consumed by each
tab via ``@use``; tab-specific decoration (active border,
expand panels, value controls) layers on top from each tab's
own scoped styles.

## What changed

- **New** ``frontend/src/components/admin/tabs/admin-section.scss``
  with the shared primitives: ``adminContainer``, ``adminGroup``,
  ``adminGroupHeader``, ``adminCard``, ``adminCardActive``,
  ``adminCardHeader``, ``adminCardInfo``, ``adminCardTitle``,
  ``adminCardDesc``, ``adminCardActions``.

- **Flags tab rewrite** — drop ``<v-table>`` entirely. Each flag
  becomes a card. Header row: title (left) + checkbox (right).
  Body: description text. Value-bearing flags (BT banner, AR/AA
  age ratings, BG default view) render their input/select in a
  body row below the description and skip the trailing checkbox
  — the control itself carries the state.

- **Jobs tab migration** — mechanical class renames (``jobCard``
  → ``adminCard``, ``jobGroup`` → ``adminGroup``, ``groupHeader``
  → ``adminGroupHeader``, ``jobHeader`` → ``adminCardHeader``,
  ``jobInfo`` → ``adminCardInfo``, ``jobTitle`` →
  ``adminCardTitle``, ``jobDesc`` → ``adminCardDesc``,
  ``jobActions`` → ``adminCardActions``) plus pulling the chrome
  out of its scoped styles into the shared file. **No visual
  change on Jobs.**

## What stayed the same

- ``changeCol`` action wiring on Flags
- ``loadTables`` mount call on Flags
- All Jobs behavior — variant selectors, expand panels, status
  rows, abort/start actions, nightly auto-expand
- The "Other" orphan-collector group on Flags (defensive
  fallback for server-released flags the frontend doesn't know
  about)

## Plan + rationale

``tasks/admin-tabs-unify/00-plan.md`` walks through the
diagnosis (why Flags' section headers don't read as headers),
the proposed unified design, the implementation steps, and
risks (700px cap on Flags, mobile layout).

## Test plan

- [x] ``bun run lint`` — clean
- [x] ``bun run build`` — succeeds
- [x] ``bun run test:ci`` — 1 pass
- [ ] Manual: ``/admin/flags`` — verify section headers stand
      apart from item cards, BT/AR/AA/BG cards render their
      controls, standard checkbox cards toggle, changes persist
      via the API
- [ ] Manual: ``/admin/jobs`` — verify nothing changed visually
      vs. main
- [ ] Manual: shrink viewport to mobile width, verify both tabs
      still read cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)