### PR TITLE
Make log and cache directories configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ Environment variables override values set in the TOML config file.
 - `CODEX_LOG_TO_FILE=0` will not log to files.
 - `CODEX_LOG_TO_CONSOLE=0` will not log to the console.
 
+#### Cache
+
+- `CODEX_CACHE_DIR` sets a custom directory for the file-based cache (Django
+  cache entries and comic book cover thumbnails). Defaults to
+  `$CODEX_CONFIG_DIR/cache`. Useful for placing the cache on a separate
+  (e.g. faster or ephemeral) volume from the rest of the config directory.
+
 ##### Browser
 
 - `CODEX_BROWSER_MAX_OBJ_PER_PAGE` the maximum number of objects per page.

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -99,7 +99,8 @@ LOGLEVEL = get_str(
     CODEX_CONFIG, "logging.loglevel", default="DEBUG" if DEBUG else "INFO"
 )
 LOG_RETENTION = get_str(CODEX_CONFIG, "logging.log_retention", default="6 months")
-LOG_DIR = Path(environ.get("CODEX_LOG_DIR", CONFIG_PATH / "logs"))
+_LOG_DIR_CONFIG = get_str(CODEX_CONFIG, "logging.log_dir", default="")
+LOG_DIR = Path(_LOG_DIR_CONFIG) if _LOG_DIR_CONFIG else CONFIG_PATH / "logs"
 LOG_TO_CONSOLE = get_bool(CODEX_CONFIG, "logging.log_to_console", default=True)
 LOG_TO_FILE = get_bool(CODEX_CONFIG, "logging.log_to_file", default=True)
 LOG_PATH = LOG_DIR / "codex.log"
@@ -546,7 +547,10 @@ for path in STATICFILES_DIRS:
 # Cache #
 #########
 
-ROOT_CACHE_PATH = CONFIG_PATH / "cache"
+_CACHE_DIR_CONFIG = get_str(CODEX_CONFIG, "cache.dir", default="")
+ROOT_CACHE_PATH = (
+    Path(_CACHE_DIR_CONFIG) if _CACHE_DIR_CONFIG else CONFIG_PATH / "cache"
+)
 DEFAULT_CACHE_PATH = ROOT_CACHE_PATH / "default"
 DEFAULT_CACHE_PATH.mkdir(exist_ok=True, parents=True)
 # MAX_ENTRIES defaults to 300 in Django's FileBasedCache. That's far

--- a/codex/settings/codex.toml.default
+++ b/codex/settings/codex.toml.default
@@ -22,6 +22,13 @@
 # log_retention = "6 months"
 # log_to_console = true
 # log_to_file = true
+# Directory for log files. Defaults to <config_dir>/logs.
+# log_dir = ""
+
+# [cache]
+# Directory for the file-based cache (covers, query results, etc).
+# Defaults to <config_dir>/cache.
+# dir = ""
 
 # [browser]
 # max_obj_per_page = 100

--- a/codex/settings/config.py
+++ b/codex/settings/config.py
@@ -26,6 +26,9 @@ _ENV_OVERRIDES: dict[str, str] = {
     "LOG_RETENTION": "logging.log_retention",  # Old
     "CODEX_LOG_TO_CONSOLE": "logging.log_to_console",
     "CODEX_LOG_TO_FILE": "logging.log_to_file",
+    "CODEX_LOG_DIR": "logging.log_dir",
+    # Cache
+    "CODEX_CACHE_DIR": "cache.dir",
     # Import
     "CODEX_IMPORTER_LINK_FK_BATCH_SIZE": "importer.link_fk_batch_size",
     "CODEX_IMPORTER_LINK_M2M_BATCH_SIZE": "importer.link_m2m_batch_size",


### PR DESCRIPTION
## Summary
- Adds `logging.log_dir` and `cache.dir` keys to `codex.toml` and a matching `CODEX_CACHE_DIR` env override (the existing `CODEX_LOG_DIR` env var is now also wired through the unified config layer).
- Empty / unset values fall back to the previous `<config_dir>/logs` and `<config_dir>/cache` defaults, so existing deployments are unaffected.
- Lets operators point logs and the file-based cache at separate volumes without symlinking the whole config directory.

## Why
Previously `LOG_DIR` only honored an env var and `ROOT_CACHE_PATH` was completely hardcoded. Both directories can grow large or want different storage characteristics from the rest of `config/`, so they should be relocatable through normal config channels.

## Test plan
- [x] Verified env var override (`CODEX_LOG_DIR`, `CODEX_CACHE_DIR`) resolves to the supplied path.
- [x] Verified TOML override (`logging.log_dir`, `cache.dir`) resolves to the supplied path.
- [x] Verified empty / missing values fall back to `<config_dir>/logs` and `<config_dir>/cache`.
- [x] `bin/lint-python.sh` (ruff, basedpyright, vulture, complexipy, codespell) clean.
- [x] `bin/test-python.sh` — 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)