### PR TITLE
Complexity: drop four functions below complexipy threshold

### DIFF
--- a/codex/librarian/scribe/importer/read/extract.py
+++ b/codex/librarian/scribe/importer/read/extract.py
@@ -146,6 +146,74 @@ class ExtractMetadataImporter(AggregateMetadataImporter):
         self.status_controller.update(status)
         return False
 
+    def _init_extract_status(
+        self,
+        status: ImporterReadComicsStatus | None,
+        total_paths: int,
+    ) -> ImporterReadComicsStatus:
+        """Reset/create the read-comics status object for an extract pass."""
+        if status is None:
+            return ImporterReadComicsStatus(0, total_paths)
+        status.complete = 0
+        status.total = total_paths
+        self.status_controller.update(status)
+        return status
+
+    def _apply_filesystem_prefilter(
+        self,
+        all_paths: frozenset[str],
+        all_old_comic_mtimes: MappingProxyType[str, datetime],
+        status: ImporterReadComicsStatus,
+    ) -> frozenset[str]:
+        """
+        Skip archive-open cost via filesystem stat mtime pre-filter.
+
+        Worker still rechecks the embedded mtime for paths that pass
+        through, so a touch-without-content-change still short-circuits
+        inside the worker.
+        """
+        if not all_old_comic_mtimes:
+            return all_paths
+        paths_to_extract, prefilter_skipped = self._filesystem_mtime_prefilter(
+            all_paths, all_old_comic_mtimes
+        )
+        if prefilter_skipped:
+            self.metadata[SKIPPED].update(prefilter_skipped)
+            skipped_n = len(prefilter_skipped)
+            self.log.debug(
+                f"Skipped archive open for {skipped_n} comics via filesystem mtime pre-filter."
+            )
+            status.increment_complete(skipped_n)
+            self.status_controller.update(status)
+        return paths_to_extract
+
+    def _run_extract_loop(
+        self,
+        paths_to_extract: frozenset[str],
+        all_old_comic_mtimes: MappingProxyType[str, datetime],
+        all_old_comic_values: MappingProxyType[str, dict[str, str | int]],
+        status: ImporterReadComicsStatus,
+        *,
+        import_metadata: bool,
+    ) -> None:
+        """Stream the comicbox extraction results into the metadata dict."""
+        for path, value in iter_process_files(
+            paths_to_extract,
+            config=COMICBOX_CONFIG,
+            logger=self.log,
+            worker_log_config={
+                "level": LOGLEVEL,
+                "format": CODEX_LOG_FORMAT,
+                "sink": "stdout",  # comicbox only accepts one sink
+            },
+            old_mtime_map=all_old_comic_mtimes,
+            full_metadata=import_metadata,
+        ):
+            if self._extract_post_process_comic(
+                path, value, all_old_comic_values, status
+            ):
+                break
+
     def extract_metadata(self, status=None) -> int:
         """Extract comic metadata into memory."""
         count = 0
@@ -161,12 +229,7 @@ class ExtractMetadataImporter(AggregateMetadataImporter):
         self.task.files_modified = frozenset()
         self.task.files_created = frozenset()
         total_paths = len(all_paths)
-        if not status:
-            status = ImporterReadComicsStatus(0, total_paths)
-        else:
-            status.complete = 0
-            status.total = total_paths
-            self.status_controller.update(status)
+        status = self._init_extract_status(status, total_paths)
 
         try:
             if not total_paths:
@@ -177,47 +240,20 @@ class ExtractMetadataImporter(AggregateMetadataImporter):
             )
             self.status_controller.start(status, notify=True)
 
-            # Set import_metadata flag
             import_metadata = self._get_import_metadata_flag()
             all_old_comic_mtimes, all_old_comic_values = self._get_all_old_comic_values(
                 all_paths
             )
