### PR TITLE
Search index: replace ComicFTS bulk_update with delete+bulk_create

### DIFF
--- a/codex/librarian/scribe/importer/search/sync_m2m.py
+++ b/codex/librarian/scribe/importer/search/sync_m2m.py
@@ -1,14 +1,25 @@
 """Update fts fields for updated foreign keys with non key search values."""
 
+from typing import TYPE_CHECKING
+
+from django.db import transaction
 from django.db.models.expressions import Value
 from django.db.models.functions.datetime import Now
 from django.db.models.functions.text import Concat
 from loguru import logger
 
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
 from codex.librarian.scribe.importer.const import FTS_UPDATED_M2MS
 from codex.librarian.scribe.importer.finish import FinishImporter
 from codex.models.comic import ComicFTS
 from codex.models.functions import GroupConcat
+
+# SQLite caps a single statement at 32,766 host parameters by
+# default. ``ComicFTS`` carries ~28 columns; 500 rows x 28 cols is a
+# safe ceiling that still amortizes per-statement overhead.
+_FTS_BATCH_SIZE = 500
 
 
 class SearchIndexSyncManyToManyImporter(FinishImporter):
@@ -41,58 +52,99 @@ class SearchIndexSyncManyToManyImporter(FinishImporter):
             exp = name_concat
         return exp
 
-    def _sync_fts_for_m2m_updates_model(
-        self,
-        field_name: str,
-        already_updated_comicfts_pks: tuple[int, ...],
-        update_fields: tuple[str, ...],
-        update_objs: list[ComicFTS],
-    ) -> None:
-        rel = f"comic__{field_name}__in"
-        fts_value = self._get_fts_m2m_concat(field_name)
-        model_pks = self.metadata[FTS_UPDATED_M2MS].pop(field_name)
-        self.log.debug(
-            f"Preparing {len(model_pks)} search entries for {field_name} updates."
-        )
-        comicftss = (
-            ComicFTS.objects.filter(**{rel: model_pks})
-            .exclude(pk__in=already_updated_comicfts_pks)
-            .annotate(fts_value=fts_value)
-            .only(*update_fields)
-        )
-        for comicfts in comicftss:
-            value = comicfts.fts_value.strip(",")  # pyright: ignore[reportAttributeAccessIssue]
+    def _gather_m2m_field_values(
+        self, already_updated_comicfts_pks: tuple[int, ...]
+    ) -> dict[int, dict[str, str]]:
+        """
+        Collapse FTS_UPDATED_M2MS into ``{comic_pk: {field: new_value}}``.
+
+        One comic can be touched by several m2m field updates in the
+        same import (e.g. a comic linked to both a renamed tag and a
+        renamed character). Building the per-comic edit set here means
+        each row is fetched and rewritten exactly once — the previous
+        ``update_objs.append`` pattern produced one ``ComicFTS``
+        instance per (comic, field) pair, which ``bulk_update`` then
+        overwrote unpredictably when the same pk appeared twice.
+        """
+        per_comic: dict[int, dict[str, str]] = {}
+        field_names = tuple(self.metadata[FTS_UPDATED_M2MS].keys())
+        for field_name in field_names:
+            if self.abort_event.is_set():
+                return per_comic
+            rel = f"comic__{field_name}__in"
+            fts_value = self._get_fts_m2m_concat(field_name)
+            model_pks = self.metadata[FTS_UPDATED_M2MS].pop(field_name)
+            self.log.debug(
+                f"Preparing {len(model_pks)} search entries for {field_name} updates."
+            )
+            rows = (
+                ComicFTS.objects.filter(**{rel: model_pks})
+                .exclude(pk__in=already_updated_comicfts_pks)
+                .annotate(fts_value=fts_value)
+                .values_list("pk", "fts_value")
+            )
+            for pk, raw_value in rows:
+                value = (raw_value or "").strip(",")
+                per_comic.setdefault(pk, {})[field_name] = value
+        return per_comic
+
+    @staticmethod
+    def _apply_field_updates(
+        comicfts: ComicFTS, field_updates: dict[str, str]
+    ) -> ComicFTS:
+        for field_name, value in field_updates.items():
             setattr(comicfts, field_name, value)
