### PR TITLE
auth: ensure every User has a UserAuth row + raise asyncio slow-callback threshold

### DIFF
--- a/codex/librarian/bookmark/user_active.py
+++ b/codex/librarian/bookmark/user_active.py
@@ -22,20 +22,22 @@ class UserActiveMixin:
         """
         Update user active timestamp on the user's :class:`UserAuth` row.
 
-        ``UserAuth`` rows are provisioned by
-        :meth:`AdminUserViewSet.perform_create` at user creation time, so
-        the row is guaranteed to exist for any logged-in pk reaching the
-        bookmark thread. ``filter().update()`` is one round trip vs the
-        prior ``User.objects.get`` + ``update_or_create`` (which fired
+        ``UserAuth`` rows are provisioned by the User ``post_save`` signal
+        in :mod:`codex.signals.django_signals` for every creation path
+        (admin UI, ``createsuperuser``, fixtures), and existing users were
+        backfilled by migration 0039, so the row is guaranteed to exist
+        for any logged-in pk reaching the bookmark thread.
+        ``filter().update()`` is one round trip vs the prior
+        ``User.objects.get`` + ``update_or_create`` (which fired
         SELECT + SELECT + UPDATE-or-INSERT). Mirrors the
         ``UserAuth`` / ``GroupAuth`` write-path pattern from
         admin-views-perf PR #610.
 
         ``auto_now=True`` on ``BaseModel.updated_at`` only fires on
         ``save()`` — ``.update()`` skips it — so pass the timestamp
-        explicitly. A missing row is a silent no-op (the create flow
-        broke its invariant; logging it surfaces the data integrity
-        issue rather than masking it with ``update_or_create``).
+        explicitly. A missing row remains a silent no-op with a warning
+        — at this point it points to a real data integrity issue worth
+        surfacing.
         """
         last_recorded = self._user_active_recorded.get(pk, EPOCH_START)
         now = django_timezone.now()

--- a/codex/migrations/0039_metron_age_rating_default_view_and_performance.py
+++ b/codex/migrations/0039_metron_age_rating_default_view_and_performance.py
@@ -8,7 +8,15 @@ Introduce :class:`AgeRatingMetron` and per-user age-rating ACL.
   row's ``name`` via comicbox's ``to_metron_age_rating()``.
 - Renames ``UserActive`` → ``UserAuth`` and adds ``UserAuth.age_rating_metron``
   FK (``SET_NULL``, nullable) — the per-user age-rating ceiling (null =
-  unrestricted).
+  unrestricted). Backfills a default ``UserAuth`` row for every
+  existing :class:`User` that doesn't have one — pre-0039
+  ``UserActive`` rows were created lazily on first activity, so users
+  provisioned via ``manage.py createsuperuser`` (or any path that
+  bypassed the admin web UI) had no row. The new invariant ("every
+  User has a UserAuth") is enforced going forward by a ``post_save``
+  signal in :mod:`codex.signals.django_signals`; the backfill brings
+  legacy rows into compliance so the bookmark thread's activity touch
+  is silent for all users.
 - Renames ``SettingsBrowserFilters.age_rating`` to ``age_rating_tagged``
   and adds the parallel ``age_rating_metron`` JSON column (stores PKs
   of :class:`AgeRatingMetron` rows now — prior scheme stored metron
@@ -301,6 +309,36 @@ def _backfill_age_rating_metron_fk(apps, _schema_editor) -> None:
         age_rating_model.objects.bulk_update(
             to_update, ["metron_id"], batch_size=_CHUNK
         )
+
+
+def _backfill_userauth(apps, schema_editor) -> None:
+    """
+    Provision a default :class:`UserAuth` row for every User missing one.
+
+    Pre-0039 ``UserActive`` rows were created lazily on first activity,
+    so any User that never bookmarked / never showed up to the bookmark
+    thread had no row. The most visible case is admins provisioned via
+    ``manage.py createsuperuser``, which bypassed the admin web UI's
+    explicit ``UserAuth.objects.create``. The bookmark thread emits
+    "No UserAuth row" warnings on every activity touch for those users.
+
+    The new ``post_save`` signal in :mod:`codex.signals.django_signals`
+    enforces the invariant going forward; this backfill heals the
+    legacy gap.
+    """
+    User = apps.get_model("auth", "User")
+    UserAuth = apps.get_model("codex", "UserAuth")
+    db = schema_editor.connection.alias
+
+    existing = set(
+        UserAuth.objects.using(db).values_list("user_id", flat=True),
+    )
+    missing = (
+        User.objects.using(db).exclude(pk__in=existing).values_list("pk", flat=True)
+    )
+    rows = [UserAuth(user_id=pk) for pk in missing]
+    if rows:
+        UserAuth.objects.using(db).bulk_create(rows)
 
 
 def _backfill_age_rating_metron_flag_fk(apps, _schema_editor) -> None:
@@ -943,6 +981,11 @@ class Migration(migrations.Migration):
                 to="codex.ageratingmetron",
             ),
         ),
