### PR TITLE
Importer: drop outer atomic blocks so status writes are visible

### DIFF
--- a/codex/librarian/scribe/importer/create/__init__.py
+++ b/codex/librarian/scribe/importer/create/__init__.py
@@ -4,8 +4,6 @@ Create all missing comic many to many objects for an import.
 So we may safely create the comics next.
 """
 
-from django.db import transaction
-
 from codex.librarian.scribe.importer.create.foreign_keys import (
     CreateForeignKeysCreateUpdateImporter,
 )
@@ -18,12 +16,25 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
         """
         Create and update FKs, covers and comics.
 
-        Wrapped in ``transaction.atomic`` to coalesce the ~2000+
-        bulk_create / bulk_update commits this phase generates into
-        one fsync. The codex daemon already serializes writers via
-        ``db_write_lock``, so the long-write transaction does not
-        starve other writers; readers under WAL never block on a
-        writer regardless of transaction length.
+        The previous version wrapped the body in ``transaction.atomic``
+        to coalesce the ~2000+ ``bulk_create`` / ``bulk_update`` commits
+        this phase generates into a single fsync. That coalescing was a
+        no-op in practice with the current ``importer_pragmas``
+        (``synchronous=NORMAL`` + ``wal_autocheckpoint=0``) — every
+        commit is a WAL frame append with no fsync until the post-
+        import ``wal_checkpoint(TRUNCATE)`` — and it had a real
+        downside: ``status_controller.start`` / ``update`` / ``finish``
+        writes lived in the same transaction, so readers (admin status
+        API, websocket-poller) couldn't see them until commit. By the
+        time the multi-minute create-and-update transaction committed,
+        ``finish()`` had already cleared each row, and the
+        Create Tags / Update Tags / Create Comics / Update Comics
+        spinners never appeared during the actual work.
+
+        Without the wrapper each helper's bulk operation runs in
+        Django's per-statement autocommit. Each ``start`` / ``update``
+        / ``finish`` lands in its own transaction and is visible to
+        readers immediately.
 
         Counts use ``+=`` so a chunked apply() loop can call
         ``create_and_update`` once per chunk and still report a
@@ -31,23 +42,22 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
         """
         if self.abort_event.is_set():
             return
-        with transaction.atomic():
-            fk_count = self.create_all_fks()
-            if self.abort_event.is_set():
-                return
-            fk_count += self.update_all_fks()
-            self.counts.tags += fk_count
-            if self.abort_event.is_set():
-                return
+        fk_count = self.create_all_fks()
+        if self.abort_event.is_set():
+            return
+        fk_count += self.update_all_fks()
+        self.counts.tags += fk_count
+        if self.abort_event.is_set():
+            return
 
-            cover_count = self.create_custom_covers()
-            if self.abort_event.is_set():
-                return
-            cover_count += self.update_custom_covers()
-            self.counts.covers += cover_count
+        cover_count = self.create_custom_covers()
+        if self.abort_event.is_set():
+            return
+        cover_count += self.update_custom_covers()
+        self.counts.covers += cover_count
 
-            if self.abort_event.is_set():
-                return
-            comic_count = self.update_comics()
-            comic_count += self.create_comics()
-            self.counts.comic += comic_count
+        if self.abort_event.is_set():
+            return
+        comic_count = self.update_comics()
+        comic_count += self.create_comics()
+        self.counts.comic += comic_count

--- a/codex/librarian/scribe/importer/link/__init__.py
+++ b/codex/librarian/scribe/importer/link/__init__.py
@@ -1,7 +1,5 @@
 """Bulk update m2m fields."""
 
-from django.db import transaction
-
 from codex.librarian.scribe.importer.link.many_to_many import LinkManyToManyImporter
 
 
@@ -12,14 +10,28 @@ class LinkComicsImporter(LinkManyToManyImporter):
         """
         Link tags and covers.
 