-            comicfts.updated_at = Now()
-            update_objs.append(comicfts)
+        comicfts.updated_at = Now()
+        return comicfts
+
+    def _delete_then_create_comicfts(self, comicftss: list[ComicFTS]) -> None:
+        """
+        Replace ComicFTS rows for ``comicftss`` via delete + bulk_create.
+
+        FTS5 virtual tables don't accept ``UPDATE … SET col = CASE WHEN``
+        cheaply (parser cost grows in rows x cols and every UPDATE is
+        an internal delete-then-insert at the segment level anyway), so
+        an explicit delete-then-bulk_create cuts wall time roughly 1.5-
+        3x on production-shaped workloads. See
+        ``tests/perf/bench_fts_sync.py`` for the supporting numbers.
+
+        ``transaction.atomic`` makes the swap all-or-nothing — an
+        interrupted run leaves the original row intact rather than a
+        comic with no FTS row.
+        """
+        pks = [c.comic_id for c in comicftss]  # pyright: ignore[reportAttributeAccessIssue]
+        with transaction.atomic():
+            for start in range(0, len(pks), _FTS_BATCH_SIZE):
+                chunk = pks[start : start + _FTS_BATCH_SIZE]
+                ComicFTS.objects.filter(pk__in=chunk).delete()
+            ComicFTS.objects.bulk_create(comicftss, batch_size=_FTS_BATCH_SIZE)
+
+    def _build_replacement_objs(
+        self, per_comic: dict[int, dict[str, str]]
+    ) -> list[ComicFTS]:
+        """Fetch full rows for every affected comic and apply the edits."""
+        if not per_comic:
+            return []
+        pks: Collection[int] = tuple(per_comic.keys())
+        existing = list(ComicFTS.objects.filter(pk__in=pks))
+        return [self._apply_field_updates(c, per_comic[c.comic_id]) for c in existing]  # pyright: ignore[reportAttributeAccessIssue]
 
     def sync_fts_for_m2m_updates(
         self, already_updated_comicfts_pks: tuple[int, ...]
     ) -> None:
         """Update fts entries for foreign keys."""
         try:
-            count = 0
-            update_field_names = tuple(self.metadata.get(FTS_UPDATED_M2MS, {}).keys())
-            if not update_field_names:
+            per_comic = self._gather_m2m_field_values(already_updated_comicfts_pks)
+            if self.abort_event.is_set():
                 return
-
-            update_objs = []
-            for field_name in update_field_names:
-                if self.abort_event.is_set():
-                    return
-                self._sync_fts_for_m2m_updates_model(
-                    field_name,
-                    already_updated_comicfts_pks,
-                    update_field_names,
-                    update_objs,
-                )
-            count += len(update_objs)
-            tags = ", ".join(update_field_names)
+            tags = ", ".join(sorted({f for d in per_comic.values() for f in d}))
+            count = len(per_comic)
             self.log.debug(
                 f"Updating {count} search index entries for comics linked to updated tags: {tags}"
             )
             if count:
