### PR TITLE
CoverThread: drain contiguous CoverCreateTasks under one status

### DIFF
--- a/codex/librarian/covers/coverd.py
+++ b/codex/librarian/covers/coverd.py
@@ -28,6 +28,6 @@ class CoverThread(CoverPurgeThread):
             case CoverCreateAllTask():
                 self.create_all_covers()
             case CoverCreateTask():
-                self._bulk_create_comic_covers(item.pks, custom=item.custom)
+                self.process_cover_create_burst(item)
             case _:
                 self.log.error(f"Bad task sent to {self.__class__.__name__}: {item}")

--- a/codex/librarian/covers/create.py
+++ b/codex/librarian/covers/create.py
@@ -1,14 +1,16 @@
 """Create comic cover paths."""
 
+from __future__ import annotations
+
 import contextlib
 import os
 from abc import ABC
-from collections.abc import Collection
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import CancelledError, ProcessPoolExecutor, as_completed
 from io import BytesIO
 from pathlib import Path
+from queue import Empty
 from time import time
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from comicbox.box import Comicbox
 from humanize import naturaldelta
@@ -16,9 +18,15 @@ from PIL import Image
 
 from codex.librarian.covers.path import CoverPathMixin
 from codex.librarian.covers.status import CreateCoversStatus
+from codex.librarian.covers.tasks import CoverCreateTask
 from codex.librarian.threads import QueuedThread
 from codex.models import Comic, CustomCover
 from codex.settings import COMICBOX_CONFIG, COVER_WORKERS
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from codex.librarian.tasks import LibrarianTask
 
 _COVER_RATIO = 1.5372233400402415  # modal cover ratio
 THUMBNAIL_WIDTH = 165
@@ -200,67 +208,168 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
             work.append((pk, db_path, cover_path_str, custom))
         return work
 
-    def _bulk_create_comic_covers(self, pks, *, custom: bool) -> int:
+    def _render_covers_into_status(
+        self,
+        pks: Collection[int],
+        *,
+        custom: bool,
+        status: CreateCoversStatus,
+    ) -> int:
         """
-        Create bulk comic covers.
+        Render covers for a batch of pks, accumulating into ``status``.
 
-        Image-decode + LANCZOS resize + WEBP encode is CPU-bound and
-        embarrassingly parallel across cover targets. Submit each
-        target to a ``ProcessPoolExecutor`` and consume the
-        completion stream via ``as_completed``.
+        Pure work-driver: no ``start()`` / ``finish()`` calls. The
+        caller owns the status lifecycle so multiple batches (e.g.
+        a drained burst of ``CoverCreateTask``s) can share one
+        status row and avoid the start/finish flicker between
+        per-task lifecycles.
 
-        Workers own the full pipeline including the disk write —
-        no inline cover-bytes path exists anymore (the cover
-        endpoint serves from the on-disk cache via the 202-poll
-        retry loop landed in cover-cleanup PR #606). Skipping the
-        bytes round-trip through the executor's pickle channel
-        avoids ~50 KB of IPC per cover and parallelizes the disk
-        writes alongside the image pipeline.
+        Image-decode + LANCZOS resize + WEBP encode is CPU-bound
+        and embarrassingly parallel across cover targets. Submit
+        each target to a ``ProcessPoolExecutor`` and consume the
+        completion stream via ``as_completed``. Workers own the
+        full pipeline including the disk write — no bytes
+        round-trip through the executor's pickle channel.
 
-        Workers return only ``(pk, cover_path_str,
-        error_msg_or_None)`` — metadata for the parent's logging
-        + status loop. Failures still write the zero-byte
-        ``tried-and-failed`` sentinel from inside the worker so
-        the on-disk shape is identical regardless of outcome.
+        Returns the number of covers rendered (skipped pks aren't
+        counted).
         """
-        # Up-front filter: drop pks that already have a cover on
-        # disk. The remaining set is what we actually need to work
-        # on.
         pending_pks = self._filter_pending_pks(tuple(pks), custom=custom)
-        num_comics = len(pending_pks)
-        if not num_comics:
+        if not pending_pks:
             return 0
-        # Single batched ``pk -> path`` map covers the full set of
-        # work items; no per-cover SELECT inside the loop.
         db_paths = self._resolve_db_paths(pending_pks, custom=custom)
         work_items = self._build_cover_work_items(pending_pks, db_paths, custom=custom)
