### PR TITLE
Reduce cognitive complexity of two burst/drift functions; fix complexipy exclude

### DIFF
--- a/codex/librarian/covers/create.py
+++ b/codex/librarian/covers/create.py
@@ -323,6 +323,45 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
                 continue
             return creates, item
 
+    @staticmethod
+    def _split_pending_pks(
+        pending: list[CoverCreateTask],
+    ) -> tuple[set[int], set[int]]:
+        """Partition queued create tasks into (comic_pks, custom_pks)."""
+        comic_pks: set[int] = set()
+        custom_pks: set[int] = set()
+        for task in pending:
+            target = custom_pks if task.custom else comic_pks
+            target.update(task.pks)
+        return comic_pks, custom_pks
+
+    def _render_burst_batch(
+        self,
+        comic_pks: set[int],
+        custom_pks: set[int],
+        status: CreateCoversStatus,
+    ) -> None:
+        """Dispatch the comic and custom render passes for one batch."""
+        if comic_pks:
+            self._render_covers_into_status(comic_pks, custom=False, status=status)
+        if custom_pks:
+            self._render_covers_into_status(custom_pks, custom=True, status=status)
+
+    def _drain_burst_loop(
+        self,
+        pending: list[CoverCreateTask],
+        status: CreateCoversStatus,
+    ) -> LibrarianTask | None:
+        """Render ``pending`` and any drained-in tasks; return the interruptor."""
+        interruptor: LibrarianTask | None = None
+        while pending:
+            comic_pks, custom_pks = self._split_pending_pks(pending)
+            pending.clear()
+            self._render_burst_batch(comic_pks, custom_pks, status)
+            more, interruptor = self._drain_contiguous_creates()
+            pending.extend(more)
+        return interruptor
+
     def process_cover_create_burst(self, first: CoverCreateTask) -> None:
         """
         Process ``first`` plus any contiguous queued ``CoverCreateTask``s.
@@ -343,25 +382,7 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
         try:
             start_time = time()
             self.status_controller.start(status)
-            while pending:
-                comic_pks: set[int] = set()
-                custom_pks: set[int] = set()
-                for task in pending:
-                    if task.custom:
-                        custom_pks.update(task.pks)
-                    else:
-                        comic_pks.update(task.pks)
-                pending.clear()
-                if comic_pks:
-                    self._render_covers_into_status(
-                        comic_pks, custom=False, status=status
-                    )
-                if custom_pks:
-                    self._render_covers_into_status(
-                        custom_pks, custom=True, status=status
-                    )
-                more, interruptor = self._drain_contiguous_creates()
-                pending.extend(more)
+            interruptor = self._drain_burst_loop(pending, status)
             count = status.complete or 0
             level = "INFO" if count else "DEBUG"
             elapsed = naturaldelta(time() - start_time)

--- a/codex/librarian/scribe/janitor/integrity/foreign_keys.py
+++ b/codex/librarian/scribe/janitor/integrity/foreign_keys.py
@@ -212,6 +212,78 @@ def _fix_fk_violations(
     return nulled, deleted, fix_comic_pks
 
 
+def _build_folder_lookups(
+    folder_model,
+) -> tuple[dict[tuple[int, str], int], dict[int, str]]:
+    """Build (library_id, path)→pk and pk→path lookups from Folder rows."""
+    folder_pk_by_key: dict[tuple[int, str], int] = {
+        (lib_id, path): pk
+        for pk, lib_id, path in folder_model.objects.values_list(
+            "id", "library_id", "path"
+        )
+    }
+    folder_path_by_pk: dict[int, str] = {
+        pk: path for (_, path), pk in folder_pk_by_key.items()
+    }
+    return folder_pk_by_key, folder_path_by_pk
+
+
+def _classify_comic_drift(
+    comic_model,
+    folder_pk_by_key: dict[tuple[int, str], int],
+    folder_path_by_pk: dict[int, str],
+) -> tuple[list[tuple[int, int]], list[tuple[int, str, str]]]:
+    """Bucket each comic into (repointed, orphaned) by parent-folder drift."""
+    repointed: list[tuple[int, int]] = []
+    orphaned: list[tuple[int, str, str]] = []
+    # ``values_list`` avoids attribute access on a generic
+    # ``Model`` (which the migration-time apps registry returns)
+    # — keeps the type checker happy without per-line ignores.
+    rows = comic_model.objects.values_list(
+        "id", "path", "parent_folder_id", "library_id"
+    ).iterator(chunk_size=2000)
+    for comic_id, comic_path, parent_folder_id, library_id in rows:
+        if not comic_path.endswith(_COMIC_SUFFIXES):
+            # Phantom comic-as-folder rows are handled elsewhere.
+            continue
+        expected = str(Path(comic_path).parent)
+        actual = folder_path_by_pk.get(parent_folder_id) if parent_folder_id else None
+        if actual == expected:
+            continue
+        new_pk = folder_pk_by_key.get((library_id, expected))
+        if new_pk is None:
+            orphaned.append((comic_id, comic_path, expected))
+        else:
+            repointed.append((comic_id, new_pk))
+    return repointed, orphaned
+
+
+def _apply_parent_folder_repoints(
+    comic_model, repointed: list[tuple[int, int]], log
+) -> None:
+    """Repoint each drifted comic at its correct parent folder."""
+    if not repointed:
+        log.debug("No parent_folder_id drift detected.")
+        return
+    with transaction.atomic():
+        for comic_id, new_pk in repointed:
+            comic_model.objects.filter(id=comic_id).update(parent_folder_id=new_pk)
+    log.info(f"Re-pointed parent_folder_id for {len(repointed)} drifted comics.")
+
+
+def _log_drift_orphans(orphaned: list[tuple[int, str, str]], log) -> None:
+    """Warn about drifted comics whose true parent folder doesn't exist yet."""
+    if not orphaned:
+        return
+    log.warning(
+        f"{len(orphaned)} comics have no matching parent Folder in their library; the next import will recreate the hierarchy. First 5:"
+    )
+    for comic_id, comic_path, expected in orphaned[:5]:
+        log.warning(
+            f"  drift orphan: comic_id={comic_id} path={comic_path} expected_parent={expected}"
+        )
+
+
 def fix_parent_folder_drift(log, apps_registry=None) -> int:
     """
     Re-point ``Comic.parent_folder_id`` rows whose FK disagrees with the path.
@@ -240,58 +312,13 @@ def fix_parent_folder_drift(log, apps_registry=None) -> int:
     comic_model = registry.get_model("codex", "Comic")
     folder_model = registry.get_model("codex", "Folder")
 
-    folder_pk_by_key: dict[tuple[int, str], int] = {
-        (lib_id, path): pk
-        for pk, lib_id, path in folder_model.objects.values_list(
-            "id", "library_id", "path"
-        )
-    }
-    folder_path_by_pk: dict[int, str] = {
-        pk: path for (_, path), pk in folder_pk_by_key.items()
-    }
+    folder_pk_by_key, folder_path_by_pk = _build_folder_lookups(folder_model)
+    repointed, orphaned = _classify_comic_drift(
+        comic_model, folder_pk_by_key, folder_path_by_pk
+    )
 
-    repointed: list[tuple[int, int]] = []
-    orphaned: list[tuple[int, str, str]] = []
-    # ``values_list`` avoids attribute access on a generic
-    # ``Model`` (which the migration-time apps registry returns)
-    # — keeps the type checker happy without per-line ignores.
-    for (
-        comic_id,
-        comic_path,
-        parent_folder_id,
-        library_id,
-    ) in comic_model.objects.values_list(
-        "id", "path", "parent_folder_id", "library_id"
-    ).iterator(chunk_size=2000):
-        if not comic_path.endswith(_COMIC_SUFFIXES):
-            # Phantom comic-as-folder rows are handled elsewhere.
-            continue
-        expected = str(Path(comic_path).parent)
-        actual = folder_path_by_pk.get(parent_folder_id) if parent_folder_id else None
-        if actual == expected:
-            continue
-        new_pk = folder_pk_by_key.get((library_id, expected))
-        if new_pk is None:
-            orphaned.append((comic_id, comic_path, expected))
-            continue
-        repointed.append((comic_id, new_pk))
-
-    if repointed:
-        with transaction.atomic():
-            for comic_id, new_pk in repointed:
-                comic_model.objects.filter(id=comic_id).update(parent_folder_id=new_pk)
-        log.info(f"Re-pointed parent_folder_id for {len(repointed)} drifted comics.")
-    else:
-        log.debug("No parent_folder_id drift detected.")
-
-    if orphaned:
-        log.warning(
-            f"{len(orphaned)} comics have no matching parent Folder in their library; the next import will recreate the hierarchy. First 5:"
-        )
-        for comic_id, comic_path, expected in orphaned[:5]:
-            log.warning(
-                f"  drift orphan: comic_id={comic_id} path={comic_path} expected_parent={expected}"
-            )
+    _apply_parent_folder_repoints(comic_model, repointed, log)
+    _log_drift_orphans(orphaned, log)
 
     return len(repointed)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ skip = "*~,.*,./bun.lock,./codex/_vendor,./codex/static,./codex/static_build,./c
 failed = true
 paths = ["codex", "tests"]
 exclude = [
-  "*/.*",
+  ".*",
   "frontend",
   "node_modules",
   "site",


### PR DESCRIPTION
## Summary

- Refactor `CoverCreateThread.process_cover_create_burst` (cognitive 20 → 4) by extracting `_split_pending_pks`, `_render_burst_batch`, and `_drain_burst_loop`.
- Refactor `fix_parent_folder_drift` (cognitive 18 → 1, cyclomatic C/13 → A/1) by extracting `_build_folder_lookups`, `_classify_comic_drift`, `_apply_parent_folder_repoints`, and `_log_drift_orphans`.
- Fix `[tool.complexipy] exclude` in `pyproject.toml`: `*/.*` was matching too broadly and silently excluding every file under the configured `paths`, so `make complexity` looked clean while functions with complexity 18 and 20 sat unfixed. Replaced with `.*`.

## Why

`make complexity` was a false negative — it printed `No function were found with complexity greater than 15` because the exclude pattern matched everything, not because the codebase was clean. Once you scan the files individually, two cognitive-complexity violations surface in the v1.11-performance branch. This PR fixes both functions and the exclude bug that hid them.

Both refactors are pure structural splits — no behavior change.

## Test plan

- [x] `make complexity` passes (now actually scanning — message changed from singular "No function" to plural "No functions").
- [x] `uv run --group lint complexipy -mx 1 codex/librarian/covers/create.py` confirms `process_cover_create_burst` now reports 4.
- [x] `uv run --group lint complexipy -mx 1 codex/librarian/scribe/janitor/integrity/foreign_keys.py` confirms `fix_parent_folder_drift` no longer appears (cognitive 1).
- [x] `make lint` shows no new warnings/errors versus the pre-change branch.
- [x] Smoke import: `from codex.librarian.covers.create import CoverCreateThread` and `from codex.librarian.scribe.janitor.integrity.foreign_keys import fix_parent_folder_drift, fix_foreign_keys` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)