### PR TITLE
Fix: empty-database browser redirect loop (regression from #656)

### DIFF
--- a/codex/views/browser/page_in_bounds.py
+++ b/codex/views/browser/page_in_bounds.py
@@ -50,9 +50,15 @@ class BrowserPageInBoundsView(BrowserAnnotateCoverView):
     def check_page_in_bounds(self, num_pages: int) -> None:
         """Redirect page out of bounds."""
         page = self.kwargs.get("page", 1)
-        if 1 <= page <= num_pages:
-            # Page within valid range (page == 1 is the root page,
-            # always valid even on a group with zero results).
+        # ``page == 1`` is the root page and is always in bounds,
+        # even when the group is empty (``num_pages == 0`` — the
+        # state on a fresh install where the importer hasn't run
+        # yet). Without that special case, an empty database
+        # redirects ``r/0/1`` → ``_get_up_page_redirect`` →
+        # ``r/0/1`` and loops. The earlier "simplification" to
+        # ``1 <= page <= num_pages`` collapsed both clauses into
+        # one but dropped this exact corner case.
+        if page == 1 or 1 <= page <= num_pages:
             return
 
         self._handle_page_out_of_bounds(num_pages)


### PR DESCRIPTION
## Summary

A user reported that a fresh install with no comics imported
loops on the browser route. The redirect log:

```
DEBUG codex.views.exceptions:__init__ | redirect {
    'reason': "group='r' pks=() page=1 does not exist.",
    'route': {'name': 'browser', 'params': {'group': 'r', 'pks': '0', 'page': 1}},
    'settings': {...}}
```

``r/0/1`` redirects to ``r/0/1``, which re-enters the same
check. Infinite loop.

## Root cause

PR #656 (python-quality-pass) collapsed:

```python
if page == 1 or (page >= 1 and page <= num_pages):
    return
```

into:

```python
if 1 <= page <= num_pages:
    return
```

The two are equivalent on a populated database, but **not**
on an empty one. For ``page=1, num_pages=0`` (no comics yet,
``ceil(0 / BROWSER_MAX_OBJ_PER_PAGE) = 0``):

- Original: ``page == 1`` → True → return (in bounds)
- Refactored: ``1 <= 1 <= 0`` is ``True and False`` → False →
  fall through to ``_handle_page_out_of_bounds(0)`` → redirect

The "simplification" looked equivalent but dropped the
``page == 1 is always in bounds`` invariant.

## Fix

Restore the explicit ``page == 1`` clause. Comment notes the
exact empty-database corner case so the next refactor doesn't
drop it again.

## What stayed broken (worth fixing in a follow-up)

The page-1 empty-database state isn't covered by the test
suite — the regression slipped through ``make test`` cleanly.
Worth a unit test on ``check_page_in_bounds(0)`` with
``page=1`` returning without raise.

## Test plan

- [x] ``make lint`` — clean
- [x] ``uv run pytest tests/`` — 26 passed
- [ ] Manual: start codex with no database, navigate to ``/r/0/1``
      — verify the empty browser page renders instead of looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)