### PR TITLE
middleware: use session.aget in async path to avoid SynchronousOnlyOperation

### DIFF
--- a/codex/middleware.py
+++ b/codex/middleware.py
@@ -41,12 +41,30 @@ class CodexMiddleware:
         else:
             timezone.deactivate()
 
+    @staticmethod
+    async def _aactivate_timezone(request) -> None:
+        """
+        Async-safe ``_activate_timezone``.
+
+        Sync ``request.session.get("django_timezone")`` triggers a lazy
+        load from the session backend, which under cached_db ends up
+        in ``Session.objects.get(...)`` — a sync ORM call. From Granian's
+        ASGI worker (running coroutines on the loop), that trips
+        ``SynchronousOnlyOperation``. ``request.session.aget`` is the
+        async-native equivalent on ``SessionBase`` and routes through
+        ``aload`` / ``_aget_session_from_db``.
+        """
+        if tzname := await request.session.aget("django_timezone"):
+            timezone.activate(tzname)
+        else:
+            timezone.deactivate()
+
     def _set_server_header(self, response):
         response["Server"] = f"{PACKAGE_NAME}/{VERSION}"
         return response
 
     async def _acall(self, request):
-        self._activate_timezone(request)
+        await self._aactivate_timezone(request)
         response = await self.get_response(request)
         return self._set_server_header(response)
 


### PR DESCRIPTION
## The bug

In production v1.11.0:

```
ERROR | Internal Server Error: /
…
django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
```

The triggering frame:

```
File "codex/middleware.py", line 39, in _activate_timezone
    if tzname := request.session.get("django_timezone"):
```

`CodexMiddleware._acall` (the async branch) was calling the sync helper `_activate_timezone(request)`, and `request.session.get("django_timezone")` lazy-loads the session — under cached_db that's `Session.objects.get(...)`, a sync ORM call. From Granian's ASGI worker (coroutines on the loop), Django's async-context guard fires and the request 500s.

The cachalot frames that show up higher in the traceback are red herrings. cachalot's monkey-patched `SQLCompiler.execute_sql` raises `UncachableQuery` internally, catches it via `except (EmptyResultSet, UncachableQuery): return execute_query_func()`, and falls through to the original `execute_sql` — which is where `SynchronousOnlyOperation` actually fires. The chained traceback is just Python's `__context__` showing the `AttributeError: '_session_cache'` raised initially during the lazy session lookup.

## The fix

`SessionBase` exposes `aget` (Django 4.1+) which routes through `aload` / `_aget_session_from_db` and stays on the event loop. Add `_aactivate_timezone` using it, and use it from `_acall`. The sync `_activate_timezone` stays for `__call__`'s sync branch.

```python
@staticmethod
async def _aactivate_timezone(request) -> None:
    if tzname := await request.session.aget("django_timezone"):
        timezone.activate(tzname)
    else:
        timezone.deactivate()

async def _acall(self, request):
    await self._aactivate_timezone(request)
    ...
```

## Test plan

- [x] `make lint-python` clean
- [x] `make ty` clean
- [x] `pytest tests/` — 26 passed
- [ ] Verify against production v1.11.x: navigate to `/` and `/favicon.ico`, confirm 200s and that `SynchronousOnlyOperation` no longer appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)