### PR TITLE
Frontend quality pass: Vue 3 / Vuetify 4 / SCSS cleanups

### DIFF
--- a/frontend/src/components/admin/tabs/admin-table.vue
+++ b/frontend/src/components/admin/tabs/admin-table.vue
@@ -15,9 +15,12 @@ export default {
 };
 </script>
 <style scoped lang="scss">
-.adminTable :deep(thead > tr > th, .adminTable tbody > tr:nth-child(even)) {
-  background-color: rgb(var(--v-theme-background)) !important;
-}
+// The rule that previously sat here was malformed: a comma inside
+// ``:deep(...)`` rooted under ``.adminTable`` (a class never applied
+// to this component or any caller). The selector matched nothing and
+// the row striping/header background it claimed to set came entirely
+// from the Vuetify ``v-data-table-virtual`` defaults below it.
+// Deleted as dead code; the visible result is unchanged.
 :deep(.adminNoData) {
   padding: 1em;
   text-align: center;

--- a/frontend/src/components/admin/tabs/datetime-column.vue
+++ b/frontend/src/components/admin/tabs/datetime-column.vue
@@ -48,6 +48,6 @@ export default {
 
 <style scoped lang="scss">
 .colTime {
-  color: rgb(var(--v-theme-textDisabled)) !important;
+  color: rgb(var(--v-theme-textDisabled));
 }
 </style>

--- a/frontend/src/components/book-cover.scss
+++ b/frontend/src/components/book-cover.scss
@@ -4,3 +4,10 @@ $cover-width: 165px;
 $cover-height: math.round(calc($cover-ratio * $cover-width));
 $small-cover-width: 100px;
 $small-cover-height: math.round(calc($cover-ratio * $small-cover-width));
+
+// Stacked-cover shadow tones, progressively darker so the eye reads
+// a deck of pages. Tuned for the codex dark theme (always-dark by
+// design, see plugins/vuetify.js).
+$stack-shadow-1: #606060;
+$stack-shadow-2: #404040;
+$stack-shadow-3: #202020;

--- a/frontend/src/components/book-cover.vue
+++ b/frontend/src/components/book-cover.vue
@@ -182,20 +182,20 @@ export default {
 }
 
 .stack2 {
-  box-shadow: 3px 3px #606060;
+  box-shadow: 3px 3px bookcover.$stack-shadow-1;
 }
 
 .stack3 {
   box-shadow:
-    3px 3px #606060,
-    6px 6px #404040;
+    3px 3px bookcover.$stack-shadow-1,
+    6px 6px bookcover.$stack-shadow-2;
 }
 
 .stack4 {
   box-shadow:
-    3px 3px #606060,
-    6px 6px #404040,
-    9px 9px #202020;
+    3px 3px bookcover.$stack-shadow-1,
+    6px 6px bookcover.$stack-shadow-2,
+    9px 9px bookcover.$stack-shadow-3;
 }
 
 @media #{map.get(vuetify.$display-breakpoints, 'sm-and-down')} {

--- a/frontend/src/components/confirm-dialog.vue
+++ b/frontend/src/components/confirm-dialog.vue
@@ -88,6 +88,7 @@ export default {
       required: true,
     },
   },
+  emits: ["cancel", "confirm"],
   data() {
     return {
       showDialog: false,

--- a/frontend/src/components/reader/book-change-drawer.vue
+++ b/frontend/src/components/reader/book-change-drawer.vue
@@ -89,6 +89,8 @@ export default {
 };
 </script>
 <style scoped lang="scss">
+@use "@/components/reader/change-column" as col;
+
 .bookChangeDrawer {
   opacity: 0.75 !important;
   z-index: 15 !important;
@@ -96,7 +98,7 @@ export default {
 
 .drawerActivated {
   // Deactivated drawers with custom width don't move off the screen enough
-  width: 33vw !important;
+  width: col.$change-column-width !important;
 }
 
 .prevCursor {

--- a/frontend/src/components/reader/change-column.scss
+++ b/frontend/src/components/reader/change-column.scss
@@ -1,6 +1,10 @@
+// Width of the prev/next-book change column. Shared with
+// ``book-change-drawer`` so the drawer's width matches the column.
+$change-column-width: 33vw;
+
 .changeColumn {
   position: fixed;
   top: 48px;
   height: calc(100vh - 96px);
-  width: 33vw;
+  width: $change-column-width;
 }

--- a/frontend/src/components/reader/drawer/_expansion-panel-overrides.scss
+++ b/frontend/src/components/reader/drawer/_expansion-panel-overrides.scss
@@ -1,0 +1,12 @@
+// Shared Vuetify v-expansion-panel overrides used by the keyboard
+// shortcuts panel/table and the reader-settings scope. ``@forward``
+// from each consumer's scoped style block so the rule lands inside
+// the consumer's scope id (matching the per-component ``:deep()``
+// targets).
+
+// Vuetify renders the active panel title with a ~48px height plus a
+// taller default — pin it so the expanded state doesn't jump the
+// drawer when the user toggles a section.
+:deep(.v-expansion-panel-title--active) {
+  min-height: 48px !important;
+}

--- a/frontend/src/components/reader/drawer/keyboard-shortcuts-panel.vue
+++ b/frontend/src/components/reader/drawer/keyboard-shortcuts-panel.vue
@@ -39,6 +39,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@forward "./expansion-panel-overrides";
+
 #readerKeyboardShortcuts {
   background-color: rgb(var(--v-theme-background));
 }
@@ -52,10 +54,6 @@ export default {
 
 #keyboardShortcutsItem {
   padding-left: 0px;
-}
-
-:deep(.v-expansion-panel-title--active) {
-  min-height: 48px !important;
 }
 
 :deep(.v-expansion-panel-text__wrapper) {

--- a/frontend/src/components/reader/drawer/keyboard-shortcuts-table.vue
+++ b/frontend/src/components/reader/drawer/keyboard-shortcuts-table.vue
@@ -116,11 +116,9 @@ export default {
 </script>
 
 <style scoped lang="scss">
-// settingsSubHeader defined in settings/settings-drawer.vue
-:deep(.v-expansion-panel-title--active) {
-  min-height: 48px !important;
-}
+@forward "./expansion-panel-overrides";
 
+// settingsSubHeader defined in settings/settings-drawer.vue
 :deep(.v-expansion-panel-text__wrapper) {
   padding-left: 10px;
   padding-right: 10px;

--- a/frontend/src/components/reader/drawer/reader-settings-scope.vue
+++ b/frontend/src/components/reader/drawer/reader-settings-scope.vue
@@ -236,6 +236,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@forward "./expansion-panel-overrides";
+
 :deep(.v-expansion-panel) {
   background-color: rgb(var(--v-theme-background));
 }
@@ -257,10 +259,6 @@ export default {
   font-size: 0.75rem;
   font-weight: normal;
   opacity: 0.7;
-}
-
-:deep(.v-expansion-panel-title--active) {
-  min-height: 48px !important;
 }
 
 :deep(.v-expansion-panel--active:not(:first-child)) {

--- a/frontend/src/components/reader/toolbars/top/reader-arc-select.vue
+++ b/frontend/src/components/reader/toolbars/top/reader-arc-select.vue
@@ -7,14 +7,22 @@
     :disabled="!items || items.length <= 1"
     @update:model-value="onUpdate"
   >
-    <template #item="{ item, props }">
+    <!--
+      Vuetify 4: ``#item`` slot scope is ``{ internalItem, props }``;
+      the custom ``prependIcon`` / ``subtitle`` / ``appendIcon`` fields
+      attached to each entry by the ``items`` computed below come off
+      ``internalItem.raw``. Pre-V4 the slot exposed the raw object
+      directly so ``item.prependIcon`` worked; after the upgrade those
+      reads silently resolved to ``undefined``.
+    -->
+    <template #item="{ internalItem, props }">
       <v-list-item
         v-bind="props"
         density="compact"
         variant="plain"
-        :prepend-icon="item.prependIcon"
-        :subtitle="item.subtitle"
-        :append-icon="item.appendIcon"
+        :prepend-icon="internalItem.raw.prependIcon"
+        :subtitle="internalItem.raw.subtitle"
+        :append-icon="internalItem.raw.appendIcon"
       />
     </template>
     <template #selection="{ props }">

--- a/frontend/src/components/reader/toolbars/top/reader-toolbar-top.vue
+++ b/frontend/src/components/reader/toolbars/top/reader-toolbar-top.vue
@@ -10,7 +10,7 @@
         <v-toolbar-items>
           <v-btn
             ref="closeBook"
-            class="closeBook"
+            class="closeBook text-uppercase"
             :to="closeRoute"
             size="large"
             density="compact"
@@ -186,7 +186,6 @@ export default {
 .closeBook {
   padding-left: max(18px, calc(env(safe-area-inset-left) / 2));
   color: rgb(var(--v-theme-textPrimary));
-  text-transform: uppercase;
 }
 
 .readerTitle {

--- a/frontend/src/components/settings/version-footer.vue
+++ b/frontend/src/components/settings/version-footer.vue
@@ -95,6 +95,6 @@ export default {
 }
 
 #warning {
-  color: rgb(230, 189, 13);
+  color: rgb(var(--v-theme-warning));
 }
 </style>

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -18,7 +18,7 @@ const codexTheme = {
     error: "#DC143C", // crimson
     // info: "#2196F3", // lightblue (similar to primary)
     success: "#14dc3c", // crimsongreen
-    // warning: "#FB8C00", // soft orange
+    warning: "#E6BD0D", // amber — version-footer "update available"
     "surface-light": "#2A2A2A",
     // --- custom ---
     linkHover: WHITE,


### PR DESCRIPTION
## Summary

Code-quality pass on the frontend per
``~/.claude/rules/js-vue-quality-pass.md``. Five commits, each
grouped by concern. The codebase was already lint-clean
(eslint + prettier baseline pass) and Vue 3 idioms are largely
in place — this PR catches the remaining mechanical wins
plus one latent slot-prop bug.

## Per-commit detail

1. **``confirm-dialog`` emits + reader-arc-select V4 slot fix**
   - ``confirm-dialog.vue`` was the only emitter in the
     codebase without an explicit ``emits: []`` declaration.
     Added ``emits: ["cancel", "confirm"]``.
   - ``reader-arc-select.vue`` was using the V3 ``#item="{ item, props }"``
     slot scope. In Vuetify 4 the slot exposes ``internalItem``
     (an ``InternalItem`` wrapper); the component's
     ``item.prependIcon``/``item.subtitle``/``item.appendIcon``
     reads were silently resolving to ``undefined`` after the
     V4 upgrade — the prepend icon, subtitle, and check mark
     were missing from the dropdown rows. Migrated to
     ``internalItem.raw.<field>``.

2. **Replace ``text-transform: uppercase`` SCSS with
   ``text-uppercase`` utility**
   - ``reader-toolbar-top.vue``'s Close Book button was
     re-implementing V3's default uppercase via a scoped SCSS
     rule. V4 dropped the default; using Vuetify's
     ``text-uppercase`` utility class makes the casing intent
     visible at the call site.

3. **Drop dead ``!important`` and a malformed ``:deep()`` selector**
   - ``admin-table.vue`` had ``.adminTable :deep(thead > tr >
     th, .adminTable tbody > tr:nth-child(even))``. The comma
     inside ``:deep()`` doesn't compile to the intended split
     selector, and ``.adminTable`` is never applied to this
     component or any caller, so the rule matched nothing.
     Removed as dead code.
   - ``datetime-column.vue:.colTime`` had a leaf-element
     ``color: ... !important`` with no competing selector to
     override. Dropped the flag.

4. **Theme color + shared SCSS variables**
   - Added ``warning: "#E6BD0D"`` (amber) to the codex Vuetify
     theme. ``version-footer.vue`` was hard-coding
     ``rgb(230, 189, 13)`` for the "update available" badge;
     now uses ``rgb(var(--v-theme-warning))`` like every
     other semantic color.
   - Added ``$stack-shadow-1/2/3`` to ``book-cover.scss``
     (the progressively darker greys used by the stacked-cover
     box-shadow).
   - Added ``$change-column-width: 33vw`` to
     ``change-column.scss`` and ``@use``d it from
     ``book-change-drawer.vue`` so the drawer collapses by
     exactly the column width.

5. **Extract duplicated expansion-panel SCSS**
   - Three reader-drawer components carried identical
     ``:deep(.v-expansion-panel-title--active) { min-height:
     48px !important }`` rules. Extracted to
     ``_expansion-panel-overrides.scss`` and ``@forward``ed
     from each consumer (matches the codebase's existing
     ``change-column.scss`` / ``anchors.scss`` pattern).

## What stayed (deliberately)

- ``codexTheme.dark: true`` and the absence of a ``system``
  theme default — codex is a brand-styled dark-only reader.
  The agent flagged this as Section 3.3 but the dark-only
  intent is correct.
- The ``browsePane*`` 8-class state explosion in
  ``browser/main.vue`` — flagged as a possible refactor but
  not a mechanical win; out of scope.
- Various ``!important`` overrides in admin tables, PDF
  viewer, etc. — these are real specificity battles against
  Vuetify defaults and would benefit from a CSS layers pass
  rather than per-rule edits.
- The ``VBtn`` casing decision (do we want a global
  ``text-uppercase`` default?) — needs product input, not
  mechanical refactor.

## Test plan

- [x] ``bun run lint`` — clean
- [x] ``bun run build`` — succeeds
- [x] ``bun run test:ci`` (vitest) — 1 pass
- [ ] Manual: open the reader on a book with story arcs, click
      the arc-select dropdown, verify each item shows its
      prepend icon, subtitle, and check mark for the active
      arc (this was a latent V4 regression — worth a
      side-by-side check).
- [ ] Manual: confirm-dialog still emits ``cancel`` /
      ``confirm`` correctly (any admin CRUD action that opens
      a confirm dialog).
- [ ] Manual: version-footer "update available" warning text
      still renders amber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)