-                ComicFTS.objects.bulk_update(update_objs, update_field_names)
+                comicftss = self._build_replacement_objs(per_comic)
+                self._delete_then_create_comicfts(comicftss)
             level = "INFO" if count else "DEBUG"
             self.log.log(
                 level,

--- a/codex/librarian/scribe/importer/search/update.py
+++ b/codex/librarian/scribe/importer/search/update.py
@@ -18,7 +18,6 @@ from codex.librarian.scribe.importer.statii.search import (
     ImporterFTSStatus,
     ImporterFTSUpdateStatus,
 )
-from codex.librarian.scribe.search.const import COMICFTS_UPDATE_FIELDS
 from codex.librarian.scribe.search.prepare import SearchEntryPrepare
 from codex.librarian.status import Status
 from codex.models.comic import ComicFTS
@@ -126,7 +125,16 @@ class SearchIndexCreateUpdateImporter(SearchIndexSyncManyToManyImporter):
         if create:
             ComicFTS.objects.bulk_create(obj_list)
         else:
-            ComicFTS.objects.bulk_update(obj_list, COMICFTS_UPDATE_FIELDS)
+            # Replace updates with delete + bulk_create. FTS5 makes
+            # ``bulk_update``'s CASE-WHEN UPDATE expensive (parser cost
+            # in rows x cols, plus an internal delete+reinsert per
+            # affected row at the segment level), and a multi-row
+            # INSERT cuts wall time roughly 1.5-3x on real workloads.
+            # See ``tests/perf/bench_fts_sync.py`` for the supporting
+            # numbers. Inherits ``_delete_then_create_comicfts`` from
+            # ``SearchIndexSyncManyToManyImporter`` for the atomic
+            # swap and chunked DELETE.
+            self._delete_then_create_comicfts(list(obj_list))
         return len(obj_list)
 
     def _update_search_index_operate(self, *, create: bool) -> int:

--- a/tests/perf/bench_fts_sync.py
+++ b/tests/perf/bench_fts_sync.py
@@ -1,0 +1,630 @@
+r"""
+Benchmark FTS5 sync strategies for SearchIndexSyncManyToManyImporter.
+
+Compares three strategies for rewriting one or more columns of N
+ComicFTS rows after an m2m relation changes:
+
+  A) Django bulk_update — current production path.
+  B) filter().delete() + bulk_create — wrapped in transaction.atomic.
+  C) Raw SQL UPDATE … WHERE comic_id IN (…) — bypasses ORM CASE-WHEN.
+
+The script seeds a fresh sqlite3 file with synthetic Comic + ComicFTS
+rows, snapshots it, then runs each strategy from the same starting
+state across a sweep of sizes and field counts. Median wall time per
+combo is reported.
+
+Usage::
+
+    DEBUG=0 uv run --no-sync python -m tests.perf.bench_fts_sync \
+        --out tasks/fts-sync-bench.json
+
+    # Or to pin a specific sweep:
+    DEBUG=0 uv run --no-sync python -m tests.perf.bench_fts_sync \
+        --table-sizes 10000 50000 \
+        --affected-counts 100 1000 10000 \
+        --field-counts 1 3 10 \
+        --runs 5 --out tasks/fts-sync-bench.json
+
+The script uses an isolated sqlite3 file in a tmp directory; it does
+not touch ``$CODEX_CONFIG_DIR/codex.sqlite3``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import random
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+# Pin everything before django.setup runs.
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="codex-fts-bench-"))
+os.environ["CODEX_CONFIG_DIR"] = str(_TMP_DIR)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "codex.settings")
+os.environ["DEBUG"] = "0"
+os.environ.setdefault("LOGLEVEL", "WARNING")
+
+# `codex/__init__.py` calls django.setup(); run it as a statement so
+# ruff's import sorter can't reorder it below the django imports that
+# require apps.populate() to have completed.
+importlib.import_module("codex")
+
+from django.core.management import call_command  # noqa: E402
+from django.db import connection, transaction  # noqa: E402
+from django.db.models.functions.datetime import Now  # noqa: E402
+
+from codex.librarian.scribe.search.const import COMICFTS_UPDATE_FIELDS  # noqa: E402
+from codex.models.comic import ComicFTS  # noqa: E402
+
+# codex_comicfts is an FTS5 virtual table (unmanaged); the Comic FK
+# isn't enforced at the storage layer, so the bench skips Comic
+# entirely and inserts raw rows. This avoids paying for Comic's
+# parent FK chain (Publisher/Imprint/Series/Volume) and isolates the
+# measurement to the FTS5 sync path.
+_COMICFTS_COLUMNS = (
+    "comic_id",
+    "created_at",
+    "updated_at",
+    "collection_title",
+    "name",
+    "review",
+    "summary",
+    "publisher",
+    "imprint",
+    "series",
+    "age_rating_tagged",
+    "age_rating_metron",
+    "country",
+    "language",
+    "original_format",
+    "scan_info",
+    "tagger",
+    "characters",
+    "credits",
+    "genres",
+    "locations",
+    "series_groups",
+    "sources",
+    "stories",
+    "story_arcs",
+    "tags",
+    "teams",
+    "universes",
+)
+
+# Realistic-ish corpora so FTS5 segments aren't degenerate.
+_SERIES_CORPUS = (
+    "Captain Science",
+    "Astro Adventures",
+    "Quantum Reach",
+    "Ironblood",
+    "Photon Patrol",
+    "Strange Vectors",
+    "Vault of Mysteries",
+    "Cosmic Tide",
+    "The Last Convoy",
+    "Nightfall Brigade",
+)
+_CHAR_CORPUS = (
+    "Captain Science",
+    "Boy Empirical",
+    "Doctor Onishi",
+    "Kei",
+    "Kiyoko",
+    "Masaru",
+    "Nezu",
+    "Ryu",
+    "Tetsuo",
+    "Akira",
+    "Colonel Shikishima",
+    "The Architect",
+    "Lt. Vega",
+    "Sergeant Holt",
+)
+_TAG_CORPUS = (
+    "post-apocalyptic",
+    "psionic",
+    "espionage",
+    "future-noir",
+    "hard-sf",
+    "biopunk",
+    "cyberpunk",
+    "mecha",
+    "first-contact",
+    "time-travel",
+    "alternate-history",
+    "anti-hero",
+)
+_CRED_CORPUS = (
+    "Joe Orlando",
+    "Wally Wood",
+    "Jack Kirby",
+    "Stan Lee",
+    "Alan Moore",
+    "Frank Miller",
+    "Brian K. Vaughan",
+    "Fiona Staples",
+    "Saladin Ahmed",
+    "Marjorie Liu",
+)
+
+
+def _join_sample(corpus: tuple[str, ...], k: int, rng: random.Random) -> str:
+    return ",".join(rng.sample(corpus, k))
+
+
+def _seed(n_comics: int, rng: random.Random) -> None:
+    """Insert n_comics ComicFTS rows directly into the FTS5 virtual table."""
+    print(f"  seeding {n_comics:,} ComicFTS rows…", flush=True)
+    t0 = time.perf_counter()
+
+    placeholders = ",".join("?" * len(_COMICFTS_COLUMNS))
+    sql = (
+        f"INSERT INTO codex_comicfts ({','.join(_COMICFTS_COLUMNS)}) "  # noqa: S608
+        f"VALUES ({placeholders})"
+    )
+
+    batch_size = 2000
+    with connection.cursor() as cursor:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        for start in range(0, n_comics, batch_size):
+            end = min(start + batch_size, n_comics)
+            rows = [
+                (
+                    pk,
+                    "2026-01-01 00:00:00",
+                    "2026-01-01 00:00:00",
+                    rng.choice(_SERIES_CORPUS),
+                    f"Issue {pk % 200}",
+                    "",
+                    "An adventure unfolds.",
+                    "Youthful Adventure Stories",
+                    "TestImprint",
+                    rng.choice(_SERIES_CORPUS),
+                    "Everyone",
+                    "Everyone",
+                    "us,United States",
+                    "en,English",
+                    "Trade Paperback",
+                    "Photocopied",
+                    "bench",
+                    _join_sample(_CHAR_CORPUS, 5, rng),
+                    _join_sample(_CRED_CORPUS, 3, rng),
+                    "Science Fiction,Adventure",
+                    "The Moon",
+                    "science comics",
+                    "comicvine",
+                    "The Beginning",
+                    "Genesis",
+                    _join_sample(_TAG_CORPUS, 4, rng),
+                    "Team Scientific Method",
+                    "Young Adult Silly Universe",
+                )
+                for pk in range(start + 1, end + 1)
+            ]
+            cursor.executemany(sql, rows)
+        # Optimize so segment state is consistent before strategies run.
+        cursor.execute(
+            "INSERT INTO codex_comicfts (codex_comicfts) VALUES('optimize')"
+        )
+
+    elapsed = time.perf_counter() - t0
+    print(f"  seeded in {elapsed:.1f}s", flush=True)
+
+
+def _make_payload(
+    pks: list[int],
+    fields: tuple[str, ...],
+    rng: random.Random,
+) -> dict[int, dict[str, str]]:
+    """Build {pk: {field: new_value}} for the chosen affected pks."""
+    payload: dict[int, dict[str, str]] = {}
+    for pk in pks:
+        row: dict[str, str] = {}
+        for f in fields:
+            # New value differs from seeded one so FTS5 actually rewrites.
+            if f == "tags":
+                row[f] = _join_sample(_TAG_CORPUS, 5, rng)
+            elif f == "characters":
+                row[f] = _join_sample(_CHAR_CORPUS, 6, rng)
+            elif f == "credits":
+                row[f] = _join_sample(_CRED_CORPUS, 4, rng)
+            else:
+                row[f] = f"bench-{rng.randrange(1, 9999)}"
+        payload[pk] = row
+    return payload
+
+
+# ---------- Strategies ----------------------------------------------------
+
+
+def _strategy_bulk_update(
+    payload: dict[int, dict[str, str]], fields: tuple[str, ...]
+) -> None:
+    """Strategy A — current production path."""
+    pks = list(payload.keys())
+    objs = list(ComicFTS.objects.filter(comic_id__in=pks).only(*fields))
+    for o in objs:
+        for field, value in payload[o.comic_id].items():  # pyright: ignore[reportAttributeAccessIssue]
+            setattr(o, field, value)
+        o.updated_at = Now()
+    # SQLite's variable limit caps how many rows Django can pack into
+    # a single CASE-WHEN UPDATE; bulk_update will issue multiple
+    # statements with batch_size. Use 500 so (n_fields + 1) * 500
+    # stays well under the 32k limit even with the big field count.
+    ComicFTS.objects.bulk_update(objs, (*fields, "updated_at"), batch_size=500)
+
+
+def _strategy_delete_create(
+    payload: dict[int, dict[str, str]], fields: tuple[str, ...]
+) -> None:
+    """Strategy B — fetch full rows, delete, bulk_create with new values."""
+    pks = list(payload.keys())
+    # Fetch all columns so we can rebuild the row.
+    existing = {
+        o.comic_id: o  # pyright: ignore[reportAttributeAccessIssue]
+        for o in ComicFTS.objects.filter(comic_id__in=pks)
+    }
+    new_objs: list[ComicFTS] = []
+    for pk, row in payload.items():
+        old = existing.get(pk)
+        if old is None:
+            continue
+        # Apply edits.
+        for field, value in row.items():
+            setattr(old, field, value)
+        old.updated_at = Now()
+        new_objs.append(old)
+    with transaction.atomic():
+        # Chunk delete and create to stay under SQLite's variable limit.
+        for start in range(0, len(pks), 500):
+            chunk = pks[start : start + 500]
+            ComicFTS.objects.filter(comic_id__in=chunk).delete()
+        ComicFTS.objects.bulk_create(new_objs, batch_size=500)
+
+
+def _strategy_raw_update(
+    payload: dict[int, dict[str, str]], fields: tuple[str, ...]
+) -> None:
+    """
+    Strategy C — raw UPDATE per (field, value) batch.
+
+    Uses one ``UPDATE … SET col = ? WHERE comic_id IN (…)`` per
+    distinct (field, value) tuple. Since synthetic data has unique
+    values per pk this collapses to one UPDATE per row, which is the
+    pessimistic case for raw SQL but a realistic worst-case (every
+    affected comic's tag list is unique).
+    """
+    pks = list(payload.keys())
+    # Group by (field, value) so identical edits collapse to one UPDATE.
+    by_field_value: dict[tuple[str, str], list[int]] = {}
+    for pk, row in payload.items():
+        for field, value in row.items():
+            by_field_value.setdefault((field, value), []).append(pk)
+    with connection.cursor() as cursor, transaction.atomic():
+        for (field, value), pk_group in by_field_value.items():
+            # Chunk the IN clause to stay under SQLite's variable limit.
+            for start in range(0, len(pk_group), 900):
+                chunk = pk_group[start : start + 900]
+                placeholders = ",".join("?" * len(chunk))
+                cursor.execute(
+                    f"UPDATE codex_comicfts "  # noqa: S608
+                    f"SET {field} = ?, updated_at = CURRENT_TIMESTAMP "
+                    f"WHERE comic_id IN ({placeholders})",
+                    [value, *chunk],
+                )
+        # Avoid unused-arg lint when fields is just informational.
+        _ = pks
+
+
+_STRATEGIES = {
+    "A_bulk_update": _strategy_bulk_update,
+    "B_delete_create": _strategy_delete_create,
+    "C_raw_update": _strategy_raw_update,
+}
+
+
+# ---------- Driver --------------------------------------------------------
+
+
+def _migrate(db_path: Path) -> None:
+    """Apply migrations against the bench DB."""
+    print(f"  migrating {db_path}…", flush=True)
+    t0 = time.perf_counter()
+    call_command("migrate", "--noinput", "-v", "0")
+    elapsed = time.perf_counter() - t0
+    print(f"  migrated in {elapsed:.1f}s", flush=True)
+
+
+def _snapshot(db_path: Path, snap_path: Path) -> None:
+    # WAL flush before copy so the snapshot is self-contained.
+    with connection.cursor() as cursor:
+        cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    connection.close()
+    shutil.copy2(db_path, snap_path)
+
+
+def _restore(db_path: Path, snap_path: Path) -> None:
+    connection.close()
+    shutil.copy2(snap_path, db_path)
+    # Re-open implicitly on next query.
+    connection.ensure_connection()
+
+
+def _fts_optimize() -> None:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO codex_comicfts (codex_comicfts) VALUES('optimize')"
+        )
+
+
+def _run_combo(
+    *,
+    db_path: Path,
+    snap_path: Path,
+    table_size: int,
+    n_affected: int,
+    fields: tuple[str, ...],
+    runs: int,
+    rng: random.Random,
+) -> dict[str, list[float]]:
+    """Run all strategies on the same starting state ``runs`` times."""
+    # Comic pks are 1..table_size by construction. Pick a random
+    # subset of size n_affected so the workload exercises non-
+    # contiguous rowids in the FTS5 segments.
+    pks_pool = list(range(1, table_size + 1))
+    rng.shuffle(pks_pool)
+    chosen = pks_pool[:n_affected]
+    payload = _make_payload(chosen, fields, rng)
+
+    durations: dict[str, list[float]] = {name: [] for name in _STRATEGIES}
+    for run in range(runs):
+        for name, fn in _STRATEGIES.items():
+            _restore(db_path, snap_path)
+            _fts_optimize()
+            t0 = time.perf_counter()
+            fn(payload, fields)
+            durations[name].append(time.perf_counter() - t0)
+        print(
+            f"    run {run + 1}/{runs}: "
+            + " ".join(
+                f"{n}={durations[n][-1] * 1000:.0f}ms" for n in _STRATEGIES
+            ),
+            flush=True,
+        )
+    return durations
+
+
+def _setup_one_size(table_size: int, db_path: Path, snap_path: Path) -> None:
+    """Migrate + seed a fresh DB at ``table_size`` and snapshot it."""
+    # Close any open connection so unlink/migrate sees the file fresh.
+    connection.close()
+    for path in (db_path, snap_path):
+        if path.exists():
+            path.unlink()
+        # Also remove WAL/SHM siblings.
+        for suffix in ("-wal", "-shm", "-journal"):
+            sib = path.with_name(path.name + suffix)
+            if sib.exists():
+                sib.unlink()
+    _migrate(db_path)
+    rng = random.Random(0xC0DE)
+    _seed(table_size, rng)
+    _snapshot(db_path, snap_path)
+
+
+def _setup_from_snapshot(
+    source: Path, db_path: Path, snap_path: Path
+) -> int:
+    """Use an existing codex DB as the bench snapshot. Returns ComicFTS row count."""
+    connection.close()
+    for path in (db_path, snap_path):
+        if path.exists():
+            path.unlink()
+        for suffix in ("-wal", "-shm", "-journal"):
+            sib = path.with_name(path.name + suffix)
+            if sib.exists():
+                sib.unlink()
+    shutil.copy2(source, db_path)
+    shutil.copy2(source, snap_path)
+    connection.ensure_connection()
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM codex_comicfts")
+        return cursor.fetchone()[0]
+
+
+def _real_pks(rng: random.Random, n_affected: int) -> list[int]:
+    """Pick n_affected random comic_ids from the existing ComicFTS table."""
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT comic_id FROM codex_comicfts")
+        pool = [row[0] for row in cursor.fetchall()]
+    rng.shuffle(pool)
+    return pool[:n_affected]
+
+
+def _run_combo_real(
+    *,
+    db_path: Path,
+    snap_path: Path,
+    chosen_pks: list[int],
+    fields: tuple[str, ...],
+    runs: int,
+    rng: random.Random,
+) -> dict[str, list[float]]:
+    """Run all strategies on the same starting state ``runs`` times — real-DB variant."""
+    payload = _make_payload(chosen_pks, fields, rng)
+    durations: dict[str, list[float]] = {name: [] for name in _STRATEGIES}
+    for run in range(runs):
+        for name, fn in _STRATEGIES.items():
+            _restore(db_path, snap_path)
+            _fts_optimize()
+            t0 = time.perf_counter()
+            fn(payload, fields)
+            durations[name].append(time.perf_counter() - t0)
+        print(
+            f"    run {run + 1}/{runs}: "
+            + " ".join(
+                f"{n}={durations[n][-1] * 1000:.0f}ms" for n in _STRATEGIES
+            ),
+            flush=True,
+        )
+    return durations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--table-sizes",
+        type=int,
+        nargs="+",
+        default=[1000, 10000, 50000],
+    )
+    parser.add_argument(
+        "--affected-counts",
+        type=int,
+        nargs="+",
+        default=[100, 1000, 10000],
+    )
+    parser.add_argument(
+        "--field-counts",
+        type=int,
+        nargs="+",
+        default=[1, 3],
+    )
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument(
+        "--out", type=Path, default=Path("tasks/fts-sync-bench.json")
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=None,
+        help="Path to an existing codex sqlite3 DB to use as the bench "
+        "snapshot. Skips migrate + seed; --table-sizes is ignored.",
+    )
+    args = parser.parse_args()
+
+    db_path = _TMP_DIR / "codex.sqlite3"
+    snap_path = _TMP_DIR / "snapshot.sqlite3"
+    print(f"bench DB: {db_path}", flush=True)
+
+    sweep_fields = tuple(COMICFTS_UPDATE_FIELDS)
+    results: list[dict[str, Any]] = []
+
+    if args.snapshot is not None:
+        print(f"\n=== real snapshot: {args.snapshot} ===", flush=True)
+        table_size = _setup_from_snapshot(args.snapshot, db_path, snap_path)
+        print(f"  ComicFTS rows: {table_size:,}", flush=True)
+        rng_pks = random.Random(0xC0DE)
+        for n_affected in args.affected_counts:
+            if n_affected > table_size:
+                print(f"  skip affected={n_affected:,} (> table size)")
+                continue
+            chosen = _real_pks(rng_pks, n_affected)
+            for n_fields in args.field_counts:
+                if n_fields > len(sweep_fields):
+                    continue
+                fields = sweep_fields[:n_fields]
+                print(
+                    f"\n  combo: affected={n_affected:,} fields={n_fields}",
+                    flush=True,
+                )
+                rng = random.Random(0xBEEF)
+                durations = _run_combo_real(
+                    db_path=db_path,
+                    snap_path=snap_path,
+                    chosen_pks=chosen,
+                    fields=fields,
+                    runs=args.runs,
+                    rng=rng,
+                )
+                medians = {n: statistics.median(d) for n, d in durations.items()}
+                results.append(
+                    {
+                        "table_size": table_size,
+                        "n_affected": n_affected,
+                        "n_fields": n_fields,
+                        "medians_s": medians,
+                        "all_runs_s": durations,
+                        "source": "real",
+                    }
+                )
+                ms = " ".join(
+                    f"{n}={medians[n] * 1000:.0f}ms" for n in _STRATEGIES
+                )
+                print(f"    median: {ms}", flush=True)
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(results, indent=2))
+        print(f"\nWrote {len(results)} combos to {args.out}", flush=True)
+        return 0
+
+    for table_size in args.table_sizes:
+        print(f"\n=== table_size={table_size:,} ===", flush=True)
+        _setup_one_size(table_size, db_path, snap_path)
+
+        for n_affected in args.affected_counts:
+            if n_affected > table_size:
+                continue
+            for n_fields in args.field_counts:
+                if n_fields > len(sweep_fields):
+                    continue
+                fields = sweep_fields[:n_fields]
+                print(
+                    f"\n  combo: affected={n_affected:,} fields={n_fields}",
+                    flush=True,
+                )
+                rng = random.Random(0xBEEF)
+                durations = _run_combo(
+                    db_path=db_path,
+                    snap_path=snap_path,
+                    table_size=table_size,
+                    n_affected=n_affected,
+                    fields=fields,
+                    runs=args.runs,
+                    rng=rng,
+                )
+                medians = {n: statistics.median(d) for n, d in durations.items()}
+                row = {
+                    "table_size": table_size,
+                    "n_affected": n_affected,
+                    "n_fields": n_fields,
+                    "medians_s": medians,
+                    "all_runs_s": durations,
+                }
+                results.append(row)
+                ms = " ".join(
+                    f"{n}={medians[n] * 1000:.0f}ms" for n in _STRATEGIES
+                )
+                print(f"    median: {ms}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(results, indent=2))
+    print(f"\nWrote {len(results)} combos to {args.out}", flush=True)
+
+    # Summary table.
+    print("\n=== Summary (median ms; lower is better) ===")
+    print(
+        f"{'table':>8} {'affected':>10} {'fields':>7} "
+        + " ".join(f"{n:>16}" for n in _STRATEGIES)
+    )
+    for row in results:
+        print(
+            f"{row['table_size']:>8,} {row['n_affected']:>10,} "
+            f"{row['n_fields']:>7} "
+            + " ".join(
+                f"{row['medians_s'][n] * 1000:>14.0f}ms" for n in _STRATEGIES
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Swap `ComicFTS.objects.bulk_update(...)` for `delete + bulk_create` (wrapped in `transaction.atomic`) at the two production update sites. FTS5 makes `bulk_update` expensive in two stacked ways:

1. SQLite's `CASE WHEN id THEN val …` parser cost grows in (rows × cols).
2. Every UPDATE on an FTS5 virtual table is internally a delete-then-reinsert at the segment level anyway, so the CASE WHEN overhead is purely waste.

A multi-row `INSERT` is parsed once and writes straight to the segment.

## Benchmarks

[tests/perf/bench_fts_sync.py](tests/perf/bench_fts_sync.py) — synthetic seeded snapshot, 5 runs per combo, median ms.

### Synthetic (1k / 10k tables)

|  Table | Affected | Fields |  A `bulk_update` | B `delete+create` | **B vs A** |
|-------:|---------:|-------:|-----------------:|------------------:|-----------:|
|  1,000 |    1,000 |      1 |            199ms |             105ms |   **1.9×** |
|  1,000 |    1,000 |      3 |            361ms |             104ms |   **3.5×** |
| 10,000 |    1,000 |      1 |            207ms |             135ms |   **1.5×** |
| 10,000 |    1,000 |      3 |            371ms |             125ms |   **3.0×** |
| 10,000 |   10,000 |      1 |          1,929ms |           1,038ms |   **1.9×** |
| 10,000 |   10,000 |      3 |          3,290ms |             991ms |   **3.3×** |

### Real DB (Milliways, 10,036 ComicFTS rows)

| Affected | Fields |  A `bulk_update` | B `delete+create` | **B vs A** |
|---------:|-------:|-----------------:|------------------:|-----------:|
|      100 |      1 |             33ms |              29ms |       1.1× |
|      100 |      3 |             46ms |              29ms |   **1.6×** |
|    1,000 |      1 |            219ms |             193ms |       1.1× |
|    1,000 |      3 |            381ms |             184ms |   **2.1×** |
|    5,000 |      1 |          1,013ms |             854ms |       1.2× |
|    5,000 |      3 |          1,726ms |             863ms |   **2.0×** |

Pattern holds across both: B wins every combo, gap widens with field count. The real-DB win is more modest at 1 field (~10–20%) but doubles at 3 fields, and the m2m sync case routinely touches multiple fields per affected comic.

## Changes

- **`SearchIndexSyncManyToManyImporter.sync_fts_for_m2m_updates`** — restructured so each affected comic is fetched exactly once even when several m2m fields changed for it. The previous loop appended one `ComicFTS` instance per (comic, field) pair, which `bulk_update` then resolved unpredictably when duplicate pks landed in the same call. New `_gather_m2m_field_values` collapses to `{pk: {field: value}}`, then `_build_replacement_objs` does one `filter(pk__in=...)` and applies all field updates in memory before the swap.
- **`SearchIndexCreateUpdateImporter._update_search_index_create_or_update`** — update branch now calls the inherited `_delete_then_create_comicfts` instead of `bulk_update`.
- **`_delete_then_create_comicfts`** (new, on the m2m sync importer) — does the chunked DELETE + `bulk_create` inside `transaction.atomic` so an interrupted run leaves the original row in place rather than a comic with no FTS row at all. `_FTS_BATCH_SIZE = 500` keeps the `pk__in` clause under SQLite's 32k host parameter limit.

## Test plan

- [x] `make test-python T=tests/importer/` — green.
- [x] `ruff check`, `basedpyright` — clean.
- [x] Synthetic bench across 1k / 10k / 50k tables, 100–10k affected, 1 / 3 fields, 5 runs each. Strategy B wins every combo.
- [x] Real-DB validation against `~/Milliways/Comics/full` (10,036 ComicFTS rows, deduped via the janitor from #681). Same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)