### PR TITLE
Type ignores: eliminate 76 with cast(), narrowing, and class-level defaults

### DIFF
--- a/codex/librarian/librariand.py
+++ b/codex/librarian/librariand.py
@@ -4,7 +4,7 @@ from copy import copy
 from multiprocessing import Process, Queue
 from threading import Lock, active_count
 from types import MappingProxyType
-from typing import Any, Final, NamedTuple, override
+from typing import Any, Final, NamedTuple, cast, override
 
 from caseconverter import snakecase
 from django.db import close_old_connections
@@ -161,7 +161,9 @@ class LibrarianDaemon(Process):
 
     def _shutdown(self) -> None:
         """Shutdown threads and queues."""
-        self._reversed_threads = tuple(reversed(self._threads))  # ty: ignore[invalid-assignment]
+        self._reversed_threads = cast(
+            "tuple[NamedThread, ...]", tuple(reversed(self._threads))
+        )
         self._stop_threads()
         self._join_threads()
         while not self.queue.empty():

--- a/codex/librarian/scribe/importer/const.py
+++ b/codex/librarian/scribe/importer/const.py
@@ -1,6 +1,7 @@
 """BULK_CREATE_COMIC_FIELDSConsts and maps for import."""
 
 from types import MappingProxyType, SimpleNamespace
+from typing import cast
 
 from bidict import frozenbidict
 from django.db.models.fields import Field
@@ -151,10 +152,13 @@ GROUP_MODEL_COUNT_FIELDS: MappingProxyType[type[BrowserGroupModel], str | None] 
         }
     )
 )
