### PR TITLE
Stop poller flagging every comic modified when inodes rotate

### DIFF
--- a/codex/librarian/fs/poller/snapshot.py
+++ b/codex/librarian/fs/poller/snapshot.py
@@ -173,7 +173,7 @@ class DatabaseSnapshot(Snapshot):
     def _create_stat(self, wp: dict, *, force: bool) -> os.stat_result:
         """Turn a database JSON stat array into an os.stat_result."""
         stat = wp["stat"]
-        if not stat or len(stat) != self._STAT_LEN or not stat[1]:
+        if not stat or len(stat) != self._STAT_LEN:
             path = Path(wp["path"])
             if path.exists():
                 self.log.debug(f"Force modify path with missing db stat: {path}")

--- a/codex/librarian/fs/poller/snapshot_diff.py
+++ b/codex/librarian/fs/poller/snapshot_diff.py
@@ -101,7 +101,6 @@ class SnapshotDiff:
             unchanged=frozenset(ref.paths & snapshot.paths),
         )
 
-        self._check_unchanged_for_inode_changes(data)
         self._find_moved_paths(data)
         self._find_modified_paths(data)
 
@@ -125,21 +124,11 @@ class SnapshotDiff:
         self.files_moved = []
         self._init_moved(data, ref)
 
-    def _is_inode_equal(self, data: _DiffData, path: str) -> bool:
-        """Return whether inodes match between ref and snapshot."""
-        return data.ref.inode(path) == data.snapshot.inode(path)
-
     def _is_stats_equal(self, data: _DiffData, old_path: str, new_path: str) -> bool:
         """Return whether mtime and size match."""
         return data.ref.mtime(old_path) == data.snapshot.mtime(
             new_path
         ) and data.ref.size(old_path) == data.snapshot.size(new_path)
-
-    def _check_unchanged_for_inode_changes(self, data: _DiffData) -> None:
-        """Check unchanged paths for inode changes (file replaced in-place)."""
-        for path in data.unchanged:
-            if not self._is_inode_equal(data, path):
-                data.modified.add(path)
 
     def _find_moved_paths(self, data: _DiffData) -> None:
         """Detect moves by matching inodes between deleted and added sets."""
@@ -158,9 +147,7 @@ class SnapshotDiff:
     def _find_modified_paths(self, data: _DiffData) -> None:
         """Find paths with changed stats (mtime/size)."""
         for path in data.unchanged:
-            if self._is_inode_equal(data, path) and not self._is_stats_equal(
-                data, path, path
-            ):
+            if not self._is_stats_equal(data, path, path):
                 data.modified.add(path)
 
         for old_path, new_path in data.moved:


### PR DESCRIPTION
## Summary

- The poller's DB-vs-disk diff treated any inode change as a modification, so on filesystems where inodes rotate across remounts (Docker bind mounts, FUSE-backed volumes), every comic in the library was flagged modified on every startup. mtime+size is the real change signal; inode was only useful as a hint for move detection within a single diff.
- Remove `_check_unchanged_for_inode_changes` and the inode-equality requirement in `_find_modified_paths`; mtime+size now solely drive modification detection.
- Drop the falsy-inode branch of the malformed-stat gate in `_create_stat`. Genuinely malformed (missing/short) stats still force-modify.
- `_find_moved_paths` still uses inode but now degrades to delete+add when nothing matches — which is what was already happening on Docker anyway.

## Test plan

- [ ] On a Docker-deployed library where startup previously logged ~all comics as modified, restart codex and confirm the poll diff is empty (or contains only genuinely-changed files).
- [ ] On a stable filesystem, modify a comic's mtime/size and confirm it still gets flagged.
- [ ] Move a comic to a new path within the library and confirm move detection still works (where inodes are stable).
- [ ] `bin/test-python.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)