### PR TITLE
browser: collapse browser pane to a single scroller

### DIFF
--- a/frontend/src/browser.vue
+++ b/frontend/src/browser.vue
@@ -40,7 +40,8 @@ export default {
   },
   watch: {
     $route() {
-      window.scrollTo(0, 0);
+      const refresh = document.getElementById("browsePaneRefreshContainer");
+      if (refresh) refresh.scrollTop = 0;
       this.loadBrowserPage();
       this.deactivateSelectMany();
     },

--- a/frontend/src/components/browser/card/card.vue
+++ b/frontend/src/components/browser/card/card.vue
@@ -61,7 +61,6 @@ import { useBrowserStore } from "@/stores/browser";
 import { useBrowserSelectManyStore } from "@/stores/browser-select-many";
 
 const SCROLL_DELAY = 100;
-const HEADER_OFFSET = -170;
 
 export default {
   name: "BrowserCard",
@@ -123,19 +122,14 @@ export default {
   },
   beforeUnmount() {
     /*
-     * Cancel any pending scroll-restore timers. Without this,
-     * a card that unmounts during the 100-200ms window (rapid
-     * filter change, live-reload, route transition) still
-     * fires ``scrollIntoView`` on a detached node and the
-     * inner ``window.scrollBy`` runs against the wrong page.
+     * Cancel any pending scroll-restore timer so a card that
+     * unmounts during the 100ms layout window (rapid filter
+     * change, live-reload, route transition) doesn't fire
+     * ``scrollIntoView`` on a detached node.
      */
-    if (this._scrollOuterTimer) {
-      globalThis.clearTimeout(this._scrollOuterTimer);
-      this._scrollOuterTimer = 0;
-    }
-    if (this._scrollInnerTimer) {
-      globalThis.clearTimeout(this._scrollInnerTimer);
-      this._scrollInnerTimer = 0;
+    if (this._scrollTimer) {
+      globalThis.clearTimeout(this._scrollTimer);
+      this._scrollTimer = 0;
     }
   },
   methods: {
@@ -153,22 +147,14 @@ export default {
         return;
       }
       /*
-       * Two stacked timers: the outer one waits for the card to
-       * lay out, then ``scrollIntoView``; the inner one waits
-       * for any toolbar reflow, then nudges the scroll up by
-       * ``HEADER_OFFSET``. The empirical 100ms delays were
-       * tuned against Vue 3's mount timing and ``nextTick``
-       * doesn't reliably substitute, so keep the timer shape.
-       * Track the IDs so ``beforeUnmount`` can cancel them.
+       * Wait one layout pass before scrolling. The empirical
+       * 100ms delay was tuned against Vue 3's mount timing and
+       * ``nextTick`` doesn't reliably substitute. Track the id
+       * so ``beforeUnmount`` can cancel it.
        */
-      this._scrollOuterTimer = globalThis.setTimeout(() => {
-        this._scrollOuterTimer = 0;
-        // This works while nextTick() does not.
+      this._scrollTimer = globalThis.setTimeout(() => {
+        this._scrollTimer = 0;
         el.scrollIntoView();
-        this._scrollInnerTimer = globalThis.setTimeout(() => {
-          this._scrollInnerTimer = 0;
-          globalThis.scrollBy(0, HEADER_OFFSET);
-        }, SCROLL_DELAY);
       }, SCROLL_DELAY);
     },
   },

--- a/frontend/src/components/browser/main.vue
+++ b/frontend/src/components/browser/main.vue
@@ -149,14 +149,15 @@ $banner-height: 20px;
 // Single scroller: #browsePane fills the viewport exactly so its content
 // area is a known size, and #browsePaneRefreshContainer fills that area.
 // The refresh container is the only element with overflow: auto.
+//
+// Side padding lives on the refresh container (not on #browsePane) so the
+// scrollbar sits at the viewport edge instead of inset by $card-margin.
 #browsePane {
   display: flex;
   flex-direction: column;
   height: 100dvh;
   box-sizing: border-box;
   padding-top: $browse-pane-padding-top;
-  padding-left: max($card-margin, env(safe-area-inset-left));
-  padding-right: max($card-margin, env(safe-area-inset-right));
   padding-bottom: max($card-margin, env(safe-area-inset-bottom));
   overflow: hidden;
 }
@@ -203,6 +204,8 @@ $banner-height: 20px;
 #browsePaneRefreshContainer {
   flex: 1;
   min-height: 0;
+  padding-left: max($card-margin, env(safe-area-inset-left));
+  padding-right: max($card-margin, env(safe-area-inset-right));
   overflow: auto;
   overscroll-behavior-y: contain;
 }
@@ -241,9 +244,12 @@ $banner-height: 20px;
   $small-card-margin: 16px;
 
   #browsePane {
+    padding-bottom: max($small-card-margin, env(safe-area-inset-bottom));
+  }
+
+  #browsePaneRefreshContainer {
     padding-left: max($small-card-margin, env(safe-area-inset-left));
     padding-right: max($small-card-margin, env(safe-area-inset-right));
-    padding-bottom: max($small-card-margin, env(safe-area-inset-bottom));
   }
 
   #browsePaneRefreshContainer > :deep(.v-pull-to-refresh__scroll-container) {