-
-            # Pre-filter against the archive file's stat mtime so we can
-            # skip the archive-open cost for files unchanged on disk.
-            # Worker still rechecks the embedded mtime for paths that
-            # pass through, so a touch-without-content-change still
-            # short-circuits inside the worker.
-            paths_to_extract = all_paths
-            if all_old_comic_mtimes:
-                paths_to_extract, prefilter_skipped = self._filesystem_mtime_prefilter(
-                    all_paths, all_old_comic_mtimes
-                )
-                if prefilter_skipped:
-                    self.metadata[SKIPPED].update(prefilter_skipped)
-                    skipped_n = len(prefilter_skipped)
-                    self.log.debug(
-                        f"Skipped archive open for {skipped_n} comics via filesystem mtime pre-filter."
-                    )
-                    status.increment_complete(skipped_n)
-                    self.status_controller.update(status)
-
-            for path, value in iter_process_files(
+            paths_to_extract = self._apply_filesystem_prefilter(
+                all_paths, all_old_comic_mtimes, status
+            )
+            self._run_extract_loop(
                 paths_to_extract,
-                config=COMICBOX_CONFIG,
-                logger=self.log,
-                worker_log_config={
-                    "level": LOGLEVEL,
-                    "format": CODEX_LOG_FORMAT,
-                    "sink": "stdout",  # comicbox only accepts one sink
-                },
-                old_mtime_map=all_old_comic_mtimes,
-                full_metadata=import_metadata,
-            ):
-                if self._extract_post_process_comic(
-                    path, value, all_old_comic_values, status
-                ):
-                    break
+                all_old_comic_mtimes,
+                all_old_comic_values,
+                status,
+                import_metadata=import_metadata,
+            )
 
             skipped_count = len(self.metadata[SKIPPED])
             count = total_paths - skipped_count

--- a/codex/librarian/scribe/janitor/adopt_folders.py
+++ b/codex/librarian/scribe/janitor/adopt_folders.py
@@ -53,6 +53,43 @@ class OrphanFolderAdopter(WorkerStatusAbortableBase):
         count = importer.bulk_folders_moved(mark_in_progress=True)
         return True, count
 
+    def _converge_orphan_folders_for_library(self, library) -> int:
+        """
+        Run capped convergence passes on one library; return total count moved.
+
+        Pre-fix this was a bare ``while folders_left:`` that could
+        run forever if the importer kept failing to actually move
+        folders (permission errors, FS races, etc.) — only the
+        external abort_event broke the loop.
+        """
+        library_total = 0
+        for _ in range(_ADOPT_FOLDERS_MAX_PASSES):
+            if self.abort_event.is_set():
+                return library_total
+            folders_left, count = self._adopt_orphan_folders_for_library(library)
+            library_total += count
+            if not folders_left:
+                return library_total
+        # Cap reached without convergence and no abort — warn so the
+        # operator notices that folders may be unreachable or
+        # unwriteable.
+        if not self.abort_event.is_set():
+            cap = _ADOPT_FOLDERS_MAX_PASSES
+            self.log.warning(
+                f"Adopt orphan folders for {library.path} hit {cap}-pass cap"
+                " without converging — folders may be unreachable or unwriteable."
+            )
+        return library_total
+
+    def _finalize_adopt_orphan_folders(self, total_count: int) -> None:
+        """Queue downstream notifications and log abort state."""
+        if total_count:
+            self.librarian_queue.put(LIBRARY_CHANGED_TASK)
+            self.librarian_queue.put(SearchIndexSyncTask())
+        if self.abort_event.is_set():
+            self.log.debug("Adopt Orphan Folders aborted early.")
+        self.abort_event.clear()
+
     def adopt_orphan_folders(self) -> None:
         """Find orphan folders and move them into their correct place."""
         self.abort_event.clear()
@@ -63,34 +100,9 @@ class OrphanFolderAdopter(WorkerStatusAbortableBase):
             self.status_controller.start_many((status, moved_status))
             libraries = Library.objects.filter(covers_only=False).only("path")
             for library in libraries.iterator():
-                converged = False
-                # Capped convergence loop. Pre-fix this was a bare
-                # ``while folders_left:`` that could run forever if the
-                # importer kept failing to actually move folders
-                # (permission errors, FS races, etc.) — only the
-                # external abort_event broke the loop.
-                for _ in range(_ADOPT_FOLDERS_MAX_PASSES):
-                    if self.abort_event.is_set():
-                        return
-                    folders_left, count = self._adopt_orphan_folders_for_library(
-                        library
-                    )
-                    total_count += count
-                    if not folders_left:
-                        converged = True
-                        break
-                if not converged and not self.abort_event.is_set():
-                    cap = _ADOPT_FOLDERS_MAX_PASSES
-                    self.log.warning(
-                        f"Adopt orphan folders for {library.path} hit {cap}-pass cap without converging — folders may be unreachable or unwriteable."
-                    )
+                if self.abort_event.is_set():
+                    return
+                total_count += self._converge_orphan_folders_for_library(library)
         finally:
             self.status_controller.finish_many((moved_status, status))
