### PR TITLE
Importer: add dedicated Update Folders status

### DIFF
--- a/codex/choices/statii.py
+++ b/codex/choices/statii.py
@@ -12,6 +12,7 @@ from codex.librarian.scribe.importer.statii.create import CREATE_STATII
 from codex.librarian.scribe.importer.statii.delete import REMOVE_STATII
 from codex.librarian.scribe.importer.statii.failed import FAILED_IMPORTS_STATII
 from codex.librarian.scribe.importer.statii.link import LINK_STATII
+from codex.librarian.scribe.importer.statii.moved import MOVED_STATII
 from codex.librarian.scribe.importer.statii.query import QUERY_STATII
 from codex.librarian.scribe.importer.statii.read import READ_STATII
 from codex.librarian.scribe.importer.statii.search import IMPORTER_SEARCH_INDEX_STATII
@@ -30,6 +31,7 @@ _STATII = (
     CREATE_STATII,
     REMOVE_STATII,
     LINK_STATII,
+    MOVED_STATII,
     QUERY_STATII,
     READ_STATII,
     IMPORTER_SEARCH_INDEX_STATII,

--- a/codex/librarian/scribe/importer/init.py
+++ b/codex/librarian/scribe/importer/init.py
@@ -29,6 +29,7 @@ from codex.librarian.scribe.importer.statii.moved import (
     ImporterMoveComicsStatus,
     ImporterMoveCoversStatus,
     ImporterMoveFoldersStatus,
+    ImporterUpdateFoldersStatus,
 )
 from codex.librarian.scribe.importer.statii.query import (
     ImporterQueryComicUpdatesStatus,
@@ -208,6 +209,10 @@ class InitImporter(WorkerStatusBase):
             search_index_updates += len(self.task.files_moved)
         if self.task.covers_moved:
             status_list += [ImporterMoveCoversStatus(None, len(self.task.covers_moved))]
+        if self.task.dirs_modified:
+            status_list += [
+                ImporterUpdateFoldersStatus(None, len(self.task.dirs_modified))
+            ]
         return search_index_updates
 
     def _init_if_modified_or_created(self, path, status_list) -> tuple:

--- a/codex/librarian/scribe/importer/moved/__init__.py
+++ b/codex/librarian/scribe/importer/moved/__init__.py
@@ -6,7 +6,7 @@ from django.db.models.functions import Now
 
 from codex.librarian.scribe.importer.const import BULK_UPDATE_FOLDER_MODIFIED_FIELDS
 from codex.librarian.scribe.importer.moved.folders import MovedFoldersImporter
-from codex.librarian.scribe.importer.statii.create import ImporterUpdateTagsStatus
+from codex.librarian.scribe.importer.statii.moved import ImporterUpdateFoldersStatus
 from codex.models import Folder
 
 
@@ -18,28 +18,34 @@ class MovedImporter(MovedFoldersImporter):
         num_dirs_modified = len(self.task.dirs_modified)
         if not num_dirs_modified:
             return 0
-        status = ImporterUpdateTagsStatus(None, num_dirs_modified)
-        status.subtitle = "Folders"
-        self.status_controller.start(status)
+        # Folder mtime updates run in the ``move_and_modify_dirs`` pre-phase,
+        # before the per-comic ``read``. The status was previously hijacking
+        # ``ImporterUpdateTagsStatus`` (which is reserved for the FK-update
+        # phase) and finishing via ``update()`` instead of ``finish()``,
+        # leaving an "Update Tags / Folders" row stuck active for the rest
+        # of the run. Use a dedicated status and ``finish()`` it cleanly.
+        status = ImporterUpdateFoldersStatus(None, num_dirs_modified)
+        try:
+            self.status_controller.start(status)
 
-        folders = Folder.objects.filter(
-            library=self.library, path__in=self.task.dirs_modified
-        ).only("stat", "updated_at")
-        self.task.dirs_modified = frozenset()
-        update_folders = []
-        for folder in folders.iterator():
-            if Path(folder.path).exists():
-                folder.updated_at = Now()
-                folder.presave()
-                update_folders.append(folder)
-        Folder.objects.bulk_update(
-            update_folders, fields=BULK_UPDATE_FOLDER_MODIFIED_FIELDS
-        )
-        count = len(update_folders)
-        level = "INFO" if count else "DEBUG"
-        self.log.log(level, f"Modified {count} folders")
-        status.complete = status.total = None
-        self.status_controller.update(status)
+            folders = Folder.objects.filter(
+                library=self.library, path__in=self.task.dirs_modified
+            ).only("stat", "updated_at")
+            self.task.dirs_modified = frozenset()
+            update_folders = []
+            for folder in folders.iterator():
+                if Path(folder.path).exists():
+                    folder.updated_at = Now()
+                    folder.presave()
+                    update_folders.append(folder)
+            Folder.objects.bulk_update(
+                update_folders, fields=BULK_UPDATE_FOLDER_MODIFIED_FIELDS
+            )
+            count = len(update_folders)
+            level = "INFO" if count else "DEBUG"
+            self.log.log(level, f"Modified {count} folders")
+        finally:
+            self.status_controller.finish(status)
         return count
 
     def move_and_modify_dirs(self) -> None:

--- a/codex/librarian/scribe/importer/statii/moved.py
+++ b/codex/librarian/scribe/importer/statii/moved.py
@@ -32,8 +32,17 @@ class ImporterMoveCoversStatus(ImporterMoveStatus):
     ITEM_NAME = "custom covers"
 
 
+class ImporterUpdateFoldersStatus(ImporterStatus):
+    """Importer Update Folders Status — folder mtime/stat refresh."""
+
+    CODE = "IUF"
+    VERB = "Update"
+    ITEM_NAME = "folders"
+
+
 MOVED_STATII = (
     ImporterMoveFoldersStatus,
     ImporterMoveComicsStatus,
     ImporterMoveCoversStatus,
+    ImporterUpdateFoldersStatus,
 )


### PR DESCRIPTION
## Summary
Fixes the bug where a force-update of a large library shows "Update Tags / Folders" running first (before "Read Tags") and then "left running" for the entire import.

**Root cause** in `codex/librarian/scribe/importer/moved/__init__.py:_bulk_folders_modified()`:
1. The folder mtime sync (`move_and_modify_dirs` pre-phase) hijacked `ImporterUpdateTagsStatus` with a manually overridden `"Folders"` subtitle.
2. It finished the row via `status_controller.update()` instead of `finish()`. `update()` is rate-limited and never clears the `active` timestamp, so the misnamed row sat flagged active for the rest of the import — appearing above the actual `Read Tags` phase in the status list because its `active` timestamp was older.

On a force-update, `dirs_modified` contains every folder in the library (the snapshot fakes `mtime=0` to trigger "modified" for every path), so the bulk folder update is non-trivial work and the stale row was very visible.

## Changes
- Add `ImporterUpdateFoldersStatus` (CODE `IUF`, "Update Folders") alongside the existing move statii in `statii/moved.py`.
- Pre-register it in `_init_librarian_status_moved` when `dirs_modified` is non-empty.
- Refactor `_bulk_folders_modified` to use the new status with `start` / `finish` under a `try`/`finally` (also gives crash safety).
- Drive-by: add `MOVED_STATII` to `ADMIN_STATUS_TITLES` in `codex/choices/statii.py`. It was omitted, so existing `IMF` / `IMC` / `IMV` codes (and the new `IUF`) had no admin title lookup. After `make build-choices`, the JSON now includes `Move Folders`, `Move Comics`, `Move Custom Covers`, and `Update Folders`.

## Test plan
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group lint --group test --group build basedpyright .` — 0 errors, 0 warnings
- [x] `uv run --group lint --group test --group build python -m pytest --no-cov` — 26 passed
- [x] `make build-choices` regenerates `frontend/src/choices/admin-status-titles.json` with the four new entries
- [ ] Manual: force-update a large library and confirm "Update Folders" appears briefly during `move_and_modify_dirs` then finishes cleanly before `Read Tags` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)