+        # Backfill a default UserAuth row for any User missing one.
+        # Heals the legacy gap from the lazy-create UserActive era so
+        # the bookmark thread's activity touch is silent for everyone
+        # (e.g. admins provisioned via ``createsuperuser``).
+        migrations.RunPython(_backfill_userauth, _noop),
         # SettingsBrowserFilters: rename tagged filter, add metron filter
         migrations.RenameField(
             model_name="settingsbrowserfilters",

--- a/codex/run.py
+++ b/codex/run.py
@@ -133,7 +133,17 @@ def _silence_disconnects(loop: asyncio.AbstractEventLoop, context: dict) -> None
 
 async def _serve(server: Server) -> None:
     """Run granian until SHUTDOWN_EVENT fires, then stop gracefully."""
-    asyncio.get_running_loop().set_exception_handler(_silence_disconnects)
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(_silence_disconnects)
+    # ``PYTHONDEVMODE=1`` (set by bin/dev-server.sh when DEBUG=1) flips
+    # asyncio into debug mode, which logs WARNINGs whenever a callback
+    # exceeds ``slow_callback_duration`` (default 100ms). Codex routes
+    # most requests through asgiref's ``AsyncToSync`` adapter — a sync
+    # Django view on a thread pool, awaited from the loop — and a DB-
+    # heavy view crossing 100ms is routine, not anomalous. Keep the
+    # warning useful (a >5s callback is a real bug worth surfacing)
+    # without spamming on every normal request.
+    loop.slow_callback_duration = 5.0
     server_task = asyncio.create_task(server.serve())
     if WATCH_FOR_CHANGES:
         watch_task = asyncio.create_task(_watch_for_changes())

--- a/codex/serializers/admin/users.py
+++ b/codex/serializers/admin/users.py
@@ -63,12 +63,11 @@ class UserSerializer(BaseModelSerializer, PasswordSerializerMixin):
         """
         Apply nested :class:`UserAuth` fields with a single ``UPDATE``.
 
-        :class:`UserAuth` rows are created by
-        :meth:`AdminUserViewSet.perform_create` on user creation, so the
-        row is guaranteed to exist on update. ``filter().update()`` is
-        one round trip vs ``get_or_create`` + ``save`` — and a missing
-        auth row stays a no-op rather than re-creating a default one
-        (which would mask a data-integrity issue from the create path).
+        :class:`UserAuth` rows are provisioned by the User ``post_save``
+        signal in :mod:`codex.signals.django_signals` for every creation
+        path (admin UI, ``createsuperuser``, fixtures), so the row is
+        guaranteed to exist on update. ``filter().update()`` is one
+        round trip vs ``get_or_create`` + ``save``.
         """
         if not userauth_data or "age_rating_metron" not in userauth_data:
             return

--- a/codex/signals/django_signals.py
+++ b/codex/signals/django_signals.py
@@ -11,10 +11,37 @@ def _on_library_changed(*_args, **_kwargs) -> None:
     invalidate_libraries_exist_cache()
 
 
+def _ensure_user_auth(sender, instance, created, **_kwargs) -> None:
+    """
+    Provision a :class:`UserAuth` row alongside every newly-created User.
+
+    Centralises the invariant "every User has a UserAuth" so all
+    creation paths satisfy it: ``manage.py createsuperuser``, the
+    admin web UI's ``perform_create``, fixtures, factory_boy, ad-hoc
+    shell sessions. Previously only the admin UI created the row,
+    leaving ``createsuperuser``-provisioned admins without one — and
+    triggering "No UserAuth row for user pk=N" warnings from the
+    bookmark thread on every activity touch.
+
+    ``get_or_create`` keeps the handler idempotent: a duplicate
+    ``post_save`` (e.g. fixture loaders that re-save) won't IntegrityError
+    on the OneToOne unique constraint.
+    """
+    del sender
+    if not created:
+        return
+    from codex.models.auth import UserAuth
+
+    UserAuth.objects.get_or_create(user=instance)
+
+
 def connect_signals() -> None:
     """Connect actions to signals."""
     # Imported lazily for the same reason as above.
+    from django.contrib.auth import get_user_model
+
     from codex.models import Library
 
     post_save.connect(_on_library_changed, sender=Library)
     post_delete.connect(_on_library_changed, sender=Library)
+    post_save.connect(_ensure_user_auth, sender=get_user_model())

--- a/codex/views/admin/user.py
+++ b/codex/views/admin/user.py
@@ -85,13 +85,15 @@ class AdminUserViewSet(AdminModelViewSet):
 
     @override
     def perform_create(self, serializer) -> None:
-        """Create user with a matching :class:`UserAuth` row."""
+        """Create user; ``UserAuth`` is provisioned by post_save signal."""
         validated_data = serializer.validated_data
         password = validated_data["password"]
         validate_password(password)
         groups = validated_data.pop("groups")
-        # Pop nested userauth data before handing to create_user; pass
-        # through to the UserAuth row we create alongside.
+        # Pop nested userauth data before handing to create_user; the
+        # post_save signal in ``codex.signals.django_signals`` provisions
+        # an empty UserAuth row, which we then patch with the
+        # admin-supplied ceiling if any.
         userauth_data = validated_data.pop("userauth", {})
         validated_data["email"] = ""
         user = User.objects.create_user(**validated_data)
@@ -99,10 +101,10 @@ class AdminUserViewSet(AdminModelViewSet):
             user.groups.set(groups)
             user.save()
         Token.objects.create(user=user)
-        UserAuth.objects.create(
-            user=user,
-            age_rating_metron=userauth_data.get("age_rating_metron"),
-        )
+        if "age_rating_metron" in userauth_data:
+            UserAuth.objects.filter(user=user).update(
+                age_rating_metron=userauth_data["age_rating_metron"],
+            )
 
 
 class AdminUserChangePasswordView(AdminGenericAPIView):

--- a/tests/test_admin_query_counts.py
+++ b/tests/test_admin_query_counts.py
@@ -25,7 +25,7 @@ from django.db import connection
 from django.test import Client, TestCase
 from django.test.utils import CaptureQueriesContext
 
-from codex.models.auth import GroupAuth, UserAuth
+from codex.models.auth import GroupAuth
 
 # Test-only password — short, fixed, and never deployed. Hush
 # bandit's hardcoded-password warning at the call sites.
@@ -45,18 +45,19 @@ class AdminListQueryCountTestCase(TestCase):
     @override
     def setUp(self) -> None:
         """Create an admin + a small fixture set of users / groups."""
+        # ``UserAuth`` rows are auto-provisioned by the User ``post_save``
+        # signal (see codex.signals.django_signals), so we don't create
+        # them explicitly here.
         self.admin = User.objects.create_user(  # pyright: ignore[reportUninitializedInstanceVariable]
             username="admin_query_count_admin",
             password=_TEST_PASSWORD,
             is_staff=True,
             is_superuser=True,
         )
-        UserAuth.objects.create(user=self.admin)
         for i in range(3):
-            user = User.objects.create_user(
+            User.objects.create_user(
                 username=f"admin_query_count_user{i}", password=_TEST_PASSWORD
             )
-            UserAuth.objects.create(user=user)
         for i in range(3):
             group = Group.objects.create(name=f"group{i}")
             GroupAuth.objects.create(group=group)

--- a/tests/test_age_rating_acl.py
+++ b/tests/test_age_rating_acl.py
@@ -126,18 +126,23 @@ class AgeRatingACLTestCase(TestCase):
         self.comic_unknown = _comic_with("unknown", unknown)  # pyright: ignore[reportUninitializedInstanceVariable]
 
         # Users: ``teen_user`` has a Teen ceiling, ``open_user`` has none.
+        # ``UserAuth`` rows are auto-provisioned by the User ``post_save``
+        # signal (see codex.signals.django_signals); we just patch the
+        # ceiling on the auto-created row for ``teen_user``. ``open_user``
+        # gets the default (None ⇒ unrestricted) without any extra work.
         self.teen_user = User.objects.create_user(  # pyright: ignore[reportUninitializedInstanceVariable]
             username="teen",
             password="x",  # noqa: S106
         )
         teen_metron = AgeRatingMetron.objects.get(name=MetronAgeRatingEnum.TEEN.value)
-        UserAuth.objects.create(user=self.teen_user, age_rating_metron=teen_metron)
+        UserAuth.objects.filter(user=self.teen_user).update(
+            age_rating_metron=teen_metron
+        )
 
         self.open_user = User.objects.create_user(  # pyright: ignore[reportUninitializedInstanceVariable]
             username="open",
             password="x",  # noqa: S106
         )
-        UserAuth.objects.create(user=self.open_user, age_rating_metron=None)
 
         # Default flag = Everyone (matches the new seed); tests that need
         # a looser or tighter default override via ``_set_flag``.
@@ -299,12 +304,16 @@ class MigrationShapeTestCase(TestCase):
     up an executor manually.
     """
 
-    def test_user_auth_table_exists_and_is_empty(self) -> None:
-        """``UserActive`` was renamed (not dropped+created) ⇒ no fixture data."""
-        # Rename-then-add-field keeps the row set; the test DB starts
-        # clean so this is zero regardless, but we still assert the
-        # model responds to queries (table exists).
-        assert UserAuth.objects.count() == 0
+    def test_user_auth_row_exists_for_every_user(self) -> None:
+        """0039 backfills UserAuth for every existing User."""
+        # ``UserActive`` was renamed (not dropped+created), then 0039
+        # backfills a default ``UserAuth`` row for any User missing one
+        # — heals the legacy lazy-create gap so the bookmark thread's
+        # activity touch is silent for everyone (the new invariant is
+        # enforced going forward by a User ``post_save`` signal).
+        from django.contrib.auth.models import User
+
+        assert UserAuth.objects.count() == User.objects.count()
 
     def test_all_metron_ratings_seeded(self) -> None:
         """Every ``MetronAgeRatingEnum`` value gets an AgeRatingMetron row."""
@@ -348,9 +357,11 @@ class UserSerializerRoundtripTestCase(TestCase):
             username="roundtrip",
             password="x",  # noqa: S106
         )
-        # Hang onto the UserAuth directly; reverse accessor ``user.userauth``
-        # works at runtime but is invisible to basedpyright.
-        self.userauth = UserAuth.objects.create(user=self.user)  # pyright: ignore[reportUninitializedInstanceVariable]
+        # ``UserAuth`` is auto-provisioned by the User ``post_save`` signal
+        # (see codex.signals.django_signals); fetch the auto-created row.
+        # The reverse accessor ``user.userauth`` works at runtime but is
+        # invisible to basedpyright, so go through the manager.
+        self.userauth = UserAuth.objects.get(user=self.user)  # pyright: ignore[reportUninitializedInstanceVariable]
         self.teen_metron = AgeRatingMetron.objects.get(  # pyright: ignore[reportUninitializedInstanceVariable]
             name=MetronAgeRatingEnum.TEEN.value
         )


### PR DESCRIPTION
Two fixes bundled, both surfacing as noisy WARNINGs in dev mode.

## 1. UserAuth invariant

`UserAuth` (renamed from `UserActive` in 0039) was only provisioned by `AdminUserViewSet.perform_create`. Anything else — `manage.py createsuperuser`, fixtures, factory_boy — left the User without a matching row, so the bookmark thread's hourly activity touch fired:

```
WARNING | BookmarkThread | No UserAuth row for user pk=1; skipping touch.
```

…on every active user (typically the `createsuperuser`-provisioned admin).

The fix establishes a single invariant: **every `User` has exactly one `UserAuth`**. Three pieces:

- **New `post_save` signal** in `codex/signals/django_signals.py` does `UserAuth.objects.get_or_create(user=instance)` whenever a User is created, so every creation path now satisfies the invariant.
- **0039 picks up a `RunPython` step** that backfills a default row for any pre-existing User missing one (the legacy lazy-create `UserActive` gap). Folded into 0039 rather than a separate 0040 since `v1.11-performance` is still alpha.
- **`perform_create` and `UserSerializer._apply_userauth`** rely on the row pre-existing now: `perform_create` only patches the admin-supplied `age_rating_metron` ceiling onto the signal-created row.

Tests that explicitly created their own `UserAuth` row alongside a `User` were updated to either drop the redundant create or patch the auto-created row, and the `MigrationShapeTestCase` "table is empty" assertion was flipped to assert the new invariant (`UserAuth.count() == User.count()`).

The `update_user_active` warning **intentionally stays** — at this point a missing row really would mean a real data-integrity issue worth surfacing, which was the original docstring rationale.

## 2. asyncio slow-callback threshold

`bin/dev-server.sh` exports `PYTHONDEVMODE=1` when DEBUG=1, which flips asyncio into debug mode. The default `slow_callback_duration` of 100ms is calibrated for pure-async codebases — Codex routes most requests through asgiref's `AsyncToSync` (sync Django view on a thread, awaited from the loop), and a DB-heavy view crossing 100ms is routine, not an anomaly:

```
WARNING | MainThread | Executing <Task pending name='Task-11'
  coro=<AsyncToSync.main_wrap() running at asgiref/sync.py:365> …> took 0.298 seconds
```

These drown out genuine slow-task signal. Bump `loop.slow_callback_duration = 5.0` in `_serve` so the warning still catches truly slow callbacks (a 5s+ async operation is a real bug worth surfacing) without spamming on every normal sync-view request.

## Test plan

- [x] `pytest tests/` — 26 passed (was failing on `MigrationShapeTestCase::test_user_auth_table_exists_and_is_empty` until I updated that test to match the new invariant)
- [x] `make lint-python` clean
- [x] `make ty` clean (basedpyright + ty both)
- [ ] Verify against a fresh dev server: previous "No UserAuth row for user pk=1" warnings stop, and the asyncio "took N seconds" warnings only fire for callbacks above 5s
- [ ] Verify against an existing production DB after migration: the 0039 backfill runs, every User has exactly one `UserAuth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)