--- a/frontend/src/components/browser/main.vue
+++ b/frontend/src/components/browser/main.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-main id="browsePane" :class="browsePaneClasses">
+  <div id="browsePane" :class="browsePaneClasses">
     <v-pull-to-refresh
       v-if="showBrowseItems"
       id="browsePaneRefreshContainer"
@@ -21,7 +21,7 @@
     >
       {{ searchLimitMessage }}
     </div>
-  </v-main>
+  </div>
 </template>
 
 <script>
@@ -141,72 +141,83 @@ export default {
 
 $top-toolbar-margin: 102px;
 $card-margin: 32px;
-$browse-pane-margin-top: calc($top-toolbar-margin + $card-margin);
-$bottom-margin: 20px;
+$browse-pane-padding-top: calc($top-toolbar-margin + $card-margin);
 $select-many-height: 40px;
+$search-toolbar-height: 32px;
+$banner-height: 20px;
 
+// Single scroller: #browsePane fills the viewport exactly so its content
+// area is a known size, and #browsePaneRefreshContainer fills that area.
+// The refresh container is the only element with overflow: auto.
 #browsePane {
-  margin-left: max($card-margin, env(safe-area-inset-left));
-  margin-right: max($card-margin, env(safe-area-inset-right));
-  margin-bottom: max($card-margin, env(safe-area-inset-bottom));
-  overflow: auto;
-}
-
-.browsePane {
-  margin-top: $browse-pane-margin-top;
-  overflow: hidden; // scroll is handled by the refresh container
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  box-sizing: border-box;
+  padding-top: $browse-pane-padding-top;
+  padding-left: max($card-margin, env(safe-area-inset-left));
+  padding-right: max($card-margin, env(safe-area-inset-right));
+  padding-bottom: max($card-margin, env(safe-area-inset-bottom));
+  overflow: hidden;
 }
 
 .browsePaneSelectMany {
-  margin-top: calc($browse-pane-margin-top + $select-many-height) !important;
+  padding-top: calc($browse-pane-padding-top + $select-many-height) !important;
 }
 
 .browsePaneSearch {
-  margin-top: calc($browse-pane-margin-top + 32px) !important;
+  padding-top: calc(
+    $browse-pane-padding-top + $search-toolbar-height
+  ) !important;
 }
 
 .browsePaneSelectManySearch {
-  margin-top: calc(
-    $browse-pane-margin-top + $select-many-height + 32px
+  padding-top: calc(
+    $browse-pane-padding-top + $select-many-height + $search-toolbar-height
   ) !important;
 }
 
 .browsePaneBanner {
-  margin-top: calc(20px + $browse-pane-margin-top) !important;
+  padding-top: calc($banner-height + $browse-pane-padding-top) !important;
 }
 
 .browsePaneSelectManyBanner {
-  margin-top: calc(
-    20px + $browse-pane-margin-top + $select-many-height
+  padding-top: calc(
+    $banner-height + $browse-pane-padding-top + $select-many-height
   ) !important;
 }
 
 .browsePaneSearchBanner {
-  margin-top: calc(20px + $browse-pane-margin-top + 32px) !important;
+  padding-top: calc(
+    $banner-height + $browse-pane-padding-top + $search-toolbar-height
+  ) !important;
 }
 
 .browsePaneSelectManySearchBanner {
-  margin-top: calc(
-    20px + $browse-pane-margin-top + $select-many-height + 32px
+  padding-top: calc(
+    $banner-height + $browse-pane-padding-top + $select-many-height +
+      $search-toolbar-height
   ) !important;
 }
 
 #browsePaneRefreshContainer {
-  height: calc(100vh - $top-toolbar-margin - $card-margin - $bottom-margin);
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   overscroll-behavior-y: contain;
 }
 
 #browsePaneRefreshContainer > :deep(.v-pull-to-refresh__scroll-container) {
-  margin-top: $card-margin;
   display: grid;
   grid-template-columns: repeat(auto-fit, bookcover.$cover-width);
   grid-gap: $card-margin;
   align-content: flex-start;
 }
 
-.padFooter {
-  padding-bottom: 45px !important;
+// Reserve room at the bottom of the scroll content for the fixed
+// pagination toolbar so the last cards aren't hidden behind it.
+.padFooter > #browsePaneRefreshContainer {
+  padding-bottom: 45px;
 }
 
 .placeholder {
@@ -219,6 +230,7 @@ $select-many-height: 40px;
 }
 
 #searchLimitMessage {
+  flex-shrink: 0;
   padding-top: 20px;
   text-align: center;
   font-size: 14px;
@@ -229,13 +241,12 @@ $select-many-height: 40px;
   $small-card-margin: 16px;
 
   #browsePane {
-    margin-left: max($small-card-margin, env(safe-area-inset-left));
-    margin-right: max($small-card-margin, env(safe-area-inset-right));
-    margin-bottom: max($small-card-margin, env(safe-area-inset-bottom));
+    padding-left: max($small-card-margin, env(safe-area-inset-left));
+    padding-right: max($small-card-margin, env(safe-area-inset-right));
+    padding-bottom: max($small-card-margin, env(safe-area-inset-bottom));
   }
 
   #browsePaneRefreshContainer > :deep(.v-pull-to-refresh__scroll-container) {
