### PR TITLE
Importer: refresh pending CreateCoversStatus total after comic phases

### DIFF
--- a/codex/librarian/scribe/importer/create/__init__.py
+++ b/codex/librarian/scribe/importer/create/__init__.py
@@ -14,6 +14,20 @@ from codex.librarian.scribe.importer.create.foreign_keys import (
 class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
     """Methods for creating foreign keys."""
 
+    def _update_pending_cover_create_total(self) -> None:
+        """
+        Refresh the pre-registered ``CreateCoversStatus`` total.
+
+        ``update_comics`` and ``create_comics`` each stash their pks
+        on ``self.cover_create_pks`` as they decide how many covers
+        will be regenerated. Writing the running set size to the
+        pre-registered (preactive) row gives the UI an accurate
+        "queued, N covers" hint before the cover thread picks up the
+        coalesced task and replaces the total via its own ``start()``.
+        """
+        status = CreateCoversStatus(total=len(self.cover_create_pks))
+        self.status_controller.update(status)
+
     def _submit_coalesced_cover_task(self) -> None:
         """
         Submit one ``CoverCreateTask`` for both newly-created and updated comics.
@@ -86,7 +100,9 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
         if self.abort_event.is_set():
             return
         comic_count = self.update_comics()
+        self._update_pending_cover_create_total()
         comic_count += self.create_comics()
+        self._update_pending_cover_create_total()
         self.counts.comic += comic_count
 
         self._submit_coalesced_cover_task()


### PR DESCRIPTION
## Summary

- Adds `_update_pending_cover_create_total` helper to `CreateForeignKeysImporter` that writes `len(self.cover_create_pks)` to the pre-registered `CreateCoversStatus` row.
- Calls it in `create_and_update` after `update_comics()` and again after `create_comics()`, so the queued cover-create row reflects the work each phase has just decided on.

## Why

`CreateCoversStatus` is pre-registered (#668) so it gets a `preactive` timestamp in the importer's phase order, but its `total` stayed `NULL` until the cover thread picked up the coalesced task and called `start()`. The UI showed a "queued" row with no count. Now both comic phases publish their running set size to the row as soon as they decide which pks will need cover regeneration — once after `update_comics` (purged covers from the bulk-update path), once after `create_comics` (newly-inserted comics) — giving an accurate "queued, N covers" hint before the cover thread takes over.

## Notes for reviewers

- Each call uses a fresh `CreateCoversStatus(total=N)` instance, so `since_updated=0.0` and the rate limit in `StatusController.update` doesn't gate the call.
- `update()` doesn't touch `active`/`preactive`, so the row stays in its preactive state until the cover thread's `start()` activates it (and overrides the total with its own `len(work_items)`).
- In multi-chunk imports, chunks 2+ may write to a finished row (both `active` and `preactive` NULL). The write is harmless: the row stays hidden until the cover thread's next `start()` makes it visible with its own total.

## Test plan

- [x] `uv run pytest tests/importer/` — all 3 passing (basic, update_all, update_none)
- [x] `uv run ruff check codex/librarian/scribe/importer/create/__init__.py` — clean
- [ ] Manual: trigger an import and confirm the "Create covers" row in the librarian status panel shows a non-null total while still queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)