### PR TITLE
Comicbox 3.0: consume ComicboxSettings dataclass directly

### DIFF
--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from types import MappingProxyType
 
 from comicbox.config import get_config
-from comicbox.config.frozenattrdict import FrozenAttrDict
+from comicbox.config.settings import ComicboxSettings
 from comicbox.schemas.comicbox.yaml import ComicboxYamlSubSchema
 from django.utils.csp import (  # pyright: ignore[reportMissingImports], # ty: ignore[unresolved-import]
     CSP,
@@ -807,11 +807,13 @@ _COMICBOX_DELETE_KEYS: frozenset[str] = frozenset(
     - USED_COMICBOX_FIELDS
 )
 
-COMICBOX_CONFIG = FrozenAttrDict(
-    get_config(
-        {
+# ``delete_keys`` is typed as ``Sequence(str)`` in the comicbox confuse
+# template, so feed it a sorted tuple rather than the source frozenset.
+COMICBOX_CONFIG: ComicboxSettings = get_config(
+    {
+        "comicbox": {
             "loglevel": LOGLEVEL,
-            "delete_keys": _COMICBOX_DELETE_KEYS,
+            "delete_keys": tuple(sorted(_COMICBOX_DELETE_KEYS)),
         }
-    )
+    }
 )

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ dependencies = [
     { name = "zipremove" },
 ]
 wheels = [
-    { filename = "comicbox-3.0.0-py3-none-any.whl", hash = "sha256:774a489339edbf00bc99882984e3110ed9f671efa0d621cde8b4d2732612b61f" },
+    { filename = "comicbox-3.0.0-py3-none-any.whl", hash = "sha256:2d37949e6967782c78c124a5f1b8bfb80e4a63814ddea6de11419b396526b625" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- comicbox 3.0 returns a typed `ComicboxSettings` dataclass from `get_config` — drop the legacy `FrozenAttrDict` wrap and annotate `COMICBOX_CONFIG` with the new type so downstream consumers get a typed object.
- Nest the args under `comicbox` so confuse can find them under the package root key.
- `delete_keys` is typed as `Sequence(str)` in comicbox's confuse template, so pass a sorted tuple rather than the source frozenset.

## Test plan
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint --group test --group build basedpyright codex/settings/__init__.py` — 0 errors, 0 warnings
- [x] `uv run --group lint --group test --group build python -m pytest --no-cov` — 26 passed
- [x] Verified at runtime: `COMICBOX_CONFIG` is a `ComicboxSettings`, `loglevel` honored, `delete_keys` populates with the 13 expected entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)