### PR TITLE
spa: self-heal stale chunk references after deploys

### DIFF
--- a/codex/views/frontend.py
+++ b/codex/views/frontend.py
@@ -31,4 +31,9 @@ class IndexView(BrowserSettingsBaseView, UserActiveMixin):
             "last_route": self._get_last_route(),
         }
         self.mark_user_active()
-        return Response(extra_context)
+        response = Response(extra_context)
+        # Force revalidation so deploys with new hashed chunk filenames are
+        # picked up immediately. Hashed /static/assets/* files remain
+        # immutable-cached via servestatic.
+        response["Cache-Control"] = "no-cache"
+        return response

--- a/frontend/src/plugins/router.js
+++ b/frontend/src/plugins/router.js
@@ -80,4 +80,36 @@ router.afterEach((to) => {
   }
 });
 
+// Self-heal stale chunk references after a deploy: when a lazy-loaded route
+// component fails to fetch (because its hashed filename no longer exists on
+// the server), force a full page load so the browser pulls a fresh index.html.
+const CHUNK_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+];
+const CHUNK_RELOAD_KEY = "codex-chunk-reload-path";
+
+const isChunkLoadError = (error) => {
+  const message = error?.message ?? String(error ?? "");
+  return CHUNK_ERROR_PATTERNS.some((re) => re.test(message));
+};
+
+router.onError((error, to) => {
+  if (!isChunkLoadError(error)) {
+    return;
+  }
+  const path = to?.fullPath ?? globalThis.location.pathname;
+  // Guard against reload loops if the fresh fetch still fails.
+  if (sessionStorage.getItem(CHUNK_RELOAD_KEY) === path) {
+    return;
+  }
+  sessionStorage.setItem(CHUNK_RELOAD_KEY, path);
+  globalThis.location.assign(path);
+});
+
+router.afterEach(() => {
+  sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+});
+
 export default router;


### PR DESCRIPTION
## Summary

After a deploy with new hashed chunk filenames, a browser holding a
cached `index.html` still requests the old `/static/assets/<name>-<hash>.js`.
The server returns the SPA shell (`text/html`) for the missing path, and
the dynamic import fails with a MIME-type error — the reader (and any
other lazy-loaded route) silently refuses to open until the user
force-refreshes.

Two complementary fixes:

- **frontend** ([frontend/src/plugins/router.js](frontend/src/plugins/router.js)) — `router.onError` catches the three known chunk-load error patterns (`Failed to fetch dynamically imported module`, `error loading dynamically imported module`, `Importing a module script failed`) and runs `globalThis.location.assign(path)` to force a full reload to the target route. A `sessionStorage` flag prevents reload loops if the second fetch also fails; the flag clears on the next successful navigation.
- **backend** ([codex/views/frontend.py](codex/views/frontend.py)) — `IndexView.get()` now emits `Cache-Control: no-cache`, so browsers always revalidate the SPA shell and pick up new chunk references on the next load. The hashed `/static/assets/*` files retain their immutable cache via `servestatic` ([codex/settings/servestatic.py](codex/settings/servestatic.py)).

Net effect on the next deploy: chunk 404s → router silently full-reloads → fresh `index.html` arrives with new hashes → reader opens. No force-refresh required.

## Test plan

- [ ] Deploy to staging, navigate into the reader, then bump versions and redeploy. Without a force refresh, clicking into another comic should reload the page once and land on the reader.
- [ ] Confirm `/` and `/<group>/<pks>/<page>` responses include `Cache-Control: no-cache`.
- [ ] Confirm `/static/assets/*.js` responses still carry the long-lived immutable cache headers from servestatic.
- [ ] Verify normal navigation between routes still works (no spurious reloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)