### PR TITLE
reader: restore scroll-to-top on horizontal page change with cacheBook on

### DIFF
--- a/frontend/src/stores/reader.js
+++ b/frontend/src/stores/reader.js
@@ -471,10 +471,26 @@ export const useReaderStore = defineStore("reader", {
       this.page = +page;
       this.setRoutesAndBookmarkPage(page);
       if (this.isPagesNotRoutes) {
+        // ``cacheBook`` mode keeps every page mounted in the same
+        // document, so a page change is a v-window slide — no real
+        // route change. Update the URL via pushState instead.
         const route = { params: { pk: this.books.current.pk, page } };
         const { href } = router.resolve(route);
         globalThis.history.pushState({}, undefined, href);
-      } else {
+      }
+      // Reset window scroll for any non-vertical mode. Previously
+      // tied to the ``else`` branch above, which assumed ``cacheBook``
+      // was always false (a snake_case typo on
+      // ``READER_DEFAULTS.cache_book`` made the default resolve to
+      // ``undefined``). Once that typo was fixed in v1.11 and
+      // ``cacheBook`` defaulted to its real ``true``, horizontal
+      // readers stopped getting a scroll-to-top on every page advance
+      // — fitTo=Width pages taller than the viewport stuck the user
+      // mid-scroll into the previous page.
+      // Vertical mode handles its own scroll via ``scrollToPage``;
+      // jumping the window to 0 there would collide with the
+      // virtual-scroll position.
+      if (!this.activeSettings.isVertical) {
         window.scrollTo(0, 0);
       }
     },


### PR DESCRIPTION
## Regression

When the reader changes pages in horizontal mode, the window no longer scrolls to the top. With `fitTo=Width` and a page taller than the viewport, the user was left mid-scroll into the previous page on every advance.

## Root cause

Pre-v1.11, the reader store's globalSettings default for `cacheBook` read `READER_DEFAULTS.cache_book` — snake_case, which doesn't exist on the camelCase choices JSON. So the default silently resolved to `undefined` and `cacheBook` was effectively always false.

The v1.11 quality-pass fixed that typo to `READER_DEFAULTS.cacheBook`, which actually reads the real default of `true`. That flipped a long-dormant code path:

[`setActivePage`](frontend/src/stores/reader.js:460) had two distinct concerns crammed into a single `if/else` keyed off `isPagesNotRoutes` (which is `isVertical || cacheBook`):

```js
if (this.isPagesNotRoutes) {
  // pushState
} else {
  window.scrollTo(0, 0);
}
```

The `else` branch assumed cacheBook was always false. Once it defaulted true, horizontal readers running cacheBook stopped hitting it.

## Fix

Split the two concerns:

```js
if (this.isPagesNotRoutes) {
  // pushState only — cacheBook & vertical keep every page mounted in the same document
}
if (!this.activeSettings.isVertical) {
  window.scrollTo(0, 0);
}
```

- `pushState` stays gated on `isPagesNotRoutes` (original semantic preserved — cacheBook horizontal is a v-window slide, not a route change).
- `window.scrollTo(0, 0)` is now gated on `!isVertical` directly. Vertical mode owns its own scroll via `PagerVertical.scrollToPage`; jumping the window to 0 there would collide with the virtual-scroll position. Every other mode — horizontal ± cacheBook, fullPdf — wants the reset.

## Test plan

- [x] `bun run build` clean
- [x] `bun run test:ci` (vitest) passes
- [x] eslint + prettier clean for the changed file
- [ ] **Verify in production**: horizontal mode with cacheBook on (default), fitTo=Width, page taller than viewport, scroll down, click Next → window resets to top.
- [ ] Vertical mode: page advance still scrolls smoothly via `scrollToPage`, no jump-to-0 collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)