-        # Race-window adjustment: if some pks vanished between
-        # _resolve_db_paths and now, skip them silently in the status.
-        skipped = num_comics - len(work_items)
-        status = CreateCoversStatus(0, len(work_items))
+        if not work_items:
+            return 0
+        # ``status.total`` accumulates across burst batches so the UI
+        # sees a growing total as new tasks drain in alongside the
+        # already-running render.
+        status.total = (status.total or 0) + len(work_items)
+        self.status_controller.update(status)
+        desc = "custom" if custom else "comic"
+        self.log.debug(f"Creating {len(work_items)} {desc} covers...")
+        pool = self._get_cover_pool()
+        futures = [pool.submit(_render_cover_thumb, w) for w in work_items]
+        rendered = 0
+        for future in as_completed(futures):
+            try:
+                pk, _cover_path_str, err = future.result()
+            except CancelledError:
+                # ``stop()`` shuts the pool with ``cancel_futures=True``
+                # before ``SHUTDOWN_MSG`` lands — outstanding futures
+                # raise here. Drop them; the burst handler's ``finally``
+                # still finishes the status cleanly.
+                break
+            if err:
+                self.log.warning(f"Could not create cover thumbnail for pk={pk}: {err}")
+            status.increment_complete()
+            self.status_controller.update(status)
+            rendered += 1
+        return rendered
+
+    def _bulk_create_comic_covers(self, pks, *, custom: bool) -> int:
+        """
+        Create bulk comic covers under a fresh status lifecycle.
+
+        Thin wrapper around ``_render_covers_into_status`` for
+        callers that own a single isolated batch (notably
+        ``create_all_covers``). The burst handler used by the
+        ``CoverThread`` queue dispatch path manages its own status
+        and calls ``_render_covers_into_status`` directly.
+        """
+        status = CreateCoversStatus(0, 0)
         try:
             start_time = time()
-            self.log.debug(f"Creating {len(work_items)} comic covers...")
             self.status_controller.start(status)
-            pool = self._get_cover_pool()
-            futures = [pool.submit(_render_cover_thumb, w) for w in work_items]
-            for future in as_completed(futures):
-                pk, _cover_path_str, err = future.result()
-                if err:
-                    self.log.warning(
-                        f"Could not create cover thumbnail for pk={pk}: {err}"
-                    )
-                status.increment_complete()
-                self.status_controller.update(status)
+            self._render_covers_into_status(pks, custom=custom, status=status)
             desc = "custom" if custom else "comic"
-            count = status.complete
+            count = status.complete or 0
             level = "INFO" if count else "DEBUG"
             elapsed = naturaldelta(time() - start_time)
-            extra = f" ({skipped} skipped)" if skipped else ""
-            self.log.log(level, f"Created {count} {desc} covers in {elapsed}{extra}.")
+            self.log.log(level, f"Created {count} {desc} covers in {elapsed}.")
         finally:
             self.status_controller.finish(status)
         return status.complete or 0
+
+    def _drain_contiguous_creates(
+        self,
+    ) -> tuple[list[CoverCreateTask], LibrarianTask | None]:
+        """
+        Drain the queue's contiguous prefix of ``CoverCreateTask``s.
+
+        Pulls items via ``get_nowait`` until either the queue is
+        empty or a non-``CoverCreateTask`` cover task is seen.
+        That interruptor is returned so the caller can dispatch it
+        *after* the current burst's status finishes — preserving
+        FIFO ordering, which the importer relies on (it enqueues
+        ``CoverRemoveTask`` before ``CoverCreateTask`` for updated
+        comics, and ``_filter_pending_pks`` would no-op the
+        regeneration if the create ran first).
+
+        ``SHUTDOWN_MSG`` is re-armed on the queue so the outer
+        ``_check_item`` loop sees it on the next iteration.
+        """
+        creates: list[CoverCreateTask] = []
+        while True:
+            try:
+                item = self.queue.get_nowait()
+            except Empty:
+                return creates, None
+            if item == self.SHUTDOWN_MSG:
+                self.queue.put(self.SHUTDOWN_MSG)
+                return creates, None
+            if isinstance(item, CoverCreateTask):
+                creates.append(item)
+                continue
+            return creates, item
+
+    def process_cover_create_burst(self, first: CoverCreateTask) -> None:
+        """
+        Process ``first`` plus any contiguous queued ``CoverCreateTask``s.
+
+        Opens one ``CreateCoversStatus`` for the entire burst so the
+        admin UI's status row stays continuously active instead of
+        flickering off-and-on between back-to-back tasks (the
+        per-pk cover endpoint at ``views/browser/cover.py`` enqueues
+        one task per cache miss).
+
+        Drain stops at the first non-create cover task to preserve
+        enqueue order; that interruptor is dispatched via
+        ``process_item`` after ``finish()`` returns.
+        """
+        pending: list[CoverCreateTask] = [first]
+        interruptor: LibrarianTask | None = None
+        status = CreateCoversStatus(0, 0)
+        try:
+            start_time = time()
+            self.status_controller.start(status)
+            while pending:
+                comic_pks: set[int] = set()
+                custom_pks: set[int] = set()
+                for task in pending:
+                    if task.custom:
+                        custom_pks.update(task.pks)
+                    else:
+                        comic_pks.update(task.pks)
+                pending.clear()
+                if comic_pks:
+                    self._render_covers_into_status(
+                        comic_pks, custom=False, status=status
+                    )
+                if custom_pks:
+                    self._render_covers_into_status(
+                        custom_pks, custom=True, status=status
+                    )
+                more, interruptor = self._drain_contiguous_creates()
+                pending.extend(more)
+            count = status.complete or 0
+            level = "INFO" if count else "DEBUG"
+            elapsed = naturaldelta(time() - start_time)
+            self.log.log(level, f"Created {count} covers in {elapsed}.")
+        finally:
+            self.status_controller.finish(status)
+        if interruptor is not None:
+            self.process_item(interruptor)
 
     def create_all_covers(self) -> None:
         """Create all covers for all libraries."""

