### PR TITLE
cache: tolerate corrupt cache files + silence granian close-frame DEBUG

### DIFF
--- a/codex/cache.py
+++ b/codex/cache.py
@@ -1,0 +1,54 @@
+"""
+Cache backends.
+
+Django's ``FileBasedCache`` treats a corrupt cache file as fatal: a
+truncated zlib stream or a partial pickle bubbles up as ``zlib.error``
+or ``pickle.UnpicklingError``, which then crashes whatever query
+happened to fall on that key. A corrupt entry is rare but inevitable
+(a write killed mid-flush leaves a file Django can't decompress) and
+the right behaviour is just "treat it as a miss".
+
+``ResilientFileBasedCache`` catches those decode errors, deletes the
+bad file, and reports a miss so the caller continues with the
+underlying query instead of returning a 500 to the user.
+"""
+
+import zlib
+from pickle import UnpicklingError
+from typing import override
+
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+from django.core.cache.backends.filebased import FileBasedCache
+from loguru import logger
+
+_CORRUPT_CACHE_ERRORS: tuple[type[BaseException], ...] = (
+    zlib.error,
+    UnpicklingError,
+    EOFError,
+)
+
+
+class ResilientFileBasedCache(FileBasedCache):
+    """Cache backend that tolerates corrupt cache entries."""
+
+    def _discard_corrupt(self, fname: str, exc: BaseException) -> None:
+        logger.debug(f"Discarded corrupt cache file {fname}: {exc}")
+        self._delete(fname)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+
+    @override
+    def get(self, key, default=None, version=None):
+        try:
+            return super().get(key, default=default, version=version)
+        except _CORRUPT_CACHE_ERRORS as exc:
+            fname = self._key_to_file(key, version)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+            self._discard_corrupt(fname, exc)
+            return default
+
+    @override
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
+        try:
+            return super().touch(key, timeout=timeout, version=version)
+        except _CORRUPT_CACHE_ERRORS as exc:
+            fname = self._key_to_file(key, version)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
+            self._discard_corrupt(fname, exc)
+            return False

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -665,7 +665,7 @@ DEFAULT_CACHE_PATH.mkdir(exist_ok=True, parents=True)
 # cheap at cull time (FileBasedCache walks the dir — negligible at 10k).
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "BACKEND": "codex.cache.ResilientFileBasedCache",
         "LOCATION": str(DEFAULT_CACHE_PATH),
         "OPTIONS": {"MAX_ENTRIES": 10000},
     },

--- a/codex/settings/logging.py
+++ b/codex/settings/logging.py
@@ -38,6 +38,13 @@ def get_logging_settings(loglevel: str | int, *, debug: bool) -> dict[str, int |
                 "asyncio": {
                     "level": "INFO",
                 },
+                # Granian's Rust core emits DEBUG noise for routine
+                # WebSocket close frames (a client disconnecting fires
+                # "Received close frame" + "Replying to close"). Not
+                # actionable; visible only at TRACE.
+                "_granian": {
+                    "level": "INFO",
+                },
             }
         )
     if not debug:


### PR DESCRIPTION
## Summary

- A truncated zlib stream in the Django file cache (left by a write killed mid-flush) was bubbling up to users as `zlib.error: Error -5 while decompressing data: incomplete or truncated stream` with a full traceback. New `ResilientFileBasedCache` treats a corrupt entry as a miss, deletes the bad file, and logs at DEBUG instead of failing the request.
- Silenced Granian's routine `Received close frame` / `Replying to close` DEBUG noise (every normal client disconnect emits two lines). Pinned `_granian` to INFO alongside the existing `asyncio` entry; still visible at TRACE.

## Test plan

- [x] `make fix`, `make ty`, `make test-python` (26 passed) all green
- [x] Smoke-tested the new cache backend: a deliberately truncated `.djcache` file at the same path shape as the production traceback is silently dropped; `get_many` returns the surviving keys
- [x] Verified `_granian` effective level is `INFO` after `dictConfig(LOGGING)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)