-COMIC_M2M_FIELDS: tuple[ManyToManyField, ...] = tuple(  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
-    field
-    for field in Comic._meta.get_fields()
-    if (field.many_to_many and not field.auto_created)
+COMIC_M2M_FIELDS: tuple[ManyToManyField, ...] = cast(
+    "tuple[ManyToManyField, ...]",
+    tuple(
+        field
+        for field in Comic._meta.get_fields()
+        if (field.many_to_many and not field.auto_created)
+    ),
 )
 COMIC_M2M_FIELD_NAMES: tuple[str, ...] = tuple(field.name for field in COMIC_M2M_FIELDS)
 COMPLEX_M2M_MODELS = (Credit, Identifier, StoryArcNumber)
@@ -303,7 +307,9 @@ MODEL_SELECT_RELATED: MappingProxyType[type[BaseModel], tuple[str, ...]] = (
 )
 FIELD_NAME_KEYS_REL_MAP = MappingProxyType(
     {
-        field.name: MODEL_REL_MAP[field.related_model][0]  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+        # ``related_model`` is typed ``type[Model] | Literal['self']
+        # | None`` but every field we iterate has a concrete model.
+        field.name: MODEL_REL_MAP[cast("type[BaseModel]", field.related_model)][0]
         for field in (*ALL_COMIC_FK_FIELDS, *COMIC_M2M_FIELDS)
     }
 )
@@ -360,7 +366,9 @@ BULK_UPDATE_COMIC_FIELDS = tuple(
         field.name
         for field in Comic._meta.get_fields()
         # Concrete check protects against SettingsReader reverse relations being updated
-        if field.concrete  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+        # ``ForeignObjectRel`` lacks ``.concrete`` on the public stub; use
+        # ``getattr`` so the check is uniform across the union.
+        if getattr(field, "concrete", False)
         and (not field.many_to_many)
         and (field.name not in _EXCLUDEBULK_UPDATE_COMIC_FIELDS)
     )

--- a/codex/librarian/scribe/importer/link/delete.py
+++ b/codex/librarian/scribe/importer/link/delete.py
@@ -1,6 +1,6 @@
 """Delete stale m2ms."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from django.db.models import ManyToManyField, Q
 
@@ -24,8 +24,12 @@ class LinkImporterDelete(LinkComicsImporterPrepare):
     @staticmethod
     def get_through_model(field: ManyToManyField) -> type[BaseModel]:
         """Get the through model for a m2m field."""
-        remote_field: ManyToManyRel = field.remote_field  # pyright: ignore[reportAssignmentType],# ty: ignore[invalid-assignment]
-        return remote_field.through  #  pyright: ignore[reportReturnType],# ty: ignore[invalid-return-type]
+        # ``ManyToManyField.remote_field`` is typed as the broader
+        # ``Field`` and ``.through`` only exists on ``ManyToManyRel``.
+        # Cast through ``object`` because pyright correctly observes
+        # the type-system gap.
+        remote_field = cast("ManyToManyRel", cast("object", field.remote_field))
+        return cast("type[BaseModel]", remote_field.through)
 
     def _delete_m2m_field_batch(
         self,
@@ -66,7 +70,10 @@ class LinkImporterDelete(LinkComicsImporterPrepare):
             return total_field_count
         status.subtitle = f"Delete stale {field_name} links"
         self.status_controller.update(status)
-        field: ManyToManyField = Comic._meta.get_field(field_name)  # pyright:ignore[reportAssignmentType], # ty: ignore[invalid-assignment]│
+        # ``Comic._meta.get_field`` returns the broad ``Field |
+        # ForeignObjectRel`` union; cast to the concrete type the
+        # caller knows we're operating on.
+        field = cast("ManyToManyField", Comic._meta.get_field(field_name))
         related_model = field.related_model
         table_name = related_model._meta.db_table
         column_name = table_name.removeprefix("codex_") + "_id"

--- a/codex/librarian/scribe/importer/read/many_to_many.py
+++ b/codex/librarian/scribe/importer/read/many_to_many.py
@@ -1,7 +1,7 @@
 """Aggregate ManyToMany Metadata."""
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from comicbox.schemas.comicbox import IDENTIFIERS_KEY, NUMBER_KEY, ROLES_KEY
 from django.db.models import CharField, Field
@@ -39,7 +39,10 @@ class AggregateManyToManyMetadataImporter(AggregateForeignKeyMetadataImporter):
         self, field_name, sub_sub_value
     ):
         field = Comic._meta.get_field(field_name)
-        model: type[BaseModel] = field.related_model  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
+        # ``related_model`` is typed ``type[Model] | Literal['self'] | None``;
+        # this code path only fires for fields whose related model is a real
+        # concrete BaseModel.
+        model = cast("type[BaseModel]", field.related_model)
         return self.get_identifier_tuple(model, sub_sub_value)
 
     def _get_m2m_metadata_dict_model_aggregate_sub_sub_value_roles(
@@ -228,14 +231,20 @@ class AggregateManyToManyMetadataImporter(AggregateForeignKeyMetadataImporter):
         # {story_arc_name_a: { number: 1, identifiers: {} }, ...}
         # {character_name_a: { identifiers: {} }, ...}
         clean_values_map: dict[tuple, frozenset[tuple]] = {}
-        if not isinstance(values, Mapping):
-            values = dict.fromkeys(values)
-        for sub_key_name, sub_value in values.items():
+        # Normalize the input to a ``Mapping`` so the iteration below is
+        # uniform; the non-mapping branch was leaking ``Any``-typed
+        # iteration variables out into the per-call signature.
+        values_map: Mapping[str, Mapping | None] = (
+            values
+            if isinstance(values, Mapping)
+            else cast("Mapping[str, Mapping | None]", dict.fromkeys(values))
+        )
+        for sub_key_name, sub_value in values_map.items():
             clean_sub_map = self._get_m2m_metadata_dict_model_aggregate_sub_values(
                 md_key,
                 field,
-                sub_key_name,  # ty: ignore[invalid-argument-type]
-                sub_value,  # ty: ignore[invalid-argument-type]
+                sub_key_name,
+                sub_value,
             )
             clean_values_map.update(clean_sub_map)
 

--- a/codex/librarian/worker.py
+++ b/codex/librarian/worker.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     # Type-hint-only — runtime imports stay lean across the nine
     # librarian modules that import this chain.
     from multiprocessing.queues import Queue
+    from threading import Lock
 
     from loguru._logger import Logger
 
@@ -18,7 +19,7 @@ class WorkerMixin:
     """Mixin for common thread attributes."""
 
     def init_worker(
-        self, /, logger_: Logger, librarian_queue: Queue, db_write_lock
+        self, /, logger_: Logger, librarian_queue: Queue, db_write_lock: Lock
     ) -> None:
         """Initialize queues."""
         if not all((logger_, librarian_queue, db_write_lock)):
@@ -33,7 +34,9 @@ class WorkerStatusMixin(WorkerMixin):
     """Worker mixin also sets up status controller."""
 
     @override
-    def init_worker(self, /, logger_, librarian_queue: Queue, db_write_lock) -> None:
+    def init_worker(
+        self, /, logger_: Logger, librarian_queue: Queue, db_write_lock: Lock
+    ) -> None:
         super().init_worker(logger_, librarian_queue, db_write_lock)
         self.status_controller = StatusController(  # pyright: ignore[reportUninitializedInstanceVariable]
             logger_, librarian_queue

--- a/codex/views/auth.py
+++ b/codex/views/auth.py
@@ -109,15 +109,25 @@ class AuthGenericAPIView(AuthMixin, GenericAPIView):  # pyright: ignore[reportIn
 class IsAdminMixin:
     """Expose lazy ``is_admin`` check for the current request user."""
 
+    # Class-level default doubles as the unmemoized sentinel; the
+    # mixin no longer needs ``init_is_admin`` to set it before use.
+    _is_admin: bool | None = None
+
+    if TYPE_CHECKING:
+        # ``self.request`` is supplied by the DRF view base class
+        # at dispatch; declare the attribute for the mixin so the
+        # property body type-checks without requiring a parent.
+        request: Request  # pyright: ignore[reportUninitializedInstanceVariable]
+
     def init_is_admin(self) -> None:
         """Initialize the cached admin flag."""
-        self._is_admin: bool | None = None  # pyright: ignore[reportUninitializedInstanceVariable]
+        self._is_admin = None
 
     @property
     def is_admin(self) -> bool:
         """Is the current user an admin."""
         if self._is_admin is None:
-            user = self.request.user  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+            user = self.request.user
             self._is_admin = bool(user and getattr(user, "is_staff", False))
         return self._is_admin
 
@@ -342,16 +352,22 @@ class GroupACLMixin(IsAdminMixin, GroupACLFilterMixin, AgeRatingACLMixin):
     exactly three bookkeeping queries total instead of three-per-model.
     """
 
+    # Class-level defaults double as the unmemoized sentinels.
+    # Lazily populated on first access via ``get_visible_library_pks``
+    # / ``get_max_idx`` / ``get_default_fits``. Each is populated at
+    # most once per request; subsequent ``get_acl_filter`` calls for
+    # other models reuse the cached value. ``init_group_acl`` resets
+    # them between requests.
+    _cached_visible_library_pks: frozenset[int] | None = None
+    _cached_max_idx: int | None = None
+    _cached_default_fits: bool | None = None
+
     def init_group_acl(self) -> None:
         """Initialize per-request cached scalars."""
         self.init_is_admin()
-        # Lazily populated on first access via ``get_visible_library_pks``
-        # / ``get_max_idx`` / ``get_default_fits``. Each is populated at
-        # most once per request; subsequent ``get_acl_filter`` calls for
-        # other models reuse the cached value.
-        self._cached_visible_library_pks: frozenset[int] | None = None  # pyright: ignore[reportUninitializedInstanceVariable]
-        self._cached_max_idx: int | None = None  # pyright: ignore[reportUninitializedInstanceVariable]
-        self._cached_default_fits: bool | None = None  # pyright: ignore[reportUninitializedInstanceVariable]
+        self._cached_visible_library_pks = None
+        self._cached_max_idx = None
+        self._cached_default_fits = None
 
     def get_visible_library_pks(self, user) -> frozenset[int]:
         """Return the per-request cached visible library pk set."""

--- a/codex/views/browser/breadcrumbs.py
+++ b/codex/views/browser/breadcrumbs.py
@@ -1,7 +1,7 @@
 """Browser breadcrumbs calculations."""
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from django.db.models import QuerySet
 
@@ -72,15 +72,13 @@ class BrowserBreadcrumbsView(BrowserPaginateView):
         group = self.kwargs.get("group")
         pks = self.kwargs.get("pks")
         page = self.kwargs.get("page")
-        if group == "r" and not pks and page == 1:
-            group_query = model.objects.none()
-        else:
+        if not (group == "r" and not pks and page == 1):
             reason = f"{group}__in={pks} does not exist!"
-            self.raise_redirect(
-                reason,
-                route_mask={"group": group},
-            )
-        return group_query  # pyright: ignore[reportPossiblyUnboundVariable]
+            # ``raise_redirect`` is ``NoReturn``; the type checker
+            # follows the early-return shape so the caller below
+            # is the only path that produces a queryset.
+            self.raise_redirect(reason, route_mask={"group": group})
+        return model.objects.none()
 
     @property
     def group_instance(self) -> BrowserGroupModel | None:
@@ -99,7 +97,10 @@ class BrowserBreadcrumbsView(BrowserPaginateView):
                     model = Publisher
                 group_query = model.objects.none()
             self._group_instance = group_query.first()
-        return self._group_instance  # pyright: ignore[reportReturnType], # ty: ignore[invalid-return-type]
+        # ``_group_instance`` carries an ``int`` sentinel (``0``) for the
+        # unmemoized state; by this point it's been resolved to a real
+        # model row or ``None``.
+        return cast("BrowserGroupModel | None", self._group_instance)
 
     def _build_group_breadcrumbs(self) -> tuple[Route, ...]:
         """Build breadcrumbs for browse group mode by walking FK parents."""
@@ -134,15 +135,17 @@ class BrowserBreadcrumbsView(BrowserPaginateView):
         """Build breadcrumbs for folder mode by walking parent_folder FKs."""
         pks = self.kwargs["pks"]
         page = self.kwargs["page"]
-        folder: Folder | None = self.group_instance  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
+        # In folder mode ``group_instance`` is a Folder (or None) by
+        # construction — the caller branches on ``group == FOLDER_GROUP``.
+        folder = cast("Folder | None", self.group_instance)
         name = folder.name if folder and pks else ""
 
         crumbs: list[Route] = [Route(FOLDER_GROUP, pks, page, name)]
 
         # Walk up the parent_folder chain
-        while folder and folder.parent_folder:
-            folder = folder.parent_folder
-            crumbs.append(Route(FOLDER_GROUP, (folder.pk,), 1, folder.name))  # pyright: ignore[reportOptionalMemberAccess]
+        while folder and (parent := folder.parent_folder):
+            folder = parent
+            crumbs.append(Route(FOLDER_GROUP, (folder.pk,), 1, folder.name))
 
         # Add folder root if not already there
         if crumbs[-1].pks:

--- a/codex/views/browser/choices.py
+++ b/codex/views/browser/choices.py
@@ -2,7 +2,7 @@
 
 from itertools import chain
 from types import MappingProxyType
-from typing import Any, override
+from typing import Any, cast, override
 
 from caseconverter import snakecase
 from django.db.models import Exists, F, QuerySet
@@ -175,7 +175,12 @@ class BrowserChoicesAvailableView(BrowserChoicesViewBase):
         early_data: dict[str, bool] = {}
         aggregates: dict[str, Exists] = {}
         m2m_specs: dict[str, str] = {}
-        serializer: BrowserFilterChoicesSerializer = self.serializer_class()  # pyright: ignore[reportOptionalCall, reportAssignmentType], # ty: ignore[call-non-callable, invalid-assignment]
+        # ``serializer_class`` is typed ``type[BaseSerializer] | None`` on
+        # the parent ViewSet but this subclass always sets it.
+        serializer_cls = cast(
+            "type[BrowserFilterChoicesSerializer]", self.serializer_class
+        )
+        serializer = serializer_cls()
         for field_name in serializer.get_fields():
             if field_name == "story_arcs" and qs.model is StoryArc:
                 # don't allow filtering on story arc in story arc view.

--- a/codex/views/browser/settings.py
+++ b/codex/views/browser/settings.py
@@ -1,6 +1,7 @@
 """Browser settings views."""
 
 from collections.abc import MutableMapping
+from typing import cast
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
@@ -47,11 +48,17 @@ class BrowserSettingsBaseView(SettingsBaseView):
 
     def reset_browser_settings(self) -> dict:
         """Reset browser settings to model defaults and return the params dict."""
-        instance: SettingsBrowser = self._get_or_create_settings(  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
-            self.MODEL,
-            self.CLIENT,
-            self.FILTER_ARGS,
-            self.CREATE_ARGS,
+        # ``_get_or_create_settings`` returns the broad ``SettingsBase``
+        # supertype; ``self.MODEL`` (``SettingsBrowser``) determines the
+        # concrete type.
+        instance = cast(
+            "SettingsBrowser",
+            self._get_or_create_settings(
+                self.MODEL,
+                self.CLIENT,
+                self.FILTER_ARGS,
+                self.CREATE_ARGS,
+            ),
         )
         defaults = self.get_browser_default_params()
 

--- a/codex/views/browser/validate.py
+++ b/codex/views/browser/validate.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from copy import deepcopy
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NoReturn, cast
 
 from loguru import logger
 from rest_framework.exceptions import NotFound
@@ -70,12 +70,12 @@ class BrowserValidateView(SearchFilterView):
 
     def raise_redirect(
         self, reason, route_mask=None, settings_mask: Mapping | None = None
-    ) -> None:
+    ) -> NoReturn:
         """Redirect the client to a valid group url."""
-        route: dict[str, Any] = mapping_to_dict(self.DEFAULT_ROUTE)  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
+        route = cast("dict[str, Any]", mapping_to_dict(self.DEFAULT_ROUTE))
         if route_mask:
             route["params"].update(route_mask)
-        settings: dict[str, Any] = deepcopy(mapping_to_dict(self.params))  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
+        settings = cast("dict[str, Any]", deepcopy(mapping_to_dict(self.params)))
         if settings_mask:
             settings.update(settings_mask)
         detail = {"route": route, "settings": settings, "reason": reason}

--- a/codex/views/opds/auth.py
+++ b/codex/views/opds/auth.py
@@ -18,10 +18,14 @@ class OPDSAuthMixin(AuthMixin):
         BearerTokenAuthentication,
         SessionAuthentication,
     )
