### PR TITLE
Filter Clear All: hide row reliably after clearing

### DIFF
--- a/frontend/src/components/browser/toolbars/top/filter-by-select.vue
+++ b/frontend/src/components/browser/toolbars/top/filter-by-select.vue
@@ -179,20 +179,32 @@ export default {
       try {
         await this.clearFilters();
         /*
-         * Belt-and-suspenders for the Age Rating pair: the server-
-         * side reset has been observed to leave one of the two keys
-         * (typically ``ageRatingTagged``) populated, so the
-         * Age Rating row reappears as "active" right after a clear.
-         * Force both empty here regardless of what the reset
-         * response said.
+         * Belt-and-suspenders. ``clearFilters`` patches state with
+         * whatever ``API.resetSettings`` returns, but the server's
+         * reset has been observed to leave some keys populated —
+         * sometimes the Age Rating pair, sometimes the bookmark.
+         * As long as ``isFiltersClearable`` returns true, the
+         * "Clear All Filters" row stays rendered (its ``v-if``),
+         * making it look like the click did nothing. Force a fully
+         * cleared state here: zero every non-bookmark filter, set
+         * bookmark to undefined (which is in
+         * ``DEFAULT_BOOKMARK_VALUES``), and explicitly seed the
+         * Age Rating pair from the dual-panel UI in case the
+         * current group's filter state doesn't expose them.
          */
-        if (
-          this.filters?.ageRatingMetron?.length ||
-          this.filters?.ageRatingTagged?.length
-        ) {
-          await this.setSettings({
-            filters: { ageRatingMetron: [], ageRatingTagged: [] },
-          });
+        if (this.isFiltersClearable) {
+          const emptyDynamic = Object.fromEntries(
+            Object.keys(this.filters || {})
+              .filter((key) => key !== "bookmark")
+              .map((key) => [key, []]),
+          );
+          const clearedFilters = {
+            bookmark: undefined,
+            ...emptyDynamic,
+            ageRatingMetron: [],
+            ageRatingTagged: [],
+          };
+          await this.setSettings({ filters: clearedFilters });
         }
         await this.loadAvailableFilterChoices();
       } catch {


### PR DESCRIPTION
## Summary
After clicking **Clear All Filters** at the top of the filter dropdown, the row remained visible (highlighted, but with nothing left to clear), making it look like the click hadn't worked.

The "Clear All Filters" v-list-item is gated by ``v-if="isFiltersClearable"`` — the row should disappear once nothing's left to clear. ``store.clearFilters`` patches state with whatever ``API.resetSettings`` returns, but the server's reset response has been observed leaving keys populated (sometimes the Age Rating pair, sometimes the bookmark filter), which kept ``isFiltersClearable`` true and the row in place.

## Fix
Broaden the existing post-clear defensive ``setSettings`` to cover every dynamic filter key, not just the Age Rating pair:

```js
const emptyDynamic = Object.fromEntries(
  Object.keys(this.filters || {})
    .filter((key) => key !== "bookmark")
    .map((key) => [key, []]),
);
const clearedFilters = {
  bookmark: undefined,
  ...emptyDynamic,
  ageRatingMetron: [],
  ageRatingTagged: [],
};
```

- Every non-bookmark filter set to ``[]``.
- ``bookmark`` set to ``undefined`` (which is in ``DEFAULT_BOOKMARK_VALUES``, so ``isDefaultBookmarkValueSelected`` returns true).
- Age Rating pair seeded explicitly in case the current group's filters didn't surface them.
- ``Object.fromEntries`` instead of mutating in a loop, sidestepping the ``security/detect-object-injection`` lint warning.

The whole defensive call is gated on ``isFiltersClearable``, so it's a no-op when ``clearFilters`` already produced a clean state — only fires as backup when the server's response missed something.

## Test plan
- [x] ``make fix`` clean
- [x] ``make lint`` clean (only the pre-existing local-env ``remark`` warning)
- [x] ``bun run build`` succeeds
- [x] ``bun run test`` passes
- [ ] Manual: select multiple filters → click Clear All Filters → menu stays open, the "Clear All Filters" row disappears, all filter rows show as inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)