### PR TITLE
logging: silence tungstenite/tokio_tungstenite DEBUG noise too

### DIFF
--- a/codex/settings/logging.py
+++ b/codex/settings/logging.py
@@ -42,7 +42,21 @@ def get_logging_settings(loglevel: str | int, *, debug: bool) -> dict[str, int |
                 # WebSocket close frames (a client disconnecting fires
                 # "Received close frame" + "Replying to close"). Not
                 # actionable; visible only at TRACE.
+                #
+                # ``_granian`` covers the granian crate; ``tungstenite``
+                # and ``tokio_tungstenite`` cover the underlying WS
+                # crates that emit the ``Received close frame`` /
+                # ``Replying to close`` / ``Sending after closing is
+                # not allowed`` messages directly. pyo3-log maps Rust
+                # ``::`` separators to Python ``.`` so these names
+                # apply hierarchically to all submodules.
                 "_granian": {
+                    "level": "INFO",
+                },
+                "tungstenite": {
+                    "level": "INFO",
+                },
+                "tokio_tungstenite": {
                     "level": "INFO",
                 },
             }


### PR DESCRIPTION
## Summary

The earlier `_granian` filter ([#704](https://github.com/ajslater/codex/pull/704)) didn't actually silence the WebSocket close-frame DEBUG noise users were still seeing. Those messages originate from the `tungstenite` / `tokio_tungstenite` crates that Granian uses for its WS layer, not from `_granian` itself.

```
DEBUG | Received close frame: Some(CloseFrame { code: Normal, … })
DEBUG | Replying to close with Frame { … Control(Close) … }
DEBUG | websocket start_send error: WebSocket protocol error: Sending after closing is not allowed
```

pyo3-log routes Rust tracing targets to Python loggers, mapping `::` → `.`, so e.g. `tungstenite::protocol` arrives as the Python logger `tungstenite.protocol`. Filtering the bare crate name applies hierarchically to all submodules.

## Test plan

- [x] `make lint-python` clean
- [x] `make ty` clean
- [x] `pytest tests/` clean (26 passed)
- [x] Apply the dictConfig in a Python REPL and confirm:
  - `tungstenite.protocol` effective level → `INFO`, `isEnabledFor(DEBUG) → False`
  - `tokio_tungstenite.compat` effective level → `INFO`, `isEnabledFor(DEBUG) → False`
  - `_granian.asgi.io` effective level → `INFO` (existing filter still works)
  - root effective level → `DEBUG` (codex code unaffected)
- [ ] Verify in production Docker that the close-frame DEBUG lines no longer appear

## Note

`make lint` (the wrapping script, not the underlying tools) errors on `nginx/http.d` with "Cannot process specified file: it's ignored" — reproducible without my changes, so unrelated. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)