+    # Class-level default doubles as the unmemoized sentinel so
+    # subclasses don't need to redeclare. Lazily resolved on first
+    # access via ``user_agent_name``.
+    _user_agent_name: str | None = None
 
     @property
     def user_agent_name(self) -> str:
         """Memoize user agent name."""
-        if self._user_agent_name is None:  # pyright: ignore[reportUnnecessaryComparison]
-            self._user_agent_name = get_user_agent_name(self.request)  # pyright: ignore[reportUninitializedInstanceVariable]
+        if self._user_agent_name is None:
+            self._user_agent_name = get_user_agent_name(self.request)
         return self._user_agent_name

--- a/codex/views/opds/feed.py
+++ b/codex/views/opds/feed.py
@@ -18,4 +18,4 @@ class OPDSBrowserView(OPDSBrowserSettingsMixin, UserActiveMixin, BrowserView):
     def __init__(self, *args, **kwargs) -> None:
         """Add User Agent Name."""
         super().__init__(*args, **kwargs)
-        self._user_agent_name: str | None = None  # pyright: ignore[reportIncompatibleUnannotatedOverride]
+        self._user_agent_name = None

--- a/codex/views/opds/v2/manifest.py
+++ b/codex/views/opds/v2/manifest.py
@@ -3,11 +3,11 @@
 import json
 from collections.abc import Mapping, Sequence
 from types import MappingProxyType, SimpleNamespace