-    margin-top: $small-card-margin;
     grid-template-columns: repeat(auto-fit, bookcover.$small-cover-width);
     grid-gap: $small-card-margin;
     justify-content: space-evenly;


### PR DESCRIPTION
## Summary
- Fix dual-scrollbar bug: `#browsePane` and `#browsePaneRefreshContainer` both had `overflow: auto`, producing two scrollbars. The inset one was especially visible in Brave (~1cm from the right edge).
- Make `#browsePaneRefreshContainer` the lone scroller. `#browsePane` becomes a flex column sized to `100dvh` with `overflow: hidden`, using `padding-top` instead of `margin-top` to clear the fixed header — so the box ends precisely at the viewport edge regardless of banner / search / select-many state.
- Replace the brittle `calc(100vh - 154px)` height on the refresh container with `flex: 1; min-height: 0`, so it always fills the available area as the header grows or shrinks.
- Drop the inner `<v-main>` for a `<div>`. Vuetify's `<v-main>` is meant to occur once per layout and was injecting unwanted automatic insets.
- Update two callers that assumed document-level scroll:
  - `browser.vue` route change resets the refresh container's `scrollTop` instead of `window.scrollTo(0, 0)`.
  - `card.vue` `scrollToMe` drops the `HEADER_OFFSET = -170` `window.scrollBy` nudge; with the new layout, `scrollIntoView()` already aligns the card below the fixed header, so the two stacked timers collapse to one.

## Test plan
- [x] `bun run lint` (eslint + prettier) clean
- [x] `bun run test:ci` passing (1/1)
- [x] `bun run build` succeeds
- [ ] Single scrollbar visible in the browser pane on the comic grid (verified manually by author)
- [ ] Verify each header-state combination still positions correctly: banner on/off, search open/closed, select-many active/inactive, multi-page (`padFooter`)
- [ ] Pagination toolbar at the bottom still leaves room for the last cards (45px reservation moved from outer pane to refresh container)
- [ ] Pull-to-refresh on touch still triggers metadata reload
- [ ] Deep-linked card hash (`#card-…`) still scrolls into view below the fixed header

🤖 Generated with [Claude Code](https://claude.com/claude-code)