### PR TITLE
frontend: silence INEFFECTIVE_DYNAMIC_IMPORT for useCommonStore

### DIFF
--- a/frontend/src/api/v3/base.js
+++ b/frontend/src/api/v3/base.js
@@ -1,4 +1,6 @@
 import xior, { merge } from "xior";
+
+import { useCommonStore } from "@/stores/common";
 const CONFIG = {
   baseURL: globalThis.CODEX.API_V3_PATH,
   withCredentials: true,
@@ -70,16 +72,16 @@ HTTP.interceptors.response.use(
        * working; without this every subsequent API call returns
        * 401 silently and the UI appears broken.
        *
-       * Lazy-import the common store to avoid a load-time cycle:
-       * ``stores/common.js`` imports ``api/v3/common.js`` which
-       * imports this module. The handler runs at request time,
-       * by which point the store has been fully evaluated.
+       * The static ``useCommonStore`` import forms a module cycle
+       * (``stores/common`` → ``api/v3/common`` → this file), but
+       * the handler only runs at request time — long after every
+       * module has finished evaluating — so the ESM live binding
+       * resolves cleanly.
        */
       invalidateCSRFCache();
       await cookieStore.delete("sessionid");
       console.error("CSRF response error. Deleted login cookie.");
       try {
-        const { useCommonStore } = await import("@/stores/common");
         useCommonStore().setSessionError(
           "Your session expired. Please reload the page.",
         );


### PR DESCRIPTION
## Summary
- Convert the lazy ``import(\"@/stores/common\")`` inside the CSRF response interceptor in [frontend/src/api/v3/base.js](frontend/src/api/v3/base.js) to a static import.
- Vite/Rolldown was emitting ``INEFFECTIVE_DYNAMIC_IMPORT`` because ``stores/common`` is statically imported by many modules, so the dynamic form gave no chunking benefit.
- The module cycle the original comment was guarding against is harmless: the interceptor runs at request time, long after every module has finished evaluating, so the ESM live binding resolves cleanly. Same pattern [frontend/src/api/v3/common.js](frontend/src/api/v3/common.js) already uses for ``_addTimestamp``.

## Test plan
- [x] ``make build-choices`` then ``make build`` in ``frontend/`` — no ``INEFFECTIVE_DYNAMIC_IMPORT`` warning.
- [x] ``eslint src/api/v3/base.js`` — clean.
- [ ] Smoke-test CSRF expiry path in a running app (session-expired snackbar still appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)