### PR TITLE
Importer: coalesce CoverCreateTask + pre-register CreateCoversStatus

### DIFF
--- a/codex/librarian/scribe/importer/create/__init__.py
+++ b/codex/librarian/scribe/importer/create/__init__.py
@@ -4,6 +4,8 @@ Create all missing comic many to many objects for an import.
 So we may safely create the comics next.
 """
 
+from codex.librarian.covers.status import CreateCoversStatus
+from codex.librarian.covers.tasks import CoverCreateTask
 from codex.librarian.scribe.importer.create.foreign_keys import (
     CreateForeignKeysCreateUpdateImporter,
 )
@@ -11,6 +13,31 @@ from codex.librarian.scribe.importer.create.foreign_keys import (
 
 class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
     """Methods for creating foreign keys."""
+
+    def _submit_coalesced_cover_task(self) -> None:
+        """
+        Submit one ``CoverCreateTask`` for both newly-created and updated comics.
+
+        Both ``create_comics`` and ``update_comics`` populate
+        ``self.cover_create_pks`` instead of submitting their own task.
+        Combining them into a single submission means the cover thread
+        runs one ``CreateCoversStatus`` start/finish per chunk; two
+        back-to-back submissions would each start and finish their own
+        status, blinking the row in and out of the active list as the
+        cover thread switches tasks.
+
+        If no pks accumulated (no created or updated comics in this
+        chunk), explicitly clear the pre-registered ``CreateCoversStatus``
+        so the row doesn't sit "queued" in the UI for the rest of the
+        import.
+        """
+        if self.cover_create_pks:
+            self.librarian_queue.put(
+                CoverCreateTask(pks=tuple(self.cover_create_pks), custom=False)
+            )
+            self.cover_create_pks.clear()
+        else:
+            self.status_controller.finish_many((CreateCoversStatus,))
 
     def create_and_update(self) -> None:
         """
@@ -61,3 +88,5 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
         comic_count = self.update_comics()
         comic_count += self.create_comics()
         self.counts.comic += comic_count
+
+        self._submit_coalesced_cover_task()

--- a/codex/librarian/scribe/importer/create/comics.py
+++ b/codex/librarian/scribe/importer/create/comics.py
@@ -3,7 +3,6 @@
 from django.db.models import NOT_PROVIDED
 from django.db.models.functions import Now
 
-from codex.librarian.covers.tasks import CoverCreateTask
 from codex.librarian.scribe.importer.const import (
     BULK_CREATE_COMIC_FIELDS,
     BULK_UPDATE_COMIC_FIELDS,
@@ -107,6 +106,11 @@ class CreateComicsImporter(CreateForeignKeyLinksImporter):
                         f"Purging covers for {len(comic_pks)} updated comics."
                     )
                     self.remove_covers(comic_pks, custom=False)
+                    # Queue cover regeneration for the just-purged
+                    # comics. Stash here; ``create_and_update`` submits
+                    # a single coalesced ``CoverCreateTask`` after
+                    # ``create_comics`` has added its own pks.
+                    self.cover_create_pks.update(comic_pks)
         except Exception:
             self.log.exception(f"While updating comics: {pks}")
         finally:
@@ -171,9 +175,13 @@ class CreateComicsImporter(CreateForeignKeyLinksImporter):
             created_pks.append(created_comic.pk)
         created_pks = tuple(created_pks)
 
-        # Pre-warm covers offline so first browse/OPDS request is fast.
+        # Stash newly-created comic pks for pre-warming. The actual
+        # ``CoverCreateTask`` is submitted by ``create_and_update``
+        # after ``update_comics`` has stashed its pks too — coalescing
+        # the two phases into a single cover-thread task so the
+        # ``CreateCoversStatus`` row doesn't blink between them.
         if created_pks:
-            self.librarian_queue.put(CoverCreateTask(pks=created_pks, custom=False))
+            self.cover_create_pks.update(created_pks)
         return count
 
     def create_comics(self) -> int:

--- a/codex/librarian/scribe/importer/init.py
+++ b/codex/librarian/scribe/importer/init.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from django.utils.timezone import now
 
