### PR TITLE
Importer: skip parent_folder re-resolution on update; heal drift in 0039

### DIFF
--- a/codex/librarian/scribe/importer/create/comics.py
+++ b/codex/librarian/scribe/importer/create/comics.py
@@ -44,7 +44,7 @@ class CreateComicsImporter(CreateForeignKeyLinksImporter):
             setattr(comic, field_name, value)
 
         self._populate_fts_attribute_values(FTS_UPDATE, comic.pk, md)
-        link_md = self.get_comic_fk_links(comic.pk, comic.path)
+        link_md = self.get_comic_fk_links(comic.pk, comic.path, for_create=False)
         for field_name, value in link_md.items():
             set_value = value
             if set_value is None:
@@ -120,7 +120,7 @@ class CreateComicsImporter(CreateForeignKeyLinksImporter):
     def _bulk_create_comic(self, path: str, create_comics: list[Comic]) -> None:
         md = self.metadata[CREATE_COMICS].pop(path, {})
         self._populate_fts_attribute_values(FTS_CREATE, path, md)
-        link_md = self.get_comic_fk_links(path, path)
+        link_md = self.get_comic_fk_links(path, path, for_create=True)
         md.update(link_md)
         if not md:
             return

--- a/codex/librarian/scribe/importer/create/link_fks.py
+++ b/codex/librarian/scribe/importer/create/link_fks.py
@@ -63,10 +63,25 @@ class CreateForeignKeyLinksImporter(LinkComicsImporter):
                     (values[-1],),
                 )
 
-    def get_comic_fk_links(self, subkey: str | int, path: str) -> dict:
-        """Get links for all foreign keys for creating and updating."""
+    def get_comic_fk_links(
+        self, subkey: str | int, path: str, *, for_create: bool
+    ) -> dict:
+        """
+        Get links for all foreign keys for creating and updating.
+
+        ``for_create=True`` resolves ``parent_folder`` from the
+        comic's path string. ``for_create=False`` (the update path)
+        skips that lookup entirely — the comic already carries a
+        valid ``parent_folder_id`` from a prior import (or from
+        ``MovedComicsImporter._prepare_moved_comic`` if the file
+        was renamed in this run), and re-resolving by string is
+        wasted work that's also brittle against any string-form
+        drift between ``Folder.path`` and
+        ``str(Path(comic.path).parent)``.
+        """
         md = {}
-        self._get_comic_folder_fk_link(md, subkey, path)
+        if for_create:
+            self._get_comic_folder_fk_link(md, subkey, path)
         if link_fks := self.metadata[LINK_FKS].pop(path, {}):
             self._get_comic_protagonist_fk_link(md, link_fks)
             self._get_comic_simple_fk_links(md, subkey, link_fks)

--- a/codex/librarian/scribe/janitor/integrity/foreign_keys.py
+++ b/codex/librarian/scribe/janitor/integrity/foreign_keys.py
@@ -2,16 +2,21 @@
 
 # Uses app.get_model() because functions may also be called before the models are ready on startup.
 from collections import defaultdict
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from django.apps import apps
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import DEFAULT_DB_ALIAS, connections, transaction
 from django.db.models.functions import Now
 
 if TYPE_CHECKING:
     from django.db.models.manager import BaseManager
 
     from codex.models.comic import Comic
+
+# Comic file extensions we'll consider — phantom directory-as-comic
+# rows (older bug) are out of scope for parent-folder drift repair.
+_COMIC_SUFFIXES = (".cbz", ".cbr", ".cb7", ".cbt", ".pdf")
 
 # SQLite's parameter cap is 32766; leave headroom for the rare case
 # where Django / the driver sneaks in extra bound values. Each rowid
