### PR TITLE
CodexMiddleware: make async-capable

### DIFF
--- a/codex/middleware.py
+++ b/codex/middleware.py
@@ -1,9 +1,11 @@
 """Django middleware for codex."""
 
 from base64 import b64decode
+from inspect import iscoroutinefunction
 from time import time
 from typing import Any, Final
 
+from asgiref.sync import markcoroutinefunction
 from django.db import connection
 from django.utils import timezone
 from loguru import logger
@@ -21,23 +23,40 @@ _SENSITIVE_HEADERS: Final = frozenset({"user-agent", "authorization", "cookie"})
 class CodexMiddleware:
     """Set Codex Headers."""
 
+    sync_capable = True
+    async_capable = True
+
     def __init__(self, get_response):
         """Initialize response method."""
         self.get_response = get_response
+        self._async = iscoroutinefunction(get_response)
+        if self._async:
+            markcoroutinefunction(self)  # ty: ignore[invalid-argument-type]
 
-    def __call__(self, request):
-        """Set headers and timezones."""
-        # Fix timeszone from the django session."""
+    @staticmethod
+    def _activate_timezone(request) -> None:
         # https://docs.djangoproject.com/en/dev/topics/i18n/timezones/
         if tzname := request.session.get("django_timezone"):
             timezone.activate(tzname)
         else:
             timezone.deactivate()
 
-        # Set server header
-        response = self.get_response(request)
+    def _set_server_header(self, response):
         response["Server"] = f"{PACKAGE_NAME}/{VERSION}"
         return response
+
+    async def _acall(self, request):
+        self._activate_timezone(request)
+        response = await self.get_response(request)
+        return self._set_server_header(response)
+
+    def __call__(self, request):
+        """Set headers and timezones."""
+        if self._async:
+            return self._acall(request)
+        self._activate_timezone(request)
+        response = self.get_response(request)
+        return self._set_server_header(response)
 
 
 class LogResponseTimeMiddleware:


### PR DESCRIPTION
## Summary

Makes `CodexMiddleware` async-capable (dual sync/async mode) so the production middleware chain stays async end-to-end.

## Why

In production, `CodexMiddleware` was the only sync-only middleware in the chain — `corsheaders`, `SecurityMiddleware`, `ServeStaticMiddleware`, and Django's built-ins (session, common, csrf, csp, auth, messages, xframe, via `MiddlewareMixin`) are all async-capable. That forced Django to insert two sync↔async boundaries on every request:

- a `SyncToAsync` hop entering `CodexMiddleware` (executor thread + shielded future)
- an `AsyncToSync` hop leaving it (because the view is async)

Each hop adds thread-pool overhead and, when an HTTP client disconnects mid-request, surfaces the cancellation as `CancelledError exception in shielded future` from asyncio's default exception handler — visible in the trace below:

```
File ".../django/utils/deprecation.py", line 309, in __call__   ← XFrame, sync
...
File ".../codex/middleware.py", line 38, in __call__            ← CodexMiddleware, sync
File ".../django/utils/deprecation.py", line 309, in __call__   ← NPlusOne, sync
File ".../codex/middleware.py", line 115, in __call__           ← LogRequest, sync
File ".../asgiref/sync.py", line 325, in __call__               ← AsyncToSync hop
  return call_result.result()                                    ← CancelledError raised here
```

## What

- Set `sync_capable = True` and `async_capable = True`
- Detect at init whether `get_response` is a coroutine function and call `markcoroutinefunction(self)` so Django's middleware adapter sees the dual mode
- Split the timezone-activation and server-header logic into helpers shared by sync `__call__` and async `_acall`

`silk`, `nplusone`, and `LogRequestMiddleware` are DEBUG-only and unchanged — they remain sync. The boundary they cause stays in DEBUG, but production no longer pays the cost.

## Test plan

- [x] `make fix` clean
- [x] `make lint` clean for python (pre-existing remark "Cannot process specified file: it's ignored" error reproduces on `main` without these changes — surfaced separately)
- [x] `make test-python` — 26 passed
- [x] `make ty` — all checks passed
- [ ] Smoke test: hit `/api/v3/admin/librarian/status` against a running dev server and confirm `Server` header still set and timezone activation still works