### PR TITLE
Status UI: split active spinner from progress bar

### DIFF
--- a/frontend/src/components/admin/drawer/status-list-item.vue
+++ b/frontend/src/components/admin/drawer/status-list-item.vue
@@ -1,6 +1,20 @@
 <template>
   <div class="statusItem">
     <div class="statusItemTitle">
+      <!--
+        Active-only spinner. Replaces the previous double-duty
+        progress bar that served both as a "task is running"
+        indicator AND as progress display — the progress bar now
+        only shows when active, and only goes indeterminate when
+        no numeric progress can be computed.
+      -->
+      <v-progress-circular
+        v-if="status.active"
+        class="statusActiveSpinner"
+        size="10"
+        width="2"
+        indeterminate
+      />
       {{ title }}
     </div>
     <div
@@ -19,6 +33,7 @@
       </div>
     </div>
     <v-progress-linear
+      v-if="status.active"
       :indeterminate="indeterminate"
       :model-value="progress"
       bottom
@@ -80,6 +95,12 @@ export default {
   padding-right: 0px;
   padding-bottom: 10px;
   color: rgb(var(--v-theme-textDisabled));
+}
+
+.statusActiveSpinner {
+  margin-right: 6px;
+  color: rgb(var(--v-theme-primary));
+  vertical-align: middle;
 }
 
 .statusItemDetails {

--- a/frontend/src/components/admin/tabs/job-tab.vue
+++ b/frontend/src/components/admin/tabs/job-tab.vue
@@ -139,6 +139,22 @@
                 >
                   <div class="statusHeader">
                     <span class="statusTitle">
+                      <!--
+                        Active-only spinner. Used to be implicit in
+                        the progress bar's indeterminate animation,
+                        which was confusing because the bar also
+                        served as a progress display for active
+                        tasks with numbers. Splitting "is running"
+                        (spinner) from "how far along" (progress
+                        bar) makes both axes unambiguous.
+                      -->
+                      <v-progress-circular
+                        v-if="status.active"
+                        class="statusActiveSpinner"
+                        size="10"
+                        width="2"
+                        indeterminate
+                      />
                       {{ statusTitle(status.statusType) }}
                     </span>
                     <span
@@ -167,11 +183,21 @@
                       {{ nf(status.total) }}
                     </span>
                   </div>
+                  <!--
+                    Progress bar is now active-only. Preactive tasks
+                    have nothing to show on a fill scale — the
+                    "pending" badge in ``.statusTime`` already
+                    signals the queued state, and the row's
+                    ``.statusRowPreactive`` background tint
+                    distinguishes preactive from active visually.
+                    Indeterminate fires only when active and no
+                    numeric progress can be computed.
+                  -->
                   <v-progress-linear
-                    v-if="status.active || status.preactive"
+                    v-if="status.active"
                     :indeterminate="isIndeterminate(status)"
                     :model-value="statusProgress(status)"
-                    :color="status.active ? 'primary' : 'grey'"
+                    color="primary"
                     height="3"
                   />
                 </div>
@@ -547,6 +573,12 @@ export default {
 
 .statusTitle {
   font-weight: 500;
+}
+
+.statusActiveSpinner {
+  margin-right: 6px;
+  color: rgb(var(--v-theme-primary));
+  vertical-align: middle;
 }
 
 .statusTime {


### PR DESCRIPTION
## Summary

The librarian status drawer and the jobs tab were both
double-duty-using ``v-progress-linear`` as **both** a "task is
running" indicator (via the indeterminate animation) **and** as
progress display (when numbers were available). Same widget,
two semantically distinct axes overlapping.

This is the misperception that led to the cover-step report:
indeterminate animation looked like "previous step is still
blocking" when it was just "this step is running but doesn't
have a fill".

## Fix

Split the two axes into two widgets:

| state | spinner | progress bar |
|---|---|---|
| active + numeric progress | shown | shown, fill % |
| active + no numbers | shown | shown, indeterminate animation |
| preactive (queued) | hidden | hidden — "pending" badge + row tint already communicate the state |
| finished / inactive | hidden | hidden |

The spinner is a small ``v-progress-circular`` (size 10, width
2) inline next to the status title. Active-only. Always
indeterminate (its job is purely "is this running", not "how
far along").

The progress bar is now gated on ``status.active`` rather than
``status.active || status.preactive``. Preactive tasks have
nothing to fill against, so the bar would show as a solid empty
strip — confusing, since users mistake it for "running but
making no progress". The "pending" string in ``.statusTime``
plus the row's ``.statusRowPreactive`` tint already
distinguish queued from active.

## Audit per the user's spec

> Indeterminate linear progress should show only when a
> progress or total can't be computed to show a sensible
> progress bar and when the task is active.

``status-helpers.js:isIndeterminate`` already matches the spec:

```js
export const isIndeterminate = (status) => {
  return status.active && (!status.total || !Number.isInteger(status.complete));
};
```

(Active **and** can't-compute.) No change needed there.

## Files

- ``components/admin/drawer/status-list-item.vue`` (drawer
  status list — librarian status sidebar)
- ``components/admin/tabs/job-tab.vue`` (jobs tab status
  rows)

## Test plan

- [x] ``bun run lint`` — clean
- [x] ``bun run test:ci`` — 1 pass
- [x] ``bun run build`` — clean
- [ ] Manual: trigger a long-running import, observe the
      drawer + jobs tab. Active steps should now show a small
      spinning circle next to the title; preactive
      (downstream) steps should show no bar at all (just
      title + "pending" badge); finished steps show "X ago".
- [ ] Manual: trigger a step with no numeric progress (e.g.
      one of the integrity checks) and verify the
      indeterminate bar still animates while the spinner is
      also active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)