### PR TITLE
startup: warn on stale SQLite siblings; fix _rebuild_db for multi-line SQL

### DIFF
--- a/codex/startup/db.py
+++ b/codex/startup/db.py
@@ -28,6 +28,14 @@ from codex.version import VERSION
 _REPAIR_FLAG_PATH = CONFIG_PATH / "rebuild_db"
 _REBUILT_DB_PATH = DB_PATH.parent / (DB_PATH.name + ".rebuilt")
 _REPAIR_ARGS = ("sqlite3", DB_PATH, ".recover")
+# ``sqlite3 .recover`` can stream a lot of SQL on a real-sized
+# library; give it room to finish without spuriously timing out.
+_REPAIR_TIMEOUT_S = 300
+# WAL/SHM/journal sibling suffixes SQLite may write next to a DB.
+# Stale ones left from an unclean shutdown contaminate every subsequent
+# open until removed; warning about them at startup is the cheapest
+# possible save for the operator.
+_DB_SIBLING_SUFFIXES = ("-wal", "-shm", "-journal")
 
 
 def _has_unapplied_migrations() -> bool:
@@ -101,35 +109,100 @@ def _queue_post_migration_fts_tasks(log) -> None:
 
 
 def _rebuild_db() -> bool:
-    """Dump and rebuild the database."""
-    # Drastic
+    """
+    Dump and rebuild the database via ``sqlite3 .recover``.
+
+    Gated on the ``rebuild_db`` sentinel file so this drastic path
+    is operator-opt-in. Reads the recovery script as a single SQL
+    blob and feeds it to ``executescript`` — ``.recover`` emits
+    multi-line ``CREATE TABLE`` / ``CREATE TRIGGER`` definitions
+    that don't survive being chopped at line boundaries and pushed
+    through ``cursor.execute`` one-line-at-a-time, which the prior
+    implementation did.
+    """
     if not _REPAIR_FLAG_PATH.exists():
         return False
 
     logger.warning("REBUILDING DATABASE!!")
     _REBUILT_DB_PATH.unlink(missing_ok=True)
