### PR TITLE
Importer: stringify verbose_name_plural before storing on status.subtitle

### DIFF
--- a/codex/librarian/scribe/importer/create/foreign_keys.py
+++ b/codex/librarian/scribe/importer/create/foreign_keys.py
@@ -133,7 +133,13 @@ class CreateForeignKeysCreateUpdateImporter(CreateForeignKeysFolderImporter):
         create_tuples = self.metadata[CREATE_FKS].pop(model, None)
         if not create_tuples:
             return count
-        status.subtitle = model._meta.verbose_name_plural
+        # ``verbose_name_plural`` is a ``gettext_lazy`` __proxy__,
+        # not a real ``str``. The Status dataclass annotates
+        # ``subtitle: str``; force the conversion at assignment so
+        # downstream consumers (notably ``" ".join`` in
+        # ``StatusController._log_finish``) don't crash on the
+        # proxy.
+        status.subtitle = str(model._meta.verbose_name_plural)
         self.status_controller.update(status)
         key_args_map, update_args_map = MODEL_CREATE_ARGS_MAP[model]
         parent_pk_maps = self._build_parent_fk_pk_maps(model)
@@ -212,7 +218,8 @@ class CreateForeignKeysCreateUpdateImporter(CreateForeignKeysFolderImporter):
         update_tuples = self.metadata[UPDATE_FKS].pop(model, None)
         if not update_tuples:
             return count
-        status.subtitle = model._meta.verbose_name_plural
+        # See ``_bulk_create_models`` — same lazy-proxy coercion.
+        status.subtitle = str(model._meta.verbose_name_plural)
         self.status_controller.update(status)
         key_args_map, update_args_map = MODEL_CREATE_ARGS_MAP[model]
         parent_pk_maps = self._build_parent_fk_pk_maps(model)

--- a/codex/librarian/status_controller.py
+++ b/codex/librarian/status_controller.py
@@ -141,10 +141,13 @@ class StatusController:
         if status.log_success:
             level = "SUCCESS"
 
-        prefix_parts = filter(
-            None, (status.verbed(), count, status.ITEM_NAME, status.subtitle)
-        )
-        prefix = " ".join(prefix_parts)
+        # ``str(p)`` defends against callers that assign a Django
+        # ``gettext_lazy`` __proxy__ (or any other str-impostor)
+        # to ``subtitle``. ``" ".join`` is strict: a non-``str``
+        # member crashes the join and takes down the
+        # status-finish path that produced it.
+        prefix_parts = (status.verbed(), count, status.ITEM_NAME, status.subtitle)
+        prefix = " ".join(str(p) for p in prefix_parts if p)
 
         self.log.log(level, f"{prefix}{suffix}.")
 


### PR DESCRIPTION
## Summary

Fix a TypeError observed in the wild during an import run:

```
File \"codex/librarian/status_controller.py\", line 147, in _log_finish
    prefix = \" \".join(prefix_parts)
TypeError: sequence item 3: expected str instance, __proxy__ found
```

``Model._meta.verbose_name_plural`` is a Django ``gettext_lazy``
``__proxy__``, not a real ``str``. The Status dataclass annotates
``subtitle: str`` but Python doesn't enforce the annotation, so
the proxy slipped through and crashed ``StatusController._log_finish``
on its ``\" \".join(prefix_parts)`` — ``join`` is strict about
types and won't coerce a proxy to str.

The repr was misleading — the dataclass log line showed
``subtitle='story arc numbers'`` because the proxy's ``__repr__``
mirrors a plain string's, but the runtime type was the
``django.utils.functional.__proxy__``.

## Two-part fix

1. **Source** — ``str()``-cast the ``verbose_name_plural`` at the
   assignment sites in
   ``foreign_keys.py:_bulk_create_models`` and
   ``_bulk_update_models``. Preserves the dataclass's
   ``subtitle: str`` invariant for any other consumer
   (websocket payloads, log lines, repr).

2. **Defensive** — ``\" \".join(str(p) for p in parts if p)`` in
   ``_log_finish``. The status-finish path shouldn't itself be
   a source of crashes — if a future caller forgets to ``str()``
   their assignment, the log line still renders.

## Test plan

- [x] ``uv run ruff check`` on changed files — clean
- [x] ``uv run ruff format --check`` — clean
- [x] Existing status / importer pytest suite — 3 pass, 23 deselected
- [ ] Manual: trigger an import run that exercises the create-FK
      phase and verify ``_log_finish`` no longer crashes when
      finishing ``ImporterCreateTagsStatus`` with a populated
      subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)