### PR TITLE
Search index: drop _update_search_index_operate below C complexity

### DIFF
--- a/codex/librarian/scribe/search/sync.py
+++ b/codex/librarian/scribe/search/sync.py
@@ -224,6 +224,50 @@ class SearchIndexerSync(SearchIndexerRemove):
         status.increment_complete(num_comic_fts)
         self.status_controller.update(status, notify=True)
 
+    def _build_search_index_batch_obj_list(
+        self,
+        base_qs: QuerySet,
+        batch_size: int,
+        *,
+        create: bool,
+    ) -> list[ComicFTS]:
+        """
+        Build one batch of ``ComicFTS`` rows for create-or-update.
+
+        Returns an empty list to signal the caller to stop iterating
+        — either the queryset is exhausted or every batch row was
+        filtered out by ``prepare_sync_fts_entry``.
+        """
+        # Snapshot the batch's pk list once; every per-relation
+        # query below filters against the same set so they stitch
+        # back together cleanly in Python.
+        batch_pks = list(
+            base_qs.order_by("pk").values_list("pk", flat=True)[:batch_size]
+        )
+        if not batch_pks:
+            return []
+
+        # Per-M2M batched queries. Replaces the previous megaquery
+        # (10 GROUP_CONCAT aggregations + 20+ LEFT JOINs + GROUP BY
+        # in a single SELECT) with one SELECT per relation — each
+        # walks one M2M's index independently, no cartesian product
+        # across the 10 M2Ms.
+        fk_rows = self._build_fk_fts_rows(batch_pks)
+        m2m_dicts = {
+            f"fts_{alias}": self._build_m2m_fts_dict(batch_pks, target)
+            for alias, target in _M2M_FTS_REL_MAP.items()
+        }
+        universes_dict = self._build_universes_fts_dict(batch_pks)
+
+        obj_list: list[ComicFTS] = []
+        for comic in fk_rows:
+            pk = comic["id"]
+            for fts_alias, m2m_dict in m2m_dicts.items():
+                comic[fts_alias] = m2m_dict.get(pk, "")
+            comic["fts_universes"] = universes_dict.get(pk, "")
+            SearchEntryPrepare.prepare_sync_fts_entry(comic, obj_list, create=create)
+        return obj_list
+
     def _update_search_index_operate(
         self, comics_filtered_qs: QuerySet, *, create: bool
     ):
@@ -259,7 +303,6 @@ class SearchIndexerSync(SearchIndexerRemove):
             self.status_controller.start(status, notify=True)
             start = 0
             while start < total_comics:
-                obj_list = []
                 if self.abort_event.is_set():
                     break
                 # Not using standard iterator chunking to control memory and really
@@ -267,48 +310,15 @@ class SearchIndexerSync(SearchIndexerRemove):
                 self.log.debug(
                     f"Preparing up to {chunk_human_size} comics for search indexing..."
                 )
-                # Snapshot the batch's pk list once; every per-relation
-                # query below filters against the same set so they
-                # stitch back together cleanly in Python.
-                batch_pks = list(
-                    base_qs.order_by("pk").values_list("pk", flat=True)[
-                        :search_index_batch_size
-                    ]
+                obj_list = self._build_search_index_batch_obj_list(
+                    base_qs, search_index_batch_size, create=create
                 )
-                if not batch_pks:
-                    break
-
-                # Per-M2M batched queries. Replaces the previous
-                # megaquery (10 GROUP_CONCAT aggregations + 20+
-                # LEFT JOINs + GROUP BY in a single SELECT) with one
-                # SELECT per relation — each walks one M2M's index
-                # independently, no cartesian product across the
-                # 10 M2Ms.
-                fk_rows = self._build_fk_fts_rows(batch_pks)
-                m2m_dicts = {
-                    f"fts_{alias}": self._build_m2m_fts_dict(batch_pks, target)
-                    for alias, target in _M2M_FTS_REL_MAP.items()
-                }
-                universes_dict = self._build_universes_fts_dict(batch_pks)
-
-                for comic in fk_rows:
-                    pk = comic["id"]
-                    for fts_alias, m2m_dict in m2m_dicts.items():
-                        comic[fts_alias] = m2m_dict.get(pk, "")
-                    comic["fts_universes"] = universes_dict.get(pk, "")
-                    SearchEntryPrepare.prepare_sync_fts_entry(
-                        comic, obj_list, create=create
-                    )
-
                 if not obj_list:
                     break
                 self._update_search_index_create_or_update(
-                    obj_list,
-                    status,
-                    create=create,
+                    obj_list, status, create=create
                 )
                 start += search_index_batch_size
-
         finally:
             self.status_controller.finish(status)
         return total_comics


### PR DESCRIPTION
## Summary

``make complexity`` (radon cc with ``--min C``) was surfacing
exactly one function:

```
codex/librarian/scribe/search/sync.py
    M 227:4 SearchIndexerSync._update_search_index_operate - C (12)
```

C-rank starts at cyclomatic complexity 11; the function was
sitting at 12. The function did three jobs in one body —
configure batching from the memory budget, decide which queryset
to walk, and run the batch loop with per-batch FTS aggregation —
which compounded into a long body with several nested branches.

## Refactor

Extract the per-batch work into a new
``_build_search_index_batch_obj_list`` helper:

- Snapshot the batch's pk list once.
- Build per-FK and per-M2M FTS columns via the same helpers the
  inline code used.
- Loop those columns onto the comic dicts and feed
  ``prepare_sync_fts_entry``.
- Return an empty list to signal "nothing more to process"; the
  caller's ``while`` loop breaks on it.

The outer loop in ``_update_search_index_operate`` is now five
lines: abort check, log, helper call, empty-list break, batch
size advance.

## Numbers

| | before | after |
|---|---|---|
| ``_update_search_index_operate`` | C (12) | **B (8)** |
| ``_build_search_index_batch_obj_list`` | — | A (5) |

``make complexity`` is fully clean.

## Test plan

- [x] ``make complexity`` — no functions above the threshold
- [x] ``make lint-python`` — clean
- [x] ``uv run pytest tests/`` — 26 passed
- [ ] Manual: trigger a search-index rebuild on a populated
      library and verify FTS rows update as before; the batch
      invariants (snapshot pks once per batch, share the same
      pk set across all M2M queries, break on empty pk list,
      break on empty obj_list) are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)