### PR TITLE
Admin folder picker: start at parent of last-added library

### DIFF
--- a/codex/views/admin/library.py
+++ b/codex/views/admin/library.py
@@ -186,13 +186,54 @@ class AdminFolderListView(AdminGenericAPIView):
         dirs.extend(sorted(subdirs))
         return tuple(dirs)
 
+    @staticmethod
+    def _default_root_path() -> Path:
+        """
+        Pick the picker's starting folder when no path is requested.
+
+        Returns the parent directory of the most-recently-added
+        non-covers ``Library``. Lets an admin who's adding a second
+        library land in the same neighborhood as the first one
+        instead of the codex install root. Falls back to the CWD
+        when no library exists yet (the original behavior) or when
+        the recorded parent is no longer a directory (library
+        moved/deleted on disk after the row was created).
+        """
+        last_path = (
+            Library.objects.filter(covers_only=False)
+            .order_by("-created_at")
+            .values_list("path", flat=True)
+            .first()
+        )
+        if last_path:
+            parent = Path(last_path).resolve().parent
+            if parent.is_dir():
+                return parent
+        return Path.cwd()
+
+    @classmethod
+    def _resolve_root_path(cls, path_param: str) -> Path:
+        """
+        Resolve the ``path`` query param to a Path.
+
+        The serializer defaults ``path`` to ``"."`` when the client
+        omits it (the folder picker's initial mount). Treat that
+        sentinel as "use the smart default"; an explicit absolute
+        or relative path from later picker navigation passes
+        through ``Path.resolve()`` unchanged.
+        """
+        if path_param == ".":
+            return cls._default_root_path()
+        return Path(path_param).resolve()
+
     @extend_schema(request=input_serializer_class)
     def get(self, *_args, **_kwargs) -> Response:
         """Get subdirectories for a path."""
         try:
             serializer = self.input_serializer_class(data=self.request.GET)
             serializer.is_valid(raise_exception=True)
-            root_path = Path(serializer.validated_data.get("path", ".")).resolve()
+            path_param = serializer.validated_data.get("path", ".")
+            root_path = self._resolve_root_path(path_param)
             show_hidden = serializer.validated_data.get("show_hidden", False)
 
             dirs = self._get_dirs(root_path, show_hidden)


### PR DESCRIPTION
## Summary

When the admin opens the "Add Library" dialog the folder picker
mounts and calls ``GET /api/v3/admin/folders`` with no ``path``
parameter. The serializer's ``default="."`` was resolving that
to the codex install root — rarely where the admin's library
folders actually live, so admins ended up clicking ``..`` two
or three times to climb back into the right neighborhood.

This PR resolves the no-path case to **the parent of the most-
recently-added non-covers ``Library``**. Setting up a second
library lands the picker right next to the first one.

## Behavior

| State | Picker starts at |
|---|---|
| Fresh install, no libraries | CWD (codex install root) — unchanged |
| ≥1 non-covers library | Parent of the most-recently-added one |
| Library exists but its path no longer resolves to a directory | CWD |
| User navigates within the picker (explicit path arg) | The requested path — unchanged |

Covers-only libraries are excluded from the lookup because they
point at the custom-covers subdirectory, not at user-managed
content.

## Implementation

In ``codex/views/admin/library.py:AdminFolderListView``:

- New ``_default_root_path()`` does a single index-only
  ``Library.objects.filter(covers_only=False).order_by("-created_at").values_list("path", flat=True).first()``.
- New ``_resolve_root_path(path_param)`` treats the serializer's
  ``"."`` default as the "no path requested" sentinel and
  returns the smart default. Any explicit path passed later in
  the picker's navigation goes through ``Path.resolve()`` as
  before.

Server-side rather than frontend so the logic lives next to
the directory-listing logic and the picker still only needs
one round-trip on mount.

## Test plan

- [x] ``make lint`` — clean
- [x] ``make ty`` — clean
- [x] ``uv run pytest tests/`` — 26 passed
- [ ] Manual: fresh install, no libraries → "Add Library"
      picker starts at CWD as before.
- [ ] Manual: add a library at ``/comics/marvel`` → "Add
      Library" again, picker starts at ``/comics``.
- [ ] Manual: add a covers-only library afterwards → picker
      still starts at ``/comics`` (covers-only ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)