### PR TITLE
Async-ify WebSocket-adjacent admin status endpoints

### DIFF
--- a/codex/urls/api/admin.py
+++ b/codex/urls/api/admin.py
@@ -23,6 +23,10 @@ from codex.views.admin.tasks import (
 from codex.views.admin.user import AdminUserChangePasswordView, AdminUserViewSet
 
 READ: Final = MappingProxyType({"get": "list"})
+# Async list action exposed by ``adrf`` viewsets; same dispatch shape
+# as ``READ`` but routes the GET to ``alist`` instead of ``list`` so the
+# request stays on the event loop.
+AREAD: Final = MappingProxyType({"get": "alist"})
 RETRIEVE: Final = MappingProxyType({"get": "retrieve"})
 CREATE: Final = MappingProxyType({"post": "create"})
 UPDATE: Final = MappingProxyType({"put": "partial_update"})
@@ -75,12 +79,12 @@ urlpatterns = [
     ),
     path(
         "librarian/status",
-        never_cache(AdminLibrarianStatusViewSet.as_view({**READ}, active_only=True)),
+        never_cache(AdminLibrarianStatusViewSet.as_view({**AREAD}, active_only=True)),
         name="librarian_status",
     ),
     path(
         "librarian/status/all",
-        never_cache(AdminLibrarianStatusViewSet.as_view({**READ})),
+        never_cache(AdminLibrarianStatusViewSet.as_view({**AREAD})),
         name="librarian_status_all",
     ),
     path("librarian/task", AdminLibrarianTaskView.as_view(), name="librarian_task"),

--- a/codex/views/admin/auth.py
+++ b/codex/views/admin/auth.py
@@ -3,6 +3,8 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
+from adrf.generics import GenericAPIView as AsyncGenericAPIView
+from adrf.viewsets import ReadOnlyModelViewSet as AsyncReadOnlyModelViewSet
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.views import APIView
@@ -33,3 +35,13 @@ class AdminModelViewSet(AdminAuthMixin, ModelViewSet):
 
 class AdminReadOnlyModelViewSet(AdminAuthMixin, ReadOnlyModelViewSet):
     """Admin Read Only Model View Set."""
+
+
+class AsyncAdminGenericAPIView(AdminAuthMixin, AsyncGenericAPIView):
+    """Admin Generic API View dispatched on the asyncio event loop."""
+
+    view_is_async = True
+
+
+class AsyncAdminReadOnlyModelViewSet(AdminAuthMixin, AsyncReadOnlyModelViewSet):
+    """Admin Read Only Model View Set dispatched on the asyncio event loop."""

--- a/codex/views/admin/stats.py
+++ b/codex/views/admin/stats.py
@@ -4,8 +4,10 @@ import hashlib
 import json
 from copy import deepcopy
 from types import MappingProxyType
-from typing import Any, Final, override
+from typing import Any, Final
 
+from adrf.mixins import get_data
+from asgiref.sync import sync_to_async
 from django.core.cache import cache
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
@@ -16,7 +18,7 @@ from codex.serializers.admin.stats import (
     AdminStatsRequestSerializer,
     StatsSerializer,
 )
-from codex.views.admin.auth import AdminGenericAPIView
+from codex.views.admin.auth import AsyncAdminGenericAPIView
 from codex.views.admin.permissions import HasAPIKeyOrIsAdminUser
 
 # Cache TTL for the assembled stats object. The data underneath only
@@ -29,7 +31,7 @@ _CACHE_TTL_SECONDS: Final = 60
 _CACHE_KEY_PREFIX: Final = "admin-stats:"
 
 
-class AdminStatsView(AdminGenericAPIView):
+class AdminStatsView(AsyncAdminGenericAPIView):
     """Admin Flag Viewset."""
 
     permission_classes = (HasAPIKeyOrIsAdminUser,)
@@ -56,12 +58,14 @@ class AdminStatsView(AdminGenericAPIView):
             self._params = MappingProxyType(dict(input_serializer.validated_data))
         return self._params
 
-    def _add_api_key(self, obj) -> None:
+    async def _aadd_api_key(self, obj) -> None:
         """Add the api key to the config object if specified."""
         request_counts = self.params.get("config", {})
         if request_counts and ("apikey" not in request_counts):
             return
-        api_key = Timestamp.objects.get(key=Timestamp.Choices.API_KEY.value).version
+        api_key = (
+            await Timestamp.objects.aget(key=Timestamp.Choices.API_KEY.value)
+        ).version
         if "config" not in obj:
             obj["config"] = {}
         obj["config"]["api_key"] = api_key
@@ -75,24 +79,27 @@ class AdminStatsView(AdminGenericAPIView):
         digest = hashlib.sha256(param_str.encode("utf-8")).hexdigest()[:16]
         return f"{_CACHE_KEY_PREFIX}{digest}"
 
-    @override
-    def get_object(self) -> dict:
+    async def _aget_stats(self) -> dict:
         """Get (or build) the cached stats object plus a fresh api key."""
         cache_key = self._cache_key()
         # Cache the heavy stats payload only; the api key is sourced
         # outside the cache so a key rotation is reflected immediately.
-        cached = cache.get(cache_key)
+        cached = await cache.aget(cache_key)
         if cached is None:
-            getter = CodexStats(self.params)
-            cached = getter.get()
-            cache.set(cache_key, cached, _CACHE_TTL_SECONDS)
+            # ``CodexStats.get`` runs ~30 sync COUNT/GROUP BY queries.
+            # Off-load it from the event loop; ``thread_sensitive=False``
+            # lets concurrent stats requests run on separate workers.
+            cached = await sync_to_async(
+                CodexStats(self.params).get, thread_sensitive=False
+            )()
+            await cache.aset(cache_key, cached, _CACHE_TTL_SECONDS)
         obj = deepcopy(cached)
-        self._add_api_key(obj)
+        await self._aadd_api_key(obj)
         return obj
 
     @extend_schema(parameters=[input_serializer_class])
-    def get(self, *_args, **_kwargs) -> Response:
+    async def get(self, *_args, **_kwargs) -> Response:
         """Get the stats object and serialize it."""
-        obj = self.get_object()
+        obj = await self._aget_stats()
         serializer = self.get_serializer(obj)
-        return Response(serializer.data)
+        return Response(await get_data(serializer))

--- a/codex/views/admin/tasks.py
+++ b/codex/views/admin/tasks.py
@@ -65,7 +65,7 @@ from codex.models import LibrarianStatus
 from codex.serializers.admin.tasks import AdminLibrarianTaskSerializer
 from codex.serializers.mixins import OKSerializer
 from codex.serializers.models.admin import LibrarianStatusSerializer
-from codex.views.admin.auth import AdminAPIView, AdminReadOnlyModelViewSet
+from codex.views.admin.auth import AdminAPIView, AsyncAdminReadOnlyModelViewSet
 from codex.views.const import EPOCH_START
 
 if TYPE_CHECKING:
@@ -120,8 +120,15 @@ _TASK_MAP = MappingProxyType(
 _ACTIVE_STATUS_FILTER: Final = Q(preactive__isnull=False) | Q(active__isnull=False)
 
 
-class AdminLibrarianStatusViewSet(AdminReadOnlyModelViewSet):
-    """Librarian Task Statuses, optionally filtered to active/preactive."""
+class AdminLibrarianStatusViewSet(AsyncAdminReadOnlyModelViewSet):
+    """
+    Librarian Task Statuses, optionally filtered to active/preactive.
+
+    Dispatched async (via ``adrf``) so the WebSocket-driven status poll
+    doesn't pay the sync<->async middleware boundary that previously
+    surfaced as ``CancelledError exception in shielded future`` log
+    noise on every aborted in-flight request.
+    """
 
     serializer_class = LibrarianStatusSerializer
     # Set per-route at ``as_view()`` time. ``True`` for the live status
@@ -130,7 +137,12 @@ class AdminLibrarianStatusViewSet(AdminReadOnlyModelViewSet):
 
     @override
     def get_queryset(self):
-        """Active rows ordered by their timestamps; otherwise insertion order."""
+        """
+        Active rows ordered by their timestamps; otherwise insertion order.
+
+        Returns a lazy ``QuerySet``; adrf's ``alist`` evaluates it on the
+        event loop via ``afilter_queryset`` / ``apaginate_queryset``.
+        """
         if self.active_only:
             return LibrarianStatus.objects.filter(_ACTIVE_STATUS_FILTER).order_by(
                 "preactive", "active", "pk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Topic :: Multimedia :: Graphics :: Viewers",
 ]
 dependencies = [
+  "adrf~=0.1.12",
   "bidict~=0.23",
   "channels~=4.2",
   "comicbox[pdf] @ file:///Users/aj/Code/comicbox/dist/comicbox-3.0.0-py3-none-any.whl",

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "adrf"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-property" },
+    { name = "django" },
+    { name = "djangorestframework" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/fe/573d7ec8805aec8e13459451f81398c6ac819882496e82fb6b4ae96c2762/adrf-0.1.12.tar.gz", hash = "sha256:e7aa49e5406b168f040f1a12cafb606e98fdd5467314240a9c42dbe63200d2c1", size = 17181, upload-time = "2025-11-24T03:25:44.337Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/47/14006c4045f818cf625d2357e823a15b4bb7fab8dd81a40acd23af41ee53/adrf-0.1.12-py3-none-any.whl", hash = "sha256:e9d1f343b82158f4c528c0809c9635a27ceef4c37d3d8e61b8096c8eeded616d", size = 20199, upload-time = "2025-11-24T03:25:43.291Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -88,6 +102,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/80/7028efe25d789b020170cc5937f6d2162a2a53604aa3914d9b03707f9390/astypes-0.2.6.tar.gz", hash = "sha256:7bfb49dc207890587cd3d1b2fe57c61aa378fb0603a3590ab5e1c1c78b24e387", size = 13595, upload-time = "2023-03-17T07:58:00.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/9f/087a31145a2b63ce01deb60e160eac29c700562921b43a7cfbbd0daf3bce/astypes-0.2.6-py3-none-any.whl", hash = "sha256:4274e83a80c616f400d05678f9b8bc8143a94e544bbfa02906cc5805d990bf13", size = 10312, upload-time = "2023-03-17T07:57:57.945Z" },
+]
+
+[[package]]
+name = "async-property"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/12/900eb34b3af75c11b69d6b78b74ec0fd1ba489376eceb3785f787d1a0a1d/async_property-0.2.2.tar.gz", hash = "sha256:17d9bd6ca67e27915a75d92549df64b5c7174e9dc806b30a3934dc4ff0506380", size = 16523, upload-time = "2023-07-03T17:21:55.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/80/9f608d13b4b3afcebd1dd13baf9551c95fc424d6390e4b1cfd7b1810cd06/async_property-0.2.2-py2.py3-none-any.whl", hash = "sha256:8924d792b5843994537f8ed411165700b27b2bd966cefc4daeefc1253442a9d7", size = 9546, upload-time = "2023-07-03T17:21:54.293Z" },
 ]
 
 [[package]]
@@ -402,6 +425,7 @@ name = "codex"
 version = "1.11.0"
 source = { editable = "." }
 dependencies = [
+    { name = "adrf" },
     { name = "bidict" },
     { name = "channels" },
     { name = "comicbox", extra = ["pdf"] },
@@ -475,6 +499,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adrf", specifier = "~=0.1.12" },
     { name = "bidict", specifier = "~=0.23" },
     { name = "channels", specifier = "~=4.2" },
     { name = "comicbox", extras = ["pdf"], path = "/Users/aj/Code/comicbox/dist/comicbox-3.0.0-py3-none-any.whl" },


### PR DESCRIPTION
## Summary

Converts the three admin endpoints that get polled automatically by the WebSocket handler to async dispatch via [adrf](https://github.com/em1208/adrf):

- `GET /api/v3/admin/librarian/status` (active poller)
- `GET /api/v3/admin/librarian/status/all` (Jobs-tab history)
- `GET /api/v3/admin/stats` (admin dashboard)

## Why

These three endpoints aren't user-clicked — `frontend/src/stores/socket.js` fires them whenever the librarian broadcasts a `LIBRARIAN_STATUS` message, which during an active import can be many times per second. Overlapping in-flight requests get cancelled by the next poll. With sync DRF views sitting inside an otherwise-async middleware chain, every cancellation surfaces as a `CancelledError exception in shielded future` log line from asyncio's default exception handler.

The earlier [#673](https://github.com/ajslater/codex/pull/673) made `CodexMiddleware` async-capable so the chain stays async end-to-end through the middlewares. This PR finishes the job for the polled endpoints by making the views themselves async.

## What changed

- **`adrf~=0.1.12` added** to `pyproject.toml` deps. adrf provides async-compatible DRF base classes; existing sync auth (`SessionAuthentication`, `BearerTokenAuthentication`), permission (`IsAdminUser`, `HasAPIKeyOrIsAdminUser`), and throttle classes are reused via adrf's automatic `sync_to_async` at dispatch.
- **New base classes** in `codex/views/admin/auth.py`: `AsyncAdminGenericAPIView`, `AsyncAdminReadOnlyModelViewSet`. Sit alongside the existing sync mixins so other admin endpoints can opt in incrementally.
- **`AdminLibrarianStatusViewSet`** swapped to the async base. The URL config uses a new `AREAD = {"get": "alist"}` mapping (parallel to the existing `READ`) so adrf's `alist` action handles the request on the event loop. `get_queryset` stays sync — querysets are lazy; adrf evaluates them via `afilter_queryset` / `apaginate_queryset`.
- **`AdminStatsView.get`** is now an async coroutine. `cache.get/set` → `cache.aget/aset`. `Timestamp.objects.get` → `aget`. `CodexStats(...).get()` (~30 sync COUNT/GROUP-BY queries) is wrapped in `sync_to_async(..., thread_sensitive=False)` so concurrent stats requests can run on separate workers.

Other admin endpoints (CRUD, flags, libraries, users, groups) intentionally remain sync — the cost/benefit only justifies the high-frequency polled endpoints.

## Verified

- URL routing — both ViewSet routes bind to `alist`; `view_is_async=True`; `AdminStatsView.get` is a coroutine function:
  ```
  librarian/status → AdminLibrarianStatusViewSet actions: {'get': 'alist'} is_async: True
  status/all       → AdminLibrarianStatusViewSet actions: {'get': 'alist'}
  stats            → AdminStatsView is_async: True
                     AdminStatsView.get is coroutine: True
  ```
- drf-spectacular schema generation — all three paths still emit `get` operations; pre-existing warnings (enum overrides, OPDS path collisions) unchanged.
- `make fix` clean; `make lint` clean for Python; `make ty` all checks pass; `make test-python` 26 passed.

Pre-existing remark error (`Cannot process specified file: it's ignored`) reproduces on the base branch — surfaced separately, unrelated to this PR.

## Test plan

- [x] URL resolution sanity check
- [x] Schema generation diff (no changes to these three paths' shape)
- [x] `make fix` / `make lint` / `make ty` / `make test-python`
- [ ] Manual smoke: hit each endpoint on a running dev server, compare JSON response to a pre-change capture (camelCase shape, field order)
- [ ] Live load: open admin Jobs tab during an active import; confirm no `CancelledError` log spam from these three endpoints