-    recover_proc = subprocess.Popen(_REPAIR_ARGS, stdout=subprocess.PIPE)  # noqa: S603
-    with sqlite3.connect(_REBUILT_DB_PATH) as new_db_conn, new_db_conn as new_db_cur:
-        if recover_proc.stdout:
-            for line in recover_proc.stdout:
-                row = line.decode().strip()
-                replaced_row = (
-                    "PRAGMA writable_schema = reset;"
-                    if row == "PRAGMA writable_schema = off;"
-                    else row
-                )
-                new_db_cur.execute(replaced_row)
-    if recover_proc.stdout:
-        recover_proc.stdout.close()
-        recover_proc.wait(timeout=15)
+    with subprocess.Popen(  # noqa: S603
+        _REPAIR_ARGS, stdout=subprocess.PIPE
+    ) as recover_proc:
+        try:
+            stdout, _stderr = recover_proc.communicate(timeout=_REPAIR_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            recover_proc.kill()
+            recover_proc.wait()
+            logger.exception("sqlite3 .recover timed out; aborting rebuild.")
+            return False
+
+    if recover_proc.returncode != 0:
+        logger.error(
+            f"sqlite3 .recover exited with status {recover_proc.returncode}; aborting rebuild."
+        )
+        return False
+
+    sql = stdout.decode()
+    # ``.recover`` emits ``PRAGMA writable_schema = off;`` at the
+    # tail; ``reset`` is the form sqlite3 expects after a recovery
+    # write so the schema cache rebuilds cleanly.
+    sql = sql.replace(
+        "PRAGMA writable_schema = off;",
+        "PRAGMA writable_schema = reset;",
+    )
+    with sqlite3.connect(_REBUILT_DB_PATH) as new_db_conn:
+        new_db_conn.executescript(sql)
 
     backup_path = _get_backup_db_path("before-rebuild")
     DB_PATH.rename(backup_path)
-    logger.info("Backed up old db to %s", backup_path)
+    logger.info(f"Backed up old db to {backup_path}")
     _REBUILT_DB_PATH.replace(DB_PATH)
     _REPAIR_FLAG_PATH.unlink(missing_ok=True)
     logger.success("Rebuilt database. You may start codex normally now.")
     return True
+
+
+def _warn_on_stale_wal_siblings() -> None:
+    """
+    Surface stale WAL/SHM/journal siblings before the first connect.
+
+    SQLite treats those siblings as part of the database — every
+    open replays whatever's in them on top of the main file. If a
+    previous codex run was killed before clean shutdown (or a
+    backup got dropped in next to leftover siblings), the merged
+    state is internally inconsistent and the very first SQL Django
+    runs after ``Database.connect`` raises
+    ``sqlite3.DatabaseError: database disk image is malformed``.
+    The wording is misleading: the main file alone is fine.
+
+    A single ``ls``-shaped probe at the top of ``ensure_db_schema``
+    converts that experience from a stack trace with no signal to a
+    one-line warning that names the recovery action. We don't
+    auto-delete: stale-looking siblings can also be a legitimate
+    in-flight WAL from a fast restart, and silently nuking them
+    would lose the last unckpointed transaction.
+    """
+    siblings = [
+        DB_PATH.with_name(DB_PATH.name + suffix)
+        for suffix in _DB_SIBLING_SUFFIXES
+    ]
+    present = [s for s in siblings if s.exists()]
+    if not present:
+        return
+    main_mtime = DB_PATH.stat().st_mtime if DB_PATH.exists() else 0.0
+    suspicious = [s for s in present if s.stat().st_mtime > main_mtime]
+    if not suspicious:
+        return
+    suspicious_names = ", ".join(s.name for s in suspicious)
+    cleanup_cmd = f"rm {DB_PATH}-wal {DB_PATH}-shm {DB_PATH}-journal"
+    msg = (
+        f"Stale SQLite siblings found newer than {DB_PATH.name}: {suspicious_names}."
+        " These are usually left by a previous startup that was killed before clean"
+        " shutdown, or by dropping a backup file next to leftover sibling files. If"
+        " the next step fails with 'database disk image is malformed', remove them"
+        f" with `{cleanup_cmd}` and try again."
+    )
+    logger.warning(msg)
 
 
 def _migrate_silk_db() -> None:
@@ -142,6 +215,7 @@ def _migrate_silk_db() -> None:
 def ensure_db_schema() -> bool:
     """Ensure the db is good and up to date."""
     logger.info("Ensuring database is correct and up to date...")
+    _warn_on_stale_wal_siblings()
     table_names = connection.introspection.table_names()
     if "django_migrations" in table_names:
         # Cache the unapplied-migrations result so the backup,


### PR DESCRIPTION
## Summary

Two small startup hardening changes from a debugging session that burned an embarrassing amount of time on a stale-WAL pollution.

### 1. Warn on stale WAL/SHM siblings before the first connect

When a backup is dropped on top of an existing ``codex.sqlite3`` (e.g., during alpha-version rollback testing), or a previous startup was killed before clean shutdown, leftover ``-wal`` / ``-shm`` / ``-journal`` siblings silently merge into the next open. The combined state is inconsistent and SQLite raises ``database disk image is malformed`` from *inside Django's ``register_functions`` probe* — before any of codex's own integrity checks get a chance to run, and without any log line pointing at the real cause.

``_warn_on_stale_wal_siblings`` fires before ``connection.introspection.table_names()`` in ``ensure_db_schema``. Detects siblings whose mtime is *newer* than the main DB file (the signal that they're not just a normal in-flight WAL waiting to checkpoint), logs one WARNING that names the recovery command. We don't auto-delete: a stale-looking ``-wal`` can also be a legitimate fast-restart WAL, and silently nuking it would lose the last uncheckpointed transaction. The warning lets the operator make the call.

### 2. ``_rebuild_db`` actually works now

The drastic recovery path (gated on the ``/config/rebuild_db`` sentinel file) piped ``sqlite3 .recover`` output through ``cursor.execute`` **one line at a time**. ``.recover`` happily emits multi-line ``CREATE TABLE`` / ``CREATE TRIGGER`` definitions, and the first such statement broke the rebuild with:

```
sqlite3.OperationalError: near ".": syntax error
```

…because the first line of a ``CREATE TABLE foo(`` is, on its own, a syntax error. So the only recovery path the code offers in the corruption case has been broken for a while.

Fix: read the recovery script as a single SQL blob and feed it to ``executescript``, which parses multi-statement scripts the way the SQLite CLI does. Also raise the subprocess timeout from 15s to 300s so a real-sized library actually finishes the recovery, and wrap the subprocess in a ``with`` block so it always gets cleaned up on error.

## Test plan

- [x] ``make test-python T=tests/importer/`` — green.
- [x] ``ruff check``, ``basedpyright`` — clean.
- [ ] Drop a stale ``-wal`` sibling next to a fresh ``codex.sqlite3`` and start codex; confirm the warning fires and names the recovery command.
- [ ] Touch ``/config/rebuild_db`` and start codex against an actually-corrupt DB; confirm the rebuild now completes for a schema that includes multi-line CREATE definitions (which codex's schema does — ``CREATE TABLE codex_comic`` is several dozen columns spread across many lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)