### PR TITLE
reader: default cache_book to False; reset global override on upgrade

### DIFF
--- a/codex/choices/reader.py
+++ b/codex/choices/reader.py
@@ -30,6 +30,6 @@ READER_DEFAULTS = MappingProxyType(
         "read_rtl_in_reverse": False,
         "two_pages": False,
         "page_transition": True,
-        "cache_book": True,
+        "cache_book": False,
     }
 )

--- a/codex/migrations/0040_reset_global_cache_book.py
+++ b/codex/migrations/0040_reset_global_cache_book.py
@@ -1,0 +1,49 @@
+"""
+Reset global ``cache_book`` so the new default takes effect.
+
+Migration 0039's ``backfill_global_reader_defaults`` populated every
+null field on each global :class:`SettingsReader` row with the value
+from :data:`READER_DEFAULTS`. At that time ``cache_book`` defaulted
+to ``True``, so installs that passed through 0039 came out with an
+opaque ``True`` baked into the global row even for users who never
+toggled the setting.
+
+The default has since flipped to ``False``. Clearing ``cache_book``
+on global rows back to ``NULL`` lets the resolution layer read the
+current ``READER_DEFAULTS`` value instead of the stale backfill.
+Per-scope rows (per-comic / series / folder / story-arc) are
+untouched — those represent deliberate per-scope choices.
+"""
+
+from django.db import migrations
+
+_GLOBAL_FILTER = {
+    "comic__isnull": True,
+    "series__isnull": True,
+    "folder__isnull": True,
+    "story_arc__isnull": True,
+}
+
+
+def reset_global_cache_book(apps, _schema_editor) -> None:
+    """Clear ``cache_book`` on global :class:`SettingsReader` rows."""
+    settings_reader = apps.get_model("codex", "SettingsReader")
+    settings_reader.objects.filter(**_GLOBAL_FILTER).exclude(
+        cache_book__isnull=True
+    ).update(cache_book=None)
+
+
+def _noop(_apps, _schema_editor) -> None:
+    """Reverse no-op (data migrations stay applied on rollback)."""
+
+
+class Migration(migrations.Migration):
+    """Reset global ``cache_book`` so the new ``False`` default applies."""
+
+    dependencies = [
+        ("codex", "0039_metron_age_rating_default_view_and_performance"),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_global_cache_book, _noop),
+    ]


### PR DESCRIPTION
## Summary
- Flip the reader's `cache_book` default from `True` to `False` in `READER_DEFAULTS`. Whole-book caching balloons memory on long archives and shouldn't be the silent default.
- Add migration `0040_reset_global_cache_book` that NULLs `cache_book` on global `SettingsReader` rows so the new default surfaces. Migration `0039`'s `backfill_global_reader_defaults` had baked the prior `True` value into every global row even for users who never toggled it. Per-scope rows (comic / series / folder / story-arc) are untouched.

## Test plan
- [ ] `make fix` clean
- [ ] `make lint` clean
- [ ] `make ty` clean
- [ ] Migration applies cleanly on a fresh DB and on a DB upgraded through `0039`
- [ ] After upgrade, a user who never toggled `cacheBook` sees the setting resolve to `False` in the reader UI
- [ ] A user with a per-scope override (e.g. per-series `cacheBook = true`) keeps that override

🤖 Generated with [Claude Code](https://claude.com/claude-code)