### PR TITLE
Importer FTS m2m sync: guard FTS_UPDATED_M2MS against missing key

### DIFF
--- a/codex/librarian/scribe/importer/search/sync_m2m.py
+++ b/codex/librarian/scribe/importer/search/sync_m2m.py
@@ -67,7 +67,12 @@ class SearchIndexSyncManyToManyImporter(FinishImporter):
         overwrote unpredictably when the same pk appeared twice.
         """
         per_comic: dict[int, dict[str, str]] = {}
-        field_names = tuple(self.metadata[FTS_UPDATED_M2MS].keys())
+        # ``FTS_UPDATED_M2MS`` is only populated when the link phase
+        # actually saw m2m row deletions/insertions; an import that
+        # only creates new comics never sets it. ``.get`` so the
+        # caller's "every post-phase runs unconditionally" model
+        # doesn't surface a KeyError here.
+        field_names = tuple(self.metadata.get(FTS_UPDATED_M2MS, {}).keys())
         for field_name in field_names:
             if self.abort_event.is_set():
                 return per_comic


### PR DESCRIPTION
## Summary

Hotfix for #683. ``sync_fts_for_m2m_updates`` was indexing ``self.metadata[FTS_UPDATED_M2MS]`` directly, but that key is only populated when the link phase actually produced m2m row changes. An import that only creates or only updates comics — without any m2m deletions/insertions — leaves ``FTS_UPDATED_M2MS`` absent from ``self.metadata``, and the post-phase pipeline calls ``sync_fts_for_m2m_updates`` unconditionally.

```
KeyError: 'fts_updated_m2ms'
  File ".../search/sync_m2m.py", line 70, in _gather_m2m_field_values
    field_names = tuple(self.metadata[FTS_UPDATED_M2MS].keys())
```

The pre-#683 implementation had ``self.metadata.get(FTS_UPDATED_M2MS, {})`` for exactly this reason; the refactor that hoisted the field-name iteration into ``_gather_m2m_field_values`` dropped the ``.get`` and switched to subscript access. Restore the ``.get`` so the early-return path fires cleanly when there's nothing to sync.

## Test plan

- [x] ``make test-python T=tests/importer/`` — green.
- [x] ``ruff check``, ``basedpyright`` — clean.
- [ ] Re-run the import that triggered the KeyError (creates-only or updates-only library import); ``full_text_search`` should complete without raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)