-from typing import override
+from typing import Any, override
 
 from django.db.models import CharField, F, Value
 
-from codex.models.base import BaseModel, NamedModel
+from codex.models.base import NamedModel
 from codex.models.identifier import Identifier
 from codex.models.named import Credit, StoryArcNumber
 from codex.serializers.opds.v2.publication import (
@@ -167,9 +167,14 @@ class OPDS2ManifestMetadataView(OPDS2PublicationBaseView):
 
         return belongs_to
 
-    def _add_tag_link(self, obj: BaseModel, filter_key: str, subfield: str = ""):
+    def _add_tag_link(self, obj: Any, filter_key: str, subfield: str = "") -> None:
+        # ``obj`` can be either a real ``NamedModel`` (when called with
+        # ``subfield=""``) or a ``SimpleNamespace`` carrying ``pk`` /
+        # ``name`` / ``links`` (the partitioned ``_publication_subject``
+        # rows). Typing as ``Any`` lets both shapes through; the
+        # function only reads ``pk`` / ``name`` and writes ``links``.
         kwargs = {"group": "s", "pks": (), "page": 1}
-        value: NamedModel = getattr(obj, subfield) if subfield else obj  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
+        value = getattr(obj, subfield) if subfield else obj
         filters = {filter_key: [value.pk]}
         filters = json.dumps(filters)
         query_params = {
@@ -184,7 +189,7 @@ class OPDS2ManifestMetadataView(OPDS2PublicationBaseView):
             mime_type=MimeType.OPDS_JSON,
         )
         link = self.link(link_data)
-        obj.links = (link,)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+        obj.links = (link,)
 
     def _publication_subject(self, obj) -> tuple[NamedModel, ...]:
         """
@@ -211,12 +216,15 @@ class OPDS2ManifestMetadataView(OPDS2PublicationBaseView):
             queries.append(q)
         rows = queries[0].union(*queries[1:], all=True).order_by("_kind", "name")
 
-        flat_subjs: list[NamedModel] = []
+        # ``flat_subjs`` carries ``SimpleNamespace`` rows that quack
+        # like ``NamedModel`` (``pk`` / ``name`` / ``links``); the
+        # serializer downstream reads only those three attributes.
+        flat_subjs: list[Any] = []
         for row in rows:
             kind = row["_kind"]
             subj = SimpleNamespace(pk=row["pk"], name=row["name"], links=())
-            self._add_tag_link(subj, kind + "s")  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
-            flat_subjs.append(subj)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+            self._add_tag_link(subj, kind + "s")
+            flat_subjs.append(subj)
         return tuple(flat_subjs)
 
     def _publication_credits(self, obj) -> Mapping[str, tuple[Credit, ...]]:

--- a/codex/views/opds/v2/progression.py
+++ b/codex/views/opds/v2/progression.py
@@ -32,8 +32,6 @@ from codex.views.opds.v2.href import OPDS2HrefMixin
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from codex.models.groups import BrowserGroupModel
-
 _EMPTY_DEVICE = MappingProxyType(
     {
         "id": "",
@@ -79,17 +77,25 @@ class OPDS2ProgressionView(
     serializer_class = OPDS2ProgressionSerializer
     content_type = ReadiumProgressionParser.media_type
 
+    # Annotated queryset rows carry ``bookmark_updated_at`` /
+    # ``page`` / ``progress`` synthetic columns the type system
+    # can't see on ``Comic``. The real model attribute
+    # ``page_count`` is also accessed. Type as ``Any`` to keep
+    # the queryset-aliased reads honest; the queryset itself is
+    # built by ``_get_bookmark_query`` and reassigned in
+    # ``get_object``.
+    _obj: Any
+
     def __init__(self, *args, **kwargs) -> None:
         """Initialize Bookmark Filter."""
         self.init_bookmark_filter()
         super().__init__(*args, **kwargs)
-        self._obj: BrowserGroupModel = Comic()
-        self._user_agent_name: str | None = None  # pyright: ignore[reportIncompatibleUnannotatedOverride]
+        self._obj = Comic()
 
     @property
     def modified(self):
         """Get modified from bookmark."""
-        return self._obj.bookmark_updated_at  # pyright: ignore[reportAttributeAccessIssue], #ty: ignore[unresolved-attribute]
+        return self._obj.bookmark_updated_at
 
     @property
     def device(self):
@@ -99,16 +105,16 @@ class OPDS2ProgressionView(
     @property
     def title(self) -> str:
         """The locator title is the page number."""
-        return f"Page {self._obj.page}"  # pyright: ignore[reportAttributeAccessIssue], #ty: ignore[unresolved-attribute]
+        return f"Page {self._obj.page}"
 
     @property
     def _progression_href(self):
         """Build a Progression HRef."""
         acq_kwargs = {
             "pk": self._obj.pk,
-            "page": self._obj.page,  # pyright: ignore[reportAttributeAccessIssue],  #ty: ignore[unresolved-attribute]
+            "page": self._obj.page,
         }
-        max_page = max_none(self._obj.page_count - 1, 0)  # pyright: ignore[reportAttributeAccessIssue], #ty: ignore[unresolved-attribute]
+        max_page = max_none(self._obj.page_count - 1, 0)
         data = HrefData(
             acq_kwargs, url_name="opds:bin:page", min_page=0, max_page=max_page
         )
@@ -118,11 +124,11 @@ class OPDS2ProgressionView(
     def _locations(self) -> dict[str, Any]:
         """Build the Locations object."""
         # The OPDS v2 progression spec secifies position as > 0.
-        position = max(self._obj.page + 1, 0)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+        position = max(self._obj.page + 1, 0)
         return {
             "position": position,
-            "progression": self._obj.progress,  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
-            "total_progression": self._obj.progress,  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+            "progression": self._obj.progress,
+            "total_progression": self._obj.progress,
         }
 
     @property
@@ -176,7 +182,7 @@ class OPDS2ProgressionView(
         )
         self._obj = qs.get(pk=pk)
 
-        if not self._obj.bookmark_updated_at:  # pyright: ignore[reportAttributeAccessIssue]
+        if not self._obj.bookmark_updated_at:
             raise NoContent
 
         return {

--- a/codex/views/reader/settings.py
+++ b/codex/views/reader/settings.py
@@ -2,6 +2,7 @@
 
 from functools import cache
 from types import MappingProxyType
+from typing import cast
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ValidationError
@@ -310,8 +311,11 @@ class ReaderSettingsView(ReaderSettingsBaseView):
                 raise ValidationError(
                     {"scope_pk": "scope_pk is required for non-global scopes."}
                 )
-            fk_field = config[0]
-            instance = self._get_or_create_scoped_settings(fk_field, scope_pk)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+            # Non-global ``_SCOPE_MAP`` entries always have a string
+            # FK name and the guard above proved ``scope_pk`` is set;
+            # narrow both for the type checker.
+            fk_field = cast("str", config[0])
+            instance = self._get_or_create_scoped_settings(fk_field, scope_pk)
 
         for key, value in data.items():
             if key in instance.DIRECT_KEYS:
@@ -348,9 +352,10 @@ class ReaderSettingsView(ReaderSettingsBaseView):
                 raise ValidationError(
                     {"scope_pk": "scope_pk is required for non-global scopes."}
                 )
-            fk_field = config[0]
+            # Same narrowing as the update path above.
+            fk_field = cast("str", config[0])
             # Delete the scoped row entirely — absence means "inherit".
-            lookup = self._get_settings_lookup(**{fk_field: scope_pk})  # pyright: ignore[reportCallIssue], # ty: ignore[invalid-argument-type]
+            lookup = self._get_settings_lookup(**{fk_field: scope_pk})
             SettingsReader.objects.filter(**lookup).delete()
             result = None
 

--- a/codex/views/settings.py
+++ b/codex/views/settings.py
@@ -4,6 +4,7 @@ from abc import ABC
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from types import MappingProxyType
+from typing import cast
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from loguru import logger
@@ -296,16 +297,22 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
         )
         if isinstance(instance, SettingsBrowser):
             return self.browser_instance_to_dict(instance)
-        return self._reader_instance_to_dict(instance)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+        # Branch invariant: ``instance`` is a ``SettingsReader`` (the
+        # only other concrete type in the union). ``_get_or_create_settings``'s
+        # broad return type forces the cast.
+        return self._reader_instance_to_dict(cast("SettingsReader", instance))
 
     def _load_browser_settings_data(self, only: Sequence[str] | None = None) -> dict:
         """Load settings from the browser model (for cross-reading)."""
-        instance: SettingsBrowser = self._get_or_create_settings(  # pyright: ignore[reportAssignmentType], # ty: ignore[invalid-assignment]
-            self.BROWSER_MODEL,
-            self.BROWSER_CLIENT,
-            BROWSER_FILTER_ARGS,
-            BROWSER_CREATE_ARGS,
-            only=only,
+        instance = cast(
+            "SettingsBrowser",
+            self._get_or_create_settings(
+                self.BROWSER_MODEL,
+                self.BROWSER_CLIENT,
+                BROWSER_FILTER_ARGS,
+                BROWSER_CREATE_ARGS,
+                only=only,
+            ),
         )
         return self.browser_instance_to_dict(instance)
 
@@ -485,7 +492,8 @@ class SettingsBaseView(AuthFilterGenericAPIView, ABC):
         if isinstance(instance, SettingsBrowser):
             self._save_browser_settings_data(instance, data)
         else:
-            self._save_reader_settings_data(instance, data)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+            # Same branch invariant as ``_load_settings_data``.
+            self._save_reader_settings_data(cast("SettingsReader", instance), data)
 
     def save_params_to_settings(self, params) -> None:  # reader session & browser final
         """Save the session from params with defaults for missing values."""


### PR DESCRIPTION
## Summary

Dedicated pass to eliminate ``# pyright: ignore`` and
``# ty: ignore`` directives where better annotations or
``cast()`` calls can resolve the underlying type-system gap
cleanly.

**Before:** 150 ``pyright: ignore`` + 92 ``ty: ignore`` directives.
**After:** 107 + 59 — **76 directives eliminated** (-31% combined).

Three commits, organized by area. Each ignore was triaged:
mechanical wins applied, remaining ignores documented (Django
ORM dynamics, mixin patterns, DRF base-class quirks). No
behavior changes.

## Patterns applied

- **``cast()`` for Django ORM type-system gaps** —
  ``Field.related_model`` returning the broad union when only
  one concrete subtype is reachable; ``ManyToManyField.remote_field``
  typed as ``ForeignObjectRel`` even though the runtime is
  always ``ManyToManyRel``; ``_get_or_create_settings`` returning
  ``SettingsBase | None`` when the caller's branch invariants
  prove the concrete subclass.
- **Class-level defaults instead of ``init_*``-method assignments**
  — ``IsAdminMixin._is_admin``, ``GroupACLMixin._cached_*``,
  ``OPDSAuthMixin._user_agent_name`` move from per-method
  first-assignment to class-level ``None`` defaults, so the
  ``init_*`` methods reset rather than first-init. Eliminates
  ``reportUninitializedInstanceVariable``.
- **``NoReturn`` for always-raises helpers** —
  ``raise_redirect`` is now ``NoReturn``, which lets
  ``_handle_group_query_missing_model`` drop a
  ``reportPossiblyUnboundVariable`` ignore via a guard-and-
  fallthrough restructure.
- **``Any`` for queryset-annotated rows** —
  ``OPDS2ProgressionView._obj`` carries synthetic
  ``bookmark_updated_at`` / ``page`` / ``progress`` columns no
  concrete model type knows about; ``Any`` reflects the
  contract honestly.
- **``Any`` for duck-typed parameters** —
  ``_add_tag_link`` accepts both ``NamedModel`` rows and
  ``SimpleNamespace`` placeholders that share a ``pk`` /
  ``name`` / ``links`` shape.
- **Walrus + early-narrow** — ``_build_folder_breadcrumbs``
  uses ``while folder and (parent := folder.parent_folder)``
  to drop the inner ``reportOptionalMemberAccess`` ignore.
- **``getattr`` over ``isinstance`` casting** —
  ``field.concrete`` (not on the public ``ForeignObjectRel``
  stub) becomes ``getattr(field, "concrete", False)`` —
  uniform across the union.

## What stayed

- Reverse OneToOne accessors (``instance.filters``,
  ``instance.last_route``) — real Django ORM dynamics; faking
  them as ClassVars hurts more than it helps.
- DRF/Django ``ClassVar`` overrides (``permission_classes``,
  ``input_serializer_class``) — base-class incompatibilities
  the type system can't unify.
- ``WorkerMixin`` attribute initialization — pyright wants
  init-in-``__init__`` for the
  ``reportUninitializedInstanceVariable`` check; doesn't fit
  the mixin/init_worker pattern.
- ``LibrarianDaemon._threads`` and ``db_write_lock`` —
  initialized post-``fork`` inside ``_create_threads``, so
  class-level defaults aren't an option.
- Field stub gaps (``Field.get_compiler``,
  ``QuerySet._chain``, ``Manager.from_queryset``) — Django-stubs
  lag.

## Files changed (10)

- ``codex/librarian/librariand.py``
- ``codex/librarian/scribe/importer/const.py``
- ``codex/librarian/scribe/importer/link/delete.py``
- ``codex/librarian/scribe/importer/read/many_to_many.py``
- ``codex/views/auth.py``
- ``codex/views/browser/breadcrumbs.py``
- ``codex/views/browser/choices.py``
- ``codex/views/browser/settings.py``
- ``codex/views/browser/validate.py``
- ``codex/views/opds/auth.py``
- ``codex/views/opds/feed.py``
- ``codex/views/opds/v2/manifest.py``
- ``codex/views/opds/v2/progression.py``
- ``codex/views/reader/settings.py``
- ``codex/views/settings.py``

## Test plan

- [x] ``make lint-python`` — 0 errors, 0 warnings (full
      basedpyright + ruff + vulture + complexipy + codespell)
- [x] ``uv run pytest tests/`` — 26 passed
- [ ] Manual: smoke-test the importer (the librarian-side
      ``cast()`` paths run during every import); the OPDS v2
      progression endpoint (``_obj`` typing changed); browser
      breadcrumbs (the ``_handle_group_query_missing_model``
      restructure is the only flow change in the pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)