@@ -205,6 +210,89 @@ def _fix_fk_violations(
                 deleted += affected
 
     return nulled, deleted, fix_comic_pks
+
+
+def fix_parent_folder_drift(log, apps_registry=None) -> int:
+    """
+    Re-point ``Comic.parent_folder_id`` rows whose FK disagrees with the path.
+
+    A normally-functioning importer keeps ``Comic.path`` and
+    ``Comic.parent_folder.path`` consistent —
+    ``Path(comic.path).parent`` always equals
+    ``comic.parent_folder.path``. A past importer bug (most likely a
+    botched directory-rename move during a single import event) has
+    been observed to produce rare drift where the FK points at a real
+    ``Folder`` row whose path no longer matches the comic's actual
+    location on disk. This function detects such rows and re-points
+    them at the correct ``Folder``, or surfaces a warning if no such
+    folder exists in the library yet.
+
+    Returns the number of comics whose FK was corrected. Safe to
+    re-run; a no-op once the database is consistent.
+
+    ``apps_registry`` is an optional override for the Django apps
+    registry. Pass the migration-time ``apps`` argument when calling
+    from a ``RunPython`` step so the function uses schema state at
+    migration time rather than the live model classes. Defaults to
+    the live registry.
+    """
+    registry = apps_registry if apps_registry is not None else apps
+    comic_model = registry.get_model("codex", "Comic")
+    folder_model = registry.get_model("codex", "Folder")
+
+    folder_pk_by_key: dict[tuple[int, str], int] = {
+        (lib_id, path): pk
+        for pk, lib_id, path in folder_model.objects.values_list(
+            "id", "library_id", "path"
+        )
+    }
+    folder_path_by_pk: dict[int, str] = {
+        pk: path for (_, path), pk in folder_pk_by_key.items()
+    }
+
+    repointed: list[tuple[int, int]] = []
+    orphaned: list[tuple[int, str, str]] = []
+    # ``values_list`` avoids attribute access on a generic
+    # ``Model`` (which the migration-time apps registry returns)
+    # — keeps the type checker happy without per-line ignores.
+    for comic_id, comic_path, parent_folder_id, library_id in (
+        comic_model.objects.values_list(
+            "id", "path", "parent_folder_id", "library_id"
+        ).iterator(chunk_size=2000)
+    ):
+        if not comic_path.endswith(_COMIC_SUFFIXES):
+            # Phantom comic-as-folder rows are handled elsewhere.
+            continue
+        expected = str(Path(comic_path).parent)
+        actual = folder_path_by_pk.get(parent_folder_id) if parent_folder_id else None
+        if actual == expected:
+            continue
+        new_pk = folder_pk_by_key.get((library_id, expected))
+        if new_pk is None:
+            orphaned.append((comic_id, comic_path, expected))
+            continue
+        repointed.append((comic_id, new_pk))
+
+    if repointed:
+        with transaction.atomic():
+            for comic_id, new_pk in repointed:
+                comic_model.objects.filter(id=comic_id).update(parent_folder_id=new_pk)
+        log.info(
+            f"Re-pointed parent_folder_id for {len(repointed)} drifted comics."
+        )
+    else:
+        log.debug("No parent_folder_id drift detected.")
+
+    if orphaned:
+        log.warning(
+            f"{len(orphaned)} comics have no matching parent Folder in their library; the next import will recreate the hierarchy. First 5:"
+        )
+        for comic_id, comic_path, expected in orphaned[:5]:
+            log.warning(
+                f"  drift orphan: comic_id={comic_id} path={comic_path} expected_parent={expected}"
+            )
+
+    return len(repointed)
 
 
 def fix_foreign_keys(log) -> None:

--- a/codex/migrations/0039_metron_age_rating_default_view_and_performance.py
+++ b/codex/migrations/0039_metron_age_rating_default_view_and_performance.py
@@ -93,6 +93,7 @@ from comicbox.enums.metroninfo import MetronAgeRatingEnum
 from django.db import migrations, models
 from django.db.models.deletion import SET_NULL
 from django.db.models.functions import Trim
+from loguru import logger
 
 import codex.models.fields
 from codex.choices.reader import READER_DEFAULTS
@@ -351,6 +352,26 @@ def _seed_anonymous_user_age_rating_flag(apps, _schema_editor) -> None:
 
 def _noop(_apps, _schema_editor) -> None:
     """Reverse no-op (data migrations stay applied on rollback)."""
+
+
+def _fix_parent_folder_drift(apps, _schema_editor) -> None:
+    """
+    One-shot heal for drifted Comic.parent_folder_id rows.
+
+    Observed once in a v1.10-era database: 8 comics' FK pointed at a
+    real Folder row whose path no longer matched
+    ``Path(comic.path).parent``. The importer's update path used to
+    re-resolve parent_folder via path string and crashed
+    (``Folder.DoesNotExist``) for these rows. The companion code
+    change in this PR stops the re-resolution; this migration step
+    cleans up the drifted data so a future browse query lands on the
+    right folder. No-op on a consistent database.
+    """
+    from codex.librarian.scribe.janitor.integrity.foreign_keys import (
+        fix_parent_folder_drift,
+    )
+
+    fix_parent_folder_drift(logger, apps_registry=apps)
 
 
 def _strip_pycountry_names(apps, _schema_editor) -> None:
@@ -861,6 +882,13 @@ class Migration(migrations.Migration):
             backfill_global_reader_defaults,
             reverse_code=migrations.RunPython.noop,
         ),