-        Wrapped in ``transaction.atomic`` for the same reason as
-        ``create_and_update``: coalesces the per-M2M-field
-        ``bulk_create`` commits (one per linked relation) into a
-        single fsync.
+        The previous version wrapped the body in ``transaction.atomic``
+        to coalesce the per-M2M-field ``bulk_create`` commits into a
+        single fsync. That coalescing was a no-op in practice with the
+        current ``importer_pragmas`` (``synchronous=NORMAL`` +
+        ``wal_autocheckpoint=0``) — every commit is a WAL frame append
+        with no fsync until the post-import ``wal_checkpoint(TRUNCATE)``
+        — and it had a real downside: ``status_controller.start`` /
+        ``update`` / ``finish`` writes (the rows the admin status API
+        and websocket-poller read) lived in the same transaction, so
+        readers couldn't see them until commit. By the time a multi-
+        minute link transaction committed, ``finish()`` had already
+        cleared the row, and the spinner never appeared during the
+        actual link work — even though the python log statements showed
+        progress the whole time.
+
+        Without the wrapper each helper's bulk operation runs in
+        Django's per-statement autocommit. Each ``start`` / ``update``
+        / ``finish`` lands in its own transaction and is visible to
+        readers immediately.
         """
-        with transaction.atomic():
-            self.counts.link += self.link_comic_m2m_fields()
-            if self.abort_event.is_set():
-                return
-            if count := self.link_custom_covers():
-                self.counts.link_covers += count
+        self.counts.link += self.link_comic_m2m_fields()
+        if self.abort_event.is_set():
+            return
+        if count := self.link_custom_covers():
+            self.counts.link_covers += count


### PR DESCRIPTION
## Summary
Fixes the bug where on a large library import, the **Link Tags** spinner never appears in the admin status UI even though the python logs show the link phase running for many seconds. Same root cause affects every status touched inside ``create_and_update`` and ``link`` — Create Tags, Update Tags, Create Comics, Update Comics, Link Tags, Link Custom Covers.

## Root cause
``create_and_update()`` and ``link()`` wrap their body in ``transaction.atomic``. Every ``status_controller.start`` / ``update`` / ``finish`` call inside (via the helper methods) writes to ``LibrarianStatus`` on the same connection, so those writes are **buffered until the transaction commits**. Under WAL, readers (admin status API + websocket-driven poller) only see the last committed snapshot. By the time the multi-minute transaction commits, ``finish()`` has already cleared each row — so the visible end-state is "default" and the spinner never showed.

## Fix
Drop the outer ``transaction.atomic`` wrapper in both ``create_and_update()`` and ``link()``. Each helper's ``bulk_create`` / ``bulk_update`` runs in Django's per-statement autocommit; each ``start`` / ``update`` / ``finish`` lands in its own transaction and is visible to readers immediately.

The wrappers were originally there to coalesce "~2000+" commits into a single fsync. With the current ``importer_pragmas`` (``synchronous=NORMAL`` + ``wal_autocheckpoint=0``), the coalescing was already a no-op in practice — every commit is a WAL frame append with no fsync, and the WAL is checkpointed once at the end of the import via ``wal_checkpoint(TRUNCATE)``.

Per-helper data atomicity is preserved (Django executes a single ``bulk_create`` / ``bulk_update`` as one SQL statement, which SQLite runs atomically). Cross-helper atomicity (e.g. "all of create_all_fks + update_all_fks + create_comics commit together") is gone, but FK helpers use ``update_conflicts=True`` so a partial state at crash time upserts cleanly on re-run.

## Test plan
- [x] ``uv run --group lint ruff check .`` — clean
- [x] ``uv run --group lint ruff format --check .`` — clean
- [x] ``uv run --group lint --group test --group build basedpyright codex/librarian/scribe/importer/`` — 0 errors, 0 warnings
- [x] ``uv run --group lint --group test --group build python -m pytest --no-cov`` — 26 passed
- [ ] Manual: force-update a large library; confirm Link Tags spinner appears and ticks during the link phase, and Create Tags / Update Tags / Create Comics / Update Comics spinners appear during their respective phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)