+from codex.librarian.covers.status import CreateCoversStatus
 from codex.librarian.scribe.importer.statii.create import (
     ImporterCreateComicsStatus,
     ImporterCreateCoversStatus,
@@ -106,6 +107,16 @@ class InitImporter(WorkerStatusBase):
         self.task: ImportTask = task
         self.metadata: dict[str, Any] = {}
         self.counts = Counts()
+        # Per-chunk accumulator for the comic-cover-create task. Both
+        # ``create_comics`` (newly-inserted Comics) and ``update_comics``
+        # (existing Comics whose covers were just purged by
+        # ``remove_covers``) add their pks here; ``create_and_update``
+        # submits a single ``CoverCreateTask`` with the union so the
+        # cover thread runs one ``CreateCoversStatus`` start/finish per
+        # chunk instead of two. Held off ``metadata`` because it's
+        # operational state, not parsed comic data — keeps the metadata
+        # fixture-comparable in tests.
+        self.cover_create_pks: set[int] = set()
         self.library = Library.objects.only("path").get(pk=self.task.library_id)
         self.abort_event = event
         self.start_time = now()
@@ -261,7 +272,17 @@ class InitImporter(WorkerStatusBase):
                 )
             ]
         if self.task.files_modified or self.task.files_created:
-            status_list += [ImporterLinkTagsStatus(subtitle=path)]
+            # Pre-register the cover-create status (CCC, owned by the
+            # cover thread) here so it gets a ``preactive`` timestamp
+            # between the comic-create/update phases and link-tags.
+            # Otherwise the cover thread's ``start()`` is the row's
+            # first appearance — fine for position (NULL preactive
+            # sorts above non-null) but means the spinner pops in
+            # cold without the "queued" indicator.
+            status_list += [
+                CreateCoversStatus(),
+                ImporterLinkTagsStatus(subtitle=path),
+            ]
 
         num_covers_linked = (
             len(self.task.covers_moved)


### PR DESCRIPTION
## Summary
Two related changes that prepare the ground for ``update_comics`` to also pre-warm covers without making the ``CreateCoversStatus`` row blink in and out of the active list.

### Coalesce (option A)
``create_comics`` and ``update_comics`` no longer each submit their own ``CoverCreateTask``. They both stash their comic pks on a new ``ImporterInit.cover_create_pks`` set; ``create_and_update`` submits **one** task with the union after both phases run. Net effect: the cover thread sees one ``start → work → finish`` lifecycle per chunk instead of two, and ``CreateCoversStatus`` doesn't disappear between the create-phase task and the (now also queued) update-phase task.

The accumulator is held off ``self.metadata`` because it's operational state, not parsed comic data — keeps the metadata snapshots in ``tests/importer/test_basic.py`` fixture-comparable.

If a chunk has neither created nor updated comics, no task gets submitted — but ``CreateCoversStatus`` was pre-registered (see below) so its ``preactive`` would otherwise sit "queued" forever. ``_submit_coalesced_cover_task`` finishes the row explicitly in that empty case.

``update_comics`` keeps its existing ``remove_covers(...)`` purge so the about-to-be-regenerated cover paths are cleared first; ``_bulk_create_comic_covers`` filters out pks that already have a cover on disk, so without the purge a cover-create task targeting updated comics would skip every one.

### Pre-register CreateCoversStatus (option C.1)
``CreateCoversStatus`` (``CCC``) is owned by the cover thread, so it had no entry in the importer's ``start_many`` list. Adding it to the modified-or-created status list — between ``ImporterUpdateComicsStatus`` and ``ImporterLinkTagsStatus`` — gives it a ``preactive`` consistent with the rest of the importer's phase ordering. (Position-wise NULLs-first sort had already put the row above ``Link Tags`` once active; pre-registration just gives it the same "queued" placeholder phase as the other importer statuses.)

## Test plan
- [x] ``uv run --group lint ruff check .`` — clean
- [x] ``uv run --group lint ruff format --check .`` — clean
- [x] ``uv run --group lint --group test --group build basedpyright codex/librarian/scribe/importer/`` — 0 errors, 0 warnings
- [x] ``test_basic.py`` (the import test that exercises the full ``create_and_update``→``link`` chain) — passes; metadata fixture unchanged thanks to keeping ``cover_create_pks`` off ``self.metadata``
- [x] All other importer-adjacent tests pass: 24/26 — see note below

### ⚠️ Pre-existing failures unrelated to this change
``tests/importer/test_update_all.py`` and ``tests/importer/test_update_none.py`` fail on the unmodified ``origin/v1.11-performance`` baseline with:

```
AttributeError: 'NoneType' object has no attribute 'count'
```

…from ``codex/librarian/scribe/importer/create/covers.py:76`` — ``update_custom_covers`` does ``self.metadata.pop(UPDATE_COVERS, None)`` and then calls ``.count()`` on the result. Surfacing rather than fixing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)