+        # One-shot heal for Comic.parent_folder_id rows that drifted
+        # off their on-disk path (rare, observed once on a v1.10-era
+        # database). The companion code change in this PR stops the
+        # importer from re-resolving parent_folder by string on the
+        # update path — this step backfills the data so existing
+        # affected installs come out clean.
+        migrations.RunPython(_fix_parent_folder_drift, _noop),
         # ComicFTS is unmanaged; its Django state tracks only (comic,
         # created_at, updated_at). The FTS columns are a SQL-level concern —
         # no state_operations are needed, only a raw DROP + CREATE.


### PR DESCRIPTION
## Summary

Two paired changes for the ``Folder.DoesNotExist`` traceback that fired during ``update_comics`` for a small set of comics in v1.11.0a0-era databases.

**Code change.** ``CreateForeignKeyLinksImporter.get_comic_fk_links`` gains a ``for_create`` keyword. The update call site (``_update_comic_values``) passes ``False`` and the parent-folder lookup is skipped; the create call site (``_bulk_create_comic``) passes ``True`` and behavior is unchanged.

The update path was unconditionally re-resolving the comic's parent folder via ``Folder.objects.get(path=str(Path(comic.path).parent))`` on every comic update — wasted work, and brittle against any string-form drift between ``Folder.path`` and the path computed from ``Comic.path``. The move phase (``MovedComicsImporter._prepare_moved_comic``) already sets ``comic.parent_folder_id`` directly when a comic is renamed, and unchanged comics carry a valid FK from their prior import, so re-resolution was never necessary on the update path.

**Migration step.** ``0039`` gains a ``RunPython`` step that runs ``fix_parent_folder_drift`` once at migrate time. The function detects ``Comic`` rows whose ``parent_folder_id`` points at a real ``Folder`` whose path no longer matches ``str(Path(comic.path).parent)``, re-points them at the matching ``Folder`` if one exists in the library, or warns about orphans (parent dir has no ``Folder`` row at all — the next import will recreate the hierarchy). No-op on a consistent database.

The function lives in ``codex/librarian/scribe/janitor/integrity/foreign_keys.py`` next to ``fix_foreign_keys`` so it's importable both from the migration and from a Django shell if drift ever recurs. It accepts an optional ``apps_registry`` argument (defaults to the live registry) so the migration can pass its time-locked ``apps`` parameter.

## Why no nightly task

The drift was observed once across years of operation, in a single ~1 second event (8 comics, all updated between ``2026-08-25 21:10:41.452`` and ``21:10:42.417``). A nightly recurring task would be permanent maintenance for a fixed-or-effectively-fixed bug. Same reasoning applied to the JSD dedupe path: one-shot in the migration, function stays callable from a shell if it ever recurs, no permanent task.

## Test plan

- [x] ``make test-python T=tests/importer/`` — green.
- [x] ``ruff check``, ``basedpyright`` — clean.
- [ ] On a v1.11.0a0 install with known drift (e.g., the original 8-comic case): apply 0039, confirm log shows ``Re-pointed parent_folder_id for 8 drifted comics.`` and the comics now point at the correct folders.
- [ ] On a clean v1.10 → v1.11 fresh upgrade: apply 0039, confirm log shows ``No parent_folder_id drift detected.`` (DEBUG level — invisible at default INFO).
- [ ] Confirm normal import flow no longer raises ``Folder.DoesNotExist`` traceback during ``update_comics``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)