### PR TITLE
Reader: indicator dot on settings blocks with overrides

### DIFF
--- a/frontend/src/components/reader/drawer/reader-settings-scope.vue
+++ b/frontend/src/components/reader/drawer/reader-settings-scope.vue
@@ -2,7 +2,8 @@
   <v-expansion-panels v-model="openPanels" multiple>
     <v-expansion-panel value="global">
       <v-expansion-panel-title class="scopePanelTitle">
-        Default Settings
+        <span>Default Settings</span>
+        <SettingsIndicatorDot :active="hasGlobalOverrides" />
       </v-expansion-panel-title>
       <v-expansion-panel-text>
         <ReaderSettingsControls
@@ -17,7 +18,10 @@
     <v-expansion-panel value="intermediate" :disabled="!hasIntermediate">
       <v-expansion-panel-title class="scopePanelTitle">
         <div class="intermediateTitleWrap">
-          <span>{{ intermediateTitle }}</span>
+          <span class="intermediateTitleMain">
+            <span>{{ intermediateTitle }}</span>
+            <SettingsIndicatorDot :active="hasIntermediateOverrides" />
+          </span>
           <span class="intermediateSubtitle">{{ intermediateName }}</span>
         </div>
       </v-expansion-panel-title>
@@ -33,7 +37,8 @@
     </v-expansion-panel>
     <v-expansion-panel value="comic" :disabled="!validBook">
       <v-expansion-panel-title class="scopePanelTitle">
-        Comic Settings
+        <span>Comic Settings</span>
+        <SettingsIndicatorDot :active="hasComicOverrides" />
       </v-expansion-panel-title>
       <v-expansion-panel-text>
         <ReaderSettingsControls
@@ -56,9 +61,10 @@ import { useAuthStore } from "@/stores/auth";
 import { useReaderStore } from "@/stores/reader";
 import { useEventListener } from "@vueuse/core";
 
-import READER_DEFAULTS from "@/choices/reader-defaults.json";
+import GLOBAL_DEFAULTS from "@/choices/reader-defaults.json";
 
 import ReaderSettingsControls from "./reader-settings-controls.vue";
+import SettingsIndicatorDot from "./settings-indicator-dot.vue";
 
 const ATTRS = Object.freeze([
   "fitTo",
@@ -76,9 +82,28 @@ const SCOPE_TYPE_TITLES = Object.freeze({
   a: "Story Arc Settings",
 });
 
+/*
+ * Global settings have a special "is overridden" criterion: rather than
+ * checking for null/undefined (as intermediate and comic settings do), they
+ * are compared against the recorded global default values, since after
+ * initialization every key is populated.
+ */
+const differsFromGlobalDefaults = (settings) => {
+  if (!settings) {
+    return false;
+  }
+  for (const attr of ATTRS) {
+    // eslint-disable-next-line security/detect-object-injection
+    if (settings[attr] !== GLOBAL_DEFAULTS[attr]) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export default {
   name: "ReaderSettingsScope",
-  components: { ReaderSettingsControls },
+  components: { ReaderSettingsControls, SettingsIndicatorDot },
   data() {
     return {
       openPanels: [],
@@ -110,17 +135,7 @@ export default {
       },
     }),
     isGlobalClearDisabled() {
-      const settings = this.globalSettings;
-      if (!settings) {
-        return true;
-      }
-      for (const attr of ATTRS) {
-        // eslint-disable-next-line security/detect-object-injection
-        if (settings[attr] !== READER_DEFAULTS[attr]) {
-          return false;
-        }
-      }
-      return true;
+      return !differsFromGlobalDefaults(this.globalSettings);
     },
     hasIntermediate() {
       return Boolean(this.intermediateInfo);
@@ -151,6 +166,15 @@ export default {
         }
       }
       return true;
+    },
+    hasGlobalOverrides() {
+      return differsFromGlobalDefaults(this.globalSettings);
+    },
+    hasIntermediateOverrides() {
+      return this.hasIntermediate && !this.isIntermediateClearDisabled;
+    },
+    hasComicOverrides() {
+      return this.validBook && !this.isClearDisabled;
     },
   },
   created() {
@@ -253,6 +277,11 @@ export default {
   display: flex;
   flex-direction: column;
   line-height: 1.3;
+}
+
+.intermediateTitleMain {
+  display: inline-flex;
+  align-items: center;
 }
 
 .intermediateSubtitle {

--- a/frontend/src/components/reader/drawer/settings-indicator-dot.vue
+++ b/frontend/src/components/reader/drawer/settings-indicator-dot.vue
@@ -1,0 +1,32 @@
+<template>
+  <span
+    v-if="active"
+    class="settingsIndicatorDot"
+    aria-label="has saved settings"
+  />
+</template>
+
+<script>
+export default {
+  name: "SettingsIndicatorDot",
+  props: {
+    active: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.settingsIndicatorDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-left: 8px;
+  border-radius: 50%;
+  background-color: rgb(var(--v-theme-primary));
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+</style>


### PR DESCRIPTION
## Summary

Adds a small primary-colored dot to each settings expander title in the comic reader drawer when that block has user-set values. Visible at a glance which scopes (global / series-or-folder-or-arc / comic) currently override the inherited cascade.

- New reusable `<SettingsIndicatorDot :active="...">` component (8px filled dot, theme primary, conditional render).
- Three computed flags in `reader-settings-scope.vue` — `hasGlobalOverrides`, `hasIntermediateOverrides`, `hasComicOverrides` — that mirror the existing per-block "clear button enabled" logic.
- Built on top of #670: now that global settings are reliably initialized to defaults, the global dot correctly hides until the user customizes something, rather than always showing.

## Special case for global

Intermediate and comic blocks treat `null`/`undefined` keys as "not set" (the cascade fallback), so their detector checks against `nullValues`. Global keys are always populated post-#670, so a different criterion is needed: compare each setting to the recorded default in `reader-defaults.json`. That comparison lives in a small module-level helper `differsFromGlobalDefaults(settings)` with a comment noting why global is the odd one out, and the `READER_DEFAULTS` import is aliased locally to `GLOBAL_DEFAULTS` so the intent reads obviously at the call site.

## Test plan

- [ ] Open the reader, confirm all three expander titles render correctly with no dots when nothing is customized
- [ ] Customize a global setting; confirm the global dot appears, then clear it and confirm it disappears
- [ ] Open a comic in a series/folder/arc, customize a series setting; confirm the intermediate dot appears
- [ ] Customize a comic setting; confirm the comic dot appears
- [ ] Confirm the dot in the intermediate panel sits beside the primary title and not the subtitle
- [ ] Confirm the dot color is visible against the muted (textDisabled) title color in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)