### PR TITLE
metadata: include ids in current-group list field (fix "None" publisher chip)

### DIFF
--- a/codex/views/browser/metadata/copy_intersections.py
+++ b/codex/views/browser/metadata/copy_intersections.py
@@ -1,6 +1,8 @@
 """Copy Intersections Into Comic Fields."""
 
 from codex.models.comic import Comic
+from codex.models.functions import JsonGroupArray
+from codex.models.groups import Volume
 from codex.serializers.browser.metadata import PREFETCH_PREFIX
 from codex.views.browser.metadata.const import (
     COMIC_VALUE_FIELDS_CONFLICTING,
@@ -12,6 +14,7 @@ from codex.views.browser.metadata.query_intersections import (
 )
 
 _PREFETCH_DICT_FIELDS = frozenset({"identifiers", "credits", "story_arc_numbers"})
+_GROUP_LIST_FIELD_OVERRIDES = {"StoryArc": "story_arc_list"}
 
 
 class MetadataCopyIntersectionsView(MetadataQueryIntersectionsView):
@@ -33,8 +36,21 @@ class MetadataCopyIntersectionsView(MetadataQueryIntersectionsView):
         """Values for highlighting the current group."""
         if self.model and self.model is not Comic:
             # move the name of the group to the correct field
-            field = self.model.__name__.lower() + "_list"
-            group_list = self.model.objects.filter(pk__in=obj.ids).values("name")
+            model_name = self.model.__name__
+            field = _GROUP_LIST_FIELD_OVERRIDES.get(
+                model_name, model_name.lower() + "_list"
+            )
+            only = ["name"]
+            if self.model is Volume:
+                only.append("number_to")
+            group_list = (
+                self.model.objects.filter(pk__in=obj.ids)
+                .only(*only)
+                .distinct()
+                .group_by(*only)  # pyright: ignore[reportAttributeAccessIssue]
+                .annotate(ids=JsonGroupArray("id", distinct=True, order_by="id"))
+                .values("ids", *only)
+            )
             setattr(obj, field, group_list)
             obj.name = None
 


### PR DESCRIPTION
## Summary

When viewing the metadata dialog for a top-level group (publisher, imprint, series, volume, folder, story arc), the current group's `*_list` field was emitted without `ids`. The frontend's `toVuetifyItem` requires `ids` (or `pk`) to build chip values; without them every entry collapsed into a single "None" chip.

Reproduced via `/api/v3/p/25,102/metadata` returning:

```json
"publisherList": [
    {"name": "pow Studios"},
    {"name": "POW Studios"}
]
```

…which the metadata dialog rendered as one "None" chip.

## Root cause

[`_highlight_current_group`](codex/views/browser/metadata/copy_intersections.py) used a simplistic `.values("name")` query. The sibling helper `_query_groups` (which handles *parent* group lists) already had the right shape — `group_by(name) + JsonGroupArray("id")`. Only the current-group path was missing it.

## Fix

Mirror the `_query_groups` shape: `group_by(*only)` + `JsonGroupArray("id", distinct=True, order_by="id")`, projected via `.values("ids", *only)`. Each entry now carries its aggregated ids and the frontend renders proper clickable chips.

## Latent bugs in the same code path, also fixed

While auditing for "similar components with similar data," three related defects shared the root cause and are resolved by the same edit:

1. **Single-id chips were silently unclickable.** `MetadataText` reads `value.ids || [value.pk]`; without `ids`, the link evaluated to `[undefined]` and clicking did nothing.
2. **Volume `number_to` was never selected**, so `formattedVolumeName(name, numberTo)` always rendered without the range suffix.
3. **`storyArcList` was always empty** — `StoryArc.__name__.lower()` produced `storyarc_list`, but the serializer reads `story_arc_list`. The data was being attached to an attribute nothing read. Mapped via `_GROUP_LIST_FIELD_OVERRIDES`.

## Test plan

- [x] `make fix` clean
- [x] `make lint` Python: `0 errors, 0 warnings, 0 notes` (the trailing `remark` markdown error is pre-existing on develop, verified by stashing)
- [x] `uv run pytest tests/` — 26 passed
- [ ] Manual: open metadata dialog for a multi-id publisher selection, confirm chips render with publisher names (not "None") and link to the correct filter
- [ ] Manual: open metadata for a single publisher, confirm clicking the name navigates
- [ ] Manual: open metadata for a Volume group, confirm the number range shows
- [ ] Manual: open metadata for a StoryArc group, confirm `storyArcList` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)