-            if total_count:
-                self.librarian_queue.put(LIBRARY_CHANGED_TASK)
-                task = SearchIndexSyncTask()
-                self.librarian_queue.put(task)
-            if self.abort_event.is_set():
-                self.log.debug("Adopt Orphan Folders aborted early.")
-
-            self.abort_event.clear()
+            self._finalize_adopt_orphan_folders(total_count)

--- a/codex/librarian/scribe/janitor/cleanup.py
+++ b/codex/librarian/scribe/janitor/cleanup.py
@@ -154,6 +154,28 @@ class JanitorCleanup(JanitorUpdateFailedImports):
             count += self._cleanup_fks_model(model, filter_dict, status)
         return count
 
+    def _converge_cleanup_fks(self, status) -> bool:
+        """
+        Run capped convergence passes inside the write lock + transaction.
+
+        Returns True if the loop converged (a pass with zero count) or
+        the abort event triggered. Returns False only if the cap was
+        hit without convergence — caller logs a warning.
+
+        Hold ``db_write_lock`` across all passes so a concurrent
+        importer can't re-introduce a parent FK between the check
+        that found it orphaned and the DELETE that removes it. The
+        integrity-check writers in ``integrity/`` use the same
+        pattern; cleanup was previously missing it.
+        """
+        with self.db_write_lock, transaction.atomic():
+            for _ in range(_FK_CLEANUP_MAX_PASSES):
+                if self.abort_event.is_set():
+                    return True
+                if not self._cleanup_fks_one_level(status):
+                    return True
+        return False
+
     def cleanup_fks(self) -> None:
         """
         Clean up unused foreign keys.
@@ -173,24 +195,12 @@ class JanitorCleanup(JanitorUpdateFailedImports):
         try:
             self.status_controller.start(status)
             self.log.debug("Cleaning up orphan tags...")
-            # Hold ``db_write_lock`` across all passes so a concurrent
-            # importer can't re-introduce a parent FK between the
-            # check that found it orphaned and the DELETE that removes
-            # it. The integrity-check writers in ``integrity/`` use the
-            # same pattern; cleanup was previously missing it.
-            converged = False
-            with self.db_write_lock, transaction.atomic():
-                for _ in range(_FK_CLEANUP_MAX_PASSES):
-                    if self.abort_event.is_set():
-                        return
-                    count = self._cleanup_fks_one_level(status)
-                    if not count:
-                        converged = True
-                        break
+            converged = self._converge_cleanup_fks(status)
             if not converged and not self.abort_event.is_set():
                 cap = _FK_CLEANUP_MAX_PASSES
                 self.log.warning(
-                    f"FK cleanup hit {cap}-pass cap without converging — investigate the reverse-relation map or the data graph."
+                    f"FK cleanup hit {cap}-pass cap without converging"
+                    " — investigate the reverse-relation map or the data graph."
                 )
             level = "INFO" if status.complete else "DEBUG"
             self.log.log(level, f"Cleaned up {status.complete} unused tags.")

--- a/codex/librarian/status_controller.py
+++ b/codex/librarian/status_controller.py
@@ -151,6 +151,39 @@ class StatusController:
 
         self.log.log(level, f"{prefix}{suffix}.")
 
+    @staticmethod
+    def _build_finish_filter(
+        positive_statii: MappingProxyType[str, Status | type[Status]],
+    ) -> Q:
+        """
+        Build the ``WHERE`` filter for the finish-many UPDATE.
+
+        Specific statuses get finished unconditionally by
+        ``status_type`` (don't require active/preactive — subtasks
+        may have already been individually finished). The empty
+        case is a clear-all that only touches rows currently active.
+        """
+        if positive_statii:
+            return Q(status_type__in=positive_statii.keys())
+        return Q(active__isnull=False) | Q(preactive__isnull=False)
+
+    def _log_finished(
+        self,
+        positive_statii: MappingProxyType[str, Status | type[Status]],
+    ) -> None:
+        """Log per-status finish lines (or a clear-all summary)."""
+        if not positive_statii:
+            self.log.info("Cleared all librarian statuses")
+            return
+        for status in positive_statii.values():
+            if isinstance(status, type):
+                # ``finish_many`` accepts both Status classes and
+                # instances. Class entries are placeholders used by
+                # ``start_many`` for ordering — no per-instance state
+                # to log.
+                continue
+            self._log_finish(status)
+
     def finish_many(
         self,
         statii: Iterable[Status | type[Status] | None],
@@ -162,43 +195,23 @@ class StatusController:
             MappingProxyType({status.CODE: status for status in statii if status})
         )
         try:
-            # Construct update query
+            # If statii has elements but they were all None, this is a
+            # noop. If statii was empty this is a finish-all command.
+            # This fires an extra LIBRARIAN_STATUS notification if none.
+            # idk if that's appropriate.
             if statii and not positive_statii:
-                # if statii has elements but they were all None, this is a noop.
-                # But if statii was empty this is a finish all command.
-                # This fires an extra LIBRARIAN_STATUS notification if none. idk if that's appropriate.
                 return
             updates = {**STATUS_DEFAULTS, "updated_at": Now()}
-            if positive_statii:
-                # Finish specific statuses unconditionally by status_type.
-                # Don't require active/preactive to be set — subtasks may
-                # have already been individually finished.
-                ls_filter = Q(status_type__in=positive_statii.keys())
-            else:
-                # Clear-all: only touch rows that are currently active.
-                ls_filter = Q(active__isnull=False) | Q(preactive__isnull=False)
-
+            ls_filter = self._build_finish_filter(positive_statii)
             # Single round-trip update. The previous shape captured a
             # ``.values()`` queryset for per-status logging, but
             # ``values()`` yields ``dict`` rows which the
-            # ``isinstance(row, Status)`` guard below would always
-            # reject — the log branch never fired despite the cost
-            # of the SELECT. Iterate ``positive_statii.values()``
-            # directly instead: those are the ``Status`` instances
-            # the caller passed in, no second SELECT required.
+            # ``isinstance(row, Status)`` guard would always reject —
+            # the log branch never fired despite the cost of the
+            # SELECT. ``_log_finished`` iterates the caller-supplied
+            # instances directly instead.
             LibrarianStatus.objects.filter(ls_filter).update(**updates)
-
-            if positive_statii:
-                for status in positive_statii.values():
-                    if isinstance(status, type):
-                        # ``finish_many`` accepts both Status classes
-                        # and instances. Class entries are placeholders
-                        # used by ``start_many`` for ordering — no
-                        # per-instance state to log.
-                        continue
-                    self._log_finish(status)
-            else:
-                self.log.info("Cleared all librarian statuses")
+            self._log_finished(positive_statii)
         except Exception:
             self.log.exception(f"Finish status {positive_statii}")
         finally:


### PR DESCRIPTION
## Summary

complexipy reported four functions over its 15-complexity
threshold:

| function | before | after |
|---|---|---|
| ``ExtractMetadataImporter::extract_metadata`` | 16 | < 15 |
| ``OrphanFolderAdopter::adopt_orphan_folders`` | 21 | < 15 |
| ``JanitorCleanup::cleanup_fks`` | 18 | < 15 |
| ``StatusController::finish_many`` | 17 | < 15 |

Pure refactor — extract helpers to flatten control flow. No
behavior changes; all 26 tests pass.

## Per-file refactors

- **``extract.py``** — split into three helpers:
  ``_init_extract_status`` (status reset/create),
  ``_apply_filesystem_prefilter`` (``if all_old_comic_mtimes:``
  block with nested skipped-set bookkeeping), and
  ``_run_extract_loop`` (the ``iter_process_files`` for-loop with
  per-result post-processing).
- **``adopt_folders.py``** — extract
  ``_converge_orphan_folders_for_library`` (the inner
  ``for _ in range(_ADOPT_FOLDERS_MAX_PASSES)`` loop with the
  abort / converged / cap-warning logic) and
  ``_finalize_adopt_orphan_folders`` (post-loop notification +
  abort logging that lived in the ``finally``).
- **``cleanup.py``** — extract ``_converge_cleanup_fks`` (the
  ``with db_write_lock, transaction.atomic()`` block with the
  capped convergence loop). Returns a single bool the caller
  uses for the cap-warning branch.
- **``status_controller.py``** — extract ``_build_finish_filter``
  (the ``ls_filter`` Q construction) and ``_log_finished`` (the
  per-status / clear-all log branches). The body of
  ``finish_many`` is now linear: noop check → filter → update
  → log → notify.

## Test plan

- [x] ``uv run --group lint complexipy <four files>`` — clean
- [x] ``make lint-python`` — clean
- [x] ``uv run pytest tests/`` — 26 passed
- [ ] Manual: trigger an import (extract path), trigger orphan
      folder adoption, trigger janitor cleanup-fks, finish a
      multi-status librarian task — verify behavior matches
      pre-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)