### PR TITLE
fix(tests): update test_update_all for missing identifier URLs

### DIFF
--- a/tests/importer/test_update_all.py
+++ b/tests/importer/test_update_all.py
@@ -166,7 +166,7 @@ AGGREGATED_UPDATE_ALL = MappingProxyType(
                     ("https://metron.cloud/creator/123",),
                 },
                 ("metron", "genre", "012"): {
-                    ("https://metron.cloud/genre/012",),
+                    (None,),
                 },
                 ("metron", "imprint", "123"): {
                     ("https://metron.cloud/imprint/123",),
@@ -175,7 +175,7 @@ AGGREGATED_UPDATE_ALL = MappingProxyType(
                     ("https://metron.cloud/publisher/111",),
                 },
                 ("metron", "story", "555"): {
-                    ("https://metron.cloud/story/555",),
+                    (None,),
                 },
             },
             Publisher: {
@@ -335,10 +335,10 @@ QUERIED_UPDATE_ALL = MappingProxyType(
                 ("metron", "character", "123", "https://metron.cloud/character/123"),
                 ("metron", "comic", "999", "https://metron.cloud/issue/999"),
                 ("metron", "creditperson", "123", "https://metron.cloud/creator/123"),
-                ("metron", "genre", "012", "https://metron.cloud/genre/012"),
+                ("metron", "genre", "012", None),
                 ("metron", "imprint", "123", "https://metron.cloud/imprint/123"),
                 ("metron", "publisher", "111", "https://metron.cloud/publisher/111"),
-                ("metron", "story", "555", "https://metron.cloud/story/555"),
+                ("metron", "story", "555", None),
             },
             Language: {("fr",)},
             AgeRating: {("Adult",)},


### PR DESCRIPTION
## Summary
- The comicbox alpha bump (c28a84a3) dropped URLs from two metron tag identifiers: Science Fiction's `genre/012` and The Beginning's `story/555`. They still carry source/type/key but no longer carry a `url`.
- Update the `AGGREGATED_UPDATE_ALL` and `QUERIED_UPDATE_ALL` fixtures in `test_update_all.py` so URL is `None` for those two identifiers, restoring `tests/importer/test_update_all.py::TestImporterUpdateAll::test_update_all`.

## Test plan
- [x] `uv run --group test pytest tests/importer/ --no-cov` — all 3 importer tests pass.
- [x] `uv run --group lint ruff check tests/importer/test_update_all.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)