### PR TITLE
Move folders: log phantom-move collisions as INFO + DEBUG, not WARNING

### DIFF
--- a/codex/librarian/scribe/importer/moved/folders.py
+++ b/codex/librarian/scribe/importer/moved/folders.py
@@ -134,7 +134,24 @@ class MovedFoldersImporter(MovedCoversImporter):
         return frozenset(create_folder_paths_one_layer)
 
     def _remove_move_collisions(self, dirs_moved: bidict[str, str]) -> None:
-        """Remove moves that would collide with an existing Folder."""
+        """
+        Remove moves whose destination already exists as a Folder.
+
+        The poller emits ``dirs_moved`` for inode-matched
+        delete/add pairs. A "destination already exists in the DB"
+        case means the destination path is already a known Folder
+        — moving the source on top of it would explode the
+        ``(library, path)`` unique constraint and isn't useful
+        anyway, since the destination is already correctly tracked.
+        Drop the move from ``dirs_moved`` and let any actual
+        disk-side absence of the source path fall out via the
+        regular delete pass on a subsequent cycle.
+
+        This is normal reconciliation, not a fault — log at INFO
+        with a count summary and at DEBUG with the path list. The
+        previous WARNING was loud enough to make operators think
+        something was broken when nothing was.
+        """
         dest_paths = set(dirs_moved.values())
         collision_dest_paths = Folder.objects.filter(
             library=self.library, path__in=dest_paths
@@ -144,9 +161,14 @@ class MovedFoldersImporter(MovedCoversImporter):
         collision_dest_paths = sorted(set(collision_dest_paths))
         for collision_dest_path in collision_dest_paths:
             dirs_moved.inverse.pop(collision_dest_path, None)
-        self.log.warning(
-            f"Not moving folders to destinations that would collide with existing database folders: {collision_dest_paths}"
+        count = len(collision_dest_paths)
+        plural = "s" if count != 1 else ""
+        msg = (
+            f"Resolved {count} phantom folder move{plural} by skipping the "
+            "rename and leaving the destinations in place."
         )
+        self.log.info(msg)
+        self.log.debug(f"Skipped folder move destinations: {collision_dest_paths}")
 
     def _bulk_move_folders_and_create_parents(self, status) -> int:
         """Find folders that can be moved without creating parents."""


### PR DESCRIPTION
## Summary

The poller emits ``dirs_moved`` for inode-matched delete/add pairs. When the destination path of a "move" is already a known ``Folder`` row, [``_remove_move_collisions``](codex/librarian/scribe/importer/moved/folders.py:136) correctly drops the move (it would explode the ``(library, path)`` unique constraint, and isn't needed — the destination is already correctly tracked) and lets the source-side absence fall out via the next delete pass.

This is normal reconciliation, not a fault. The previous WARNING made it look like something had gone wrong:

```
2026-05-02 03:54:40 | WARNING | Not moving folders to destinations that would collide with existing database folders: ['/comics/Dynamite Entertainment/James Bond Agent of SPECTRE (2021)', …]
```

…and prompted operators to investigate something that needed no investigating.

## Change

* One-line INFO: ``Resolved 3 phantom folder moves by skipping the rename and leaving the destinations in place.``
* DEBUG with the actual path list, for anyone who does want to see which folders were involved.

Same data, healthier signal-to-noise.

## Test plan

- [x] ``make test-python T=tests/importer/`` — green.
- [x] ``ruff check``, ``basedpyright`` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)