### PR TITLE
cache: no-op validate_key to silence memcached portability warnings

### DIFF
--- a/codex/cache.py
+++ b/codex/cache.py
@@ -11,6 +11,14 @@ the right behaviour is just "treat it as a miss".
 ``ResilientFileBasedCache`` catches those decode errors, deletes the
 bad file, and reports a miss so the caller continues with the
 underlying query instead of returning a 500 to the user.
+
+It also no-ops ``validate_key``: the base class checks every key for
+memcached compatibility (no spaces / control chars / length > 250)
+and emits a ``CacheKeyWarning`` for violators. Codex hashes-and-pickles
+to disk; the FS layer accepts arbitrary keys, so the memcached
+portability warnings are noise. Cachalot in particular composes keys
+from query plans that include tuples (``(127, 128)``) which trip the
+warning on every browse / cover request.
 """
 
 import zlib
@@ -52,3 +60,7 @@ class ResilientFileBasedCache(FileBasedCache):
             fname = self._key_to_file(key, version)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
             self._discard_corrupt(fname, exc)
             return False
+
+    @override
+    def validate_key(self, key):
+        """No-op key validation — see module docstring."""


### PR DESCRIPTION
## Summary

Django's base cache class checks every key for memcached compatibility (no spaces / control chars / length > 250) and emits a `CacheKeyWarning` for violators. Codex hashes-and-pickles to disk via `ResilientFileBasedCache`; the FS layer accepts arbitrary keys, so the memcached portability warnings are noise.

In production:

```
CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached:
  ':1:codex:page_mtime:1:Series:p:(127, 128):1:9e1d95859d91a186'
CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached:
  ':1:codex:page_mtime:1:Comic:s:(2043, 2057):1:9e1d95859d91a186'
```

Cachalot composes keys from query plans that include tuple reprs like `(127, 128)` (pk ranges from `IN`-clauses), and those tuple-repr spaces trip the warning on every browse / cover request.

## Fix

Override `validate_key` on `ResilientFileBasedCache` to a no-op. Extended the module docstring to explain why.

## Verified

```python
>>> from codex.cache import ResilientFileBasedCache
>>> cache = ResilientFileBasedCache('/tmp/x', {'OPTIONS': {'MAX_ENTRIES': 100}})
>>> with warnings.catch_warnings(record=True) as w:
...     warnings.simplefilter('always')
...     cache.validate_key(':1:codex:page_mtime:1:Series:p:(127, 128):1:9e1d95859d91a186')
>>> [wi for wi in w if issubclass(wi.category, CacheKeyWarning)]
[]
# vs. base FileBasedCache emits 1 CacheKeyWarning on the same key.
```

## Test plan

- [x] `make lint-python` clean
- [x] `make ty` clean
- [x] `pytest tests/` clean (26 passed)
- [ ] Verify against production: `CacheKeyWarning` lines stop appearing in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)