### PR TITLE
run: silence asyncio CancelledError from disconnected clients

### DIFF
--- a/codex/run.py
+++ b/codex/run.py
@@ -114,8 +114,26 @@ async def _watch_for_changes() -> None:
         break
 
 
+def _silence_disconnects(loop: asyncio.AbstractEventLoop, context: dict) -> None:
+    """
+    Drop CancelledError from unretrieved shielded futures.
+
+    asgiref's ``SyncToAsync`` adapter shields the executor coroutine
+    running a sync Django view. On client disconnect the outer task is
+    cancelled; the inner future continues (sync work in a thread can't
+    be cancelled), completes, and is then unretrieved — and asyncio's
+    default handler logs that as "CancelledError exception in shielded
+    future". The work itself isn't lost; there's just no client to hand
+    the response to. Silencing keeps user-facing logs uncluttered.
+    """
+    if isinstance(context.get("exception"), asyncio.CancelledError):
+        return
+    loop.default_exception_handler(context)
+
+
 async def _serve(server: Server) -> None:
     """Run granian until SHUTDOWN_EVENT fires, then stop gracefully."""
+    asyncio.get_running_loop().set_exception_handler(_silence_disconnects)
     server_task = asyncio.create_task(server.serve())
     if WATCH_FOR_CHANGES:
         watch_task = asyncio.create_task(_watch_for_changes())


### PR DESCRIPTION
## Summary

Codex was logging `CancelledError exception in shielded future` at ERROR level whenever a client disconnected mid-request — alarming in user-facing logs but functionally a no-op.

## What's actually happening

Granian + asgiref's `SyncToAsync` adapter shields the executor coroutine running a sync Django view (`asyncio.shield(loop.run_in_executor(...))`). When the browser cancels an in-flight request (scrolling past covers, navigating away):

1. Granian cancels the request task → cancellation propagates to `await asyncio.shield(exec_coro)`.
2. `shield` raises `CancelledError` to the awaiter.
3. The inner `exec_coro`, running sync work in a thread, **can't be cancelled** (Python threads have no external interrupt) — it runs to completion, generates the response, and the response is silently discarded at the socket level.
4. The completed inner future is now unretrieved → asyncio's default exception handler logs it at ERROR.

Result in user logs:

```
ERROR | MainThread:asyncio.base_events:default_exception_handler:1886 |
  CancelledError exception in shielded future
  future: <Future finished exception=CancelledError() ...
```

No work is lost. The disconnect is the user's choice.

## Change

Install a custom loop exception handler in `_serve` that drops `CancelledError` contexts and delegates everything else to the default handler. Surgical — only `CancelledError` is suppressed, real exceptions still surface.

```python
def _silence_disconnects(loop, context):
    if isinstance(context.get("exception"), asyncio.CancelledError):
        return
    loop.default_exception_handler(context)
```

## Test plan

- [x] `make lint` — Python clean (only pre-existing `remark` error on `.`)
- [x] `make ty` — `All checks passed!`
- [x] `make test-python` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)