--- a/codex/librarian/scribe/importer/create/__init__.py
+++ b/codex/librarian/scribe/importer/create/__init__.py
@@ -40,6 +40,12 @@ class CreateForeignKeysImporter(CreateForeignKeysCreateUpdateImporter):
         status, blinking the row in and out of the active list as the
         cover thread switches tasks.
 
+        ``CoverThread.process_cover_create_burst`` also drains
+        contiguous queued ``CoverCreateTask``s under one status row,
+        so per-task flicker is now smoothed at the consumer side too;
+        producer-side coalescing here still avoids extra queue churn
+        and keeps the importer's preactive ``total`` hint accurate.
+
         If no pks accumulated (no created or updated comics in this
         chunk), explicitly clear the pre-registered ``CreateCoversStatus``
         so the row doesn't sit "queued" in the UI for the rest of the


### PR DESCRIPTION
## Summary

- Bursts of `CoverCreateTask`s (e.g. parallel cover-endpoint cache misses from the 202-poll path) previously each opened and closed their own `CreateCoversStatus`, flickering the admin "Create Covers" status row off-and-on between tasks.
- The cover thread now drains the queue's contiguous prefix of `CoverCreateTask`s into one status lifecycle: `total` grows from 1 → N as queued tasks arrive, `complete` climbs to match, the row clears once at the end.
- Drain stops at the first non-create cover task so FIFO ordering is preserved — the importer enqueues `CoverRemoveTask` before `CoverCreateTask` for updated comics, and `_filter_pending_pks` would silently no-op the regen if the create ran first.

## Implementation

- **`covers/create.py`** — split `_bulk_create_comic_covers` into a thin status wrapper (kept for `create_all_covers`) plus a new `_render_covers_into_status` work driver that mutates `status.total` / `status.complete` without owning the status lifecycle. Added `process_cover_create_burst` (opens one `CreateCoversStatus`, drains contiguous queued creates, finishes once in `finally`) and `_drain_contiguous_creates` (FIFO-safe peek via `get_nowait`, stops at the first non-create, re-arms `SHUTDOWN_MSG` if seen). Wrapped `future.result()` in `except CancelledError` so pool shutdown during a burst exits cleanly instead of crashing.
- **`covers/coverd.py`** — `CoverCreateTask` arm dispatches to `process_cover_create_burst` instead of `_bulk_create_comic_covers`.
- **`scribe/importer/create/__init__.py`** — comment-only update noting the consumer also coalesces now, so future readers don't think producer-side coalescing is the only flicker defense.

## Notes for reviewer

- Producer-side coalescing in the importer is intentionally kept — it still reduces queue churn and keeps the preactive `total` hint accurate.
- `CoverCreateAllTask` mid-burst is treated as an interruptor (keeps its own status lifecycle); its semantics differ from per-pk tasks and pulling DB-wide pks into an in-flight burst risks unbounded total drift.
- Same pk in two contiguous tasks: second batch's `_filter_pending_pks` skips it (cover already on disk). Correct.
- `LibrarianStatus.total` is `PositiveSmallIntegerField` (max 32767); the same ceiling already applies to existing `CoverCreateAllTask` paths on large libraries — not a new risk.

## Test plan

- [ ] `uv run ruff check codex/` — passes
- [ ] `uv run --group test pytest tests/ --ignore=tests/perf` — 26/26 pass
- [ ] Manual repro: fire parallel `curl` against `/api/v3/c/<pk>/cover.webp` for several missing covers, confirm one continuous `CCC` row in the admin status panel (instead of N flickers)
- [ ] Importer regression check: edit a comic's metadata, trigger re-import, verify the new cover thumbnail appears (validates remove-before-create ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)