### PR TITLE
metadata: extract group_list helper to formalize GroupSerializer contract

### DIFF
--- a/codex/views/browser/metadata/copy_intersections.py
+++ b/codex/views/browser/metadata/copy_intersections.py
@@ -1,20 +1,21 @@
 """Copy Intersections Into Comic Fields."""
 
 from codex.models.comic import Comic
-from codex.models.functions import JsonGroupArray
-from codex.models.groups import Volume
 from codex.serializers.browser.metadata import PREFETCH_PREFIX
 from codex.views.browser.metadata.const import (
     COMIC_VALUE_FIELDS_CONFLICTING,
     COMIC_VALUE_FIELDS_CONFLICTING_PREFIX,
     PATH_GROUPS,
 )
+from codex.views.browser.metadata.group_list import (
+    annotate_group_list,
+    group_list_field_name,
+)
 from codex.views.browser.metadata.query_intersections import (
     MetadataQueryIntersectionsView,
 )
 
 _PREFETCH_DICT_FIELDS = frozenset({"identifiers", "credits", "story_arc_numbers"})
-_GROUP_LIST_FIELD_OVERRIDES = {"StoryArc": "story_arc_list"}
 
 
 class MetadataCopyIntersectionsView(MetadataQueryIntersectionsView):
@@ -35,23 +36,9 @@ class MetadataCopyIntersectionsView(MetadataQueryIntersectionsView):
     def _highlight_current_group(self, obj) -> None:
         """Values for highlighting the current group."""
         if self.model and self.model is not Comic:
-            # move the name of the group to the correct field
-            model_name = self.model.__name__
-            field = _GROUP_LIST_FIELD_OVERRIDES.get(
-                model_name, model_name.lower() + "_list"
-            )
-            only = ["name"]
-            if self.model is Volume:
-                only.append("number_to")
-            group_list = (
-                self.model.objects.filter(pk__in=obj.ids)
-                .only(*only)
-                .distinct()
-                .group_by(*only)  # pyright: ignore[reportAttributeAccessIssue]
-                .annotate(ids=JsonGroupArray("id", distinct=True, order_by="id"))
-                .values("ids", *only)
-            )
-            setattr(obj, field, group_list)
+            field = group_list_field_name(self.model)
+            qs = self.model.objects.filter(pk__in=obj.ids)
+            setattr(obj, field, annotate_group_list(qs))
             obj.name = None
 
     @classmethod

--- a/codex/views/browser/metadata/group_list.py
+++ b/codex/views/browser/metadata/group_list.py
@@ -1,0 +1,44 @@
+"""
+Shared queryset shape for ``GroupSerializer`` consumers.
+
+The metadata view emits ``*_list`` fields populated by
+``codex.serializers.browser.metadata.GroupSerializer``, which expects
+each row to expose ``ids``, ``name`` (and ``number_to`` for Volume).
+Two call sites populate these lists — parent groups in
+``MetadataQueryIntersectionsView._query_groups`` and the current group
+in ``MetadataCopyIntersectionsView._highlight_current_group`` — so the
+projection lives here to keep them from drifting.
+"""
+
+from types import MappingProxyType
+
+from django.db.models import QuerySet
+
+from codex.models import BrowserGroupModel
+from codex.models.functions import JsonGroupArray
+from codex.models.groups import Volume
+
+# Model class names whose ``*_list`` attribute name on the metadata
+# response object doesn't match ``__name__.lower() + "_list"``.
+# ``StoryArc.__name__.lower() == "storyarc"`` but the serializer reads
+# ``story_arc_list``; without this map the populated attribute would
+# silently fall on the floor.
+_GROUP_LIST_FIELD_OVERRIDES = MappingProxyType({"StoryArc": "story_arc_list"})
+
+
+def group_list_field_name(model: type[BrowserGroupModel]) -> str:
+    """Return the metadata-obj attribute the serializer reads for ``model``."""
+    name = model.__name__
+    return _GROUP_LIST_FIELD_OVERRIDES.get(name, name.lower() + "_list")
+
+
+def annotate_group_list(qs: QuerySet) -> QuerySet:
+    """Project a pre-filtered BrowserGroupModel qs into ``GroupSerializer`` shape."""
+    only = ["name", "number_to"] if qs.model is Volume else ["name"]
+    return (
+        qs.only(*only)
+        .distinct()
+        .group_by(*only)  # pyright: ignore[reportAttributeAccessIssue]
+        .annotate(ids=JsonGroupArray("id", distinct=True, order_by="id"))
+        .values("ids", *only)
+    )

--- a/codex/views/browser/metadata/query_intersections.py
+++ b/codex/views/browser/metadata/query_intersections.py
@@ -5,8 +5,6 @@ from django.db.models.query import QuerySet
 
 from codex.librarian.scribe.importer.const import COMIC_FK_FIELDS, COMIC_M2M_FIELDS
 from codex.models import Comic
-from codex.models.functions import JsonGroupArray
-from codex.models.groups import Volume
 from codex.views.browser.metadata.annotate import MetadataAnnotateView
 from codex.views.browser.metadata.const import (
     COMIC_MAIN_FIELD_NAME_BACK_REL_MAP,
@@ -14,6 +12,7 @@ from codex.views.browser.metadata.const import (
     GROUP_MODELS,
     M2M_QUERY_OPTIMIZERS,
 )
+from codex.views.browser.metadata.group_list import annotate_group_list
 from codex.views.const import METADATA_GROUP_RELATION, MODEL_REL_MAP
 
 
@@ -36,14 +35,7 @@ class MetadataQueryIntersectionsView(MetadataAnnotateView):
         for model in GROUP_MODELS.get(group, ()):
             field_name = MODEL_REL_MAP[model]
             qs = model.objects.filter(**group_filter)
-            only = ["name"]
-            if model is Volume:
-                only.append("number_to")
-            qs = qs.only(*only).distinct()
-            qs = qs.group_by(*only)  # pyright: ignore[reportAttributeAccessIssue]
-            qs = qs.annotate(ids=JsonGroupArray("id", distinct=True, order_by="id"))
-            qs = qs.values("ids", *only)
-            groups[field_name] = qs
+            groups[field_name] = annotate_group_list(qs)
         return groups
 
     def _get_comic_pks(self, filtered_qs: QuerySet) -> frozenset[int]:

--- a/tests/test_metadata_group_list.py
+++ b/tests/test_metadata_group_list.py
@@ -1,0 +1,182 @@
+"""
+Regression tests for the metadata view's ``*_list`` projection.
+
+The metadata response embeds ``publisherList`` / ``imprintList`` /
+``seriesList`` / ``volumeList`` / ``storyArcList`` for the chips in the
+metadata dialog. ``GroupSerializer`` requires each row to expose
+``ids`` (and ``number_to`` for Volume); without ``ids`` the frontend
+``toVuetifyItem`` collapses every entry into a single "None" chip and
+single-id rows lose their click target. See PR #725.
+
+These tests pin the contract end-to-end through the HTTP layer so that
+both projection sites — ``_query_groups`` (parent groups, populated
+when the current group is below them) and ``_highlight_current_group``
+(current group, populated for top-level group views) — keep emitting
+``ids`` for every row.
+"""
+
+import shutil
+from pathlib import Path
+from typing import Final, override
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from codex.models import Comic, Imprint, Library, Publisher, Series, Volume
+from codex.models.named import StoryArc
+from codex.startup import init_admin_flags
+from codex.views.browser.metadata.group_list import group_list_field_name
+
+TMP_DIR = Path("/tmp/codex.tests.metadata_group_list")  # noqa: S108
+_TEST_PASSWORD: Final = "test-pw-hush-S106"  # noqa: S105
+_HTTP_OK: Final = 200
+_EXPECTED_PUBLISHER_ROWS: Final = 2
+
+
+class MetadataGroupListTestCase(TestCase):
+    """Pin the ``GroupSerializer`` shape on every metadata ``*_list`` field."""
+
+    @override
+    def setUp(self) -> None:
+        """Seed two publishers (case-different names) sharing one comic each."""
+        # Migrations don't seed every AdminFlag the request pipeline reads
+        # (notably ``NU`` for ``IsAuthenticatedOrEnabledNonUsers``); rely
+        # on the same idempotent seeder ``codex.run`` calls at startup.
+        init_admin_flags()
+        TMP_DIR.mkdir(exist_ok=True, parents=True)
+        library = Library.objects.create(path=str(TMP_DIR))
+        # Two publishers with case-different names — the original bug
+        # reproducer. Their ``sort_name`` collides ("boom! studios"), so
+        # ``add_group_by`` aggregates both pks onto a single metadata
+        # row, exercising the multi-id path through ``obj.ids``.
+        self.pub_a = Publisher.objects.create(name="Boom! Studios")  # pyright: ignore[reportUninitializedInstanceVariable]
+        self.pub_b = Publisher.objects.create(name="BOOM! Studios")  # pyright: ignore[reportUninitializedInstanceVariable]
+        imprint_a = Imprint.objects.create(name="Imp A", publisher=self.pub_a)
+        imprint_b = Imprint.objects.create(name="Imp B", publisher=self.pub_b)
+        series_a = Series.objects.create(
+            name="Ser A", imprint=imprint_a, publisher=self.pub_a
+        )
+        series_b = Series.objects.create(
+            name="Ser B", imprint=imprint_b, publisher=self.pub_b
+        )
+        volume_a = Volume.objects.create(
+            name="2024", series=series_a, imprint=imprint_a, publisher=self.pub_a
+        )
+        volume_b = Volume.objects.create(
+            name="2025", series=series_b, imprint=imprint_b, publisher=self.pub_b
+        )
+
+        def _comic(suffix: str, pub, imp, ser, vol) -> Comic:
+            path = TMP_DIR / f"{suffix}.cbz"
+            path.touch()
+            return Comic.objects.create(
+                library=library,
+                path=path,
+                issue_number=1,
+                name=suffix,
+                publisher=pub,
+                imprint=imp,
+                series=ser,
+                volume=vol,
+                size=1,
+            )
+
+        self.comic_a = _comic("a", self.pub_a, imprint_a, series_a, volume_a)  # pyright: ignore[reportUninitializedInstanceVariable]
+        self.comic_b = _comic("b", self.pub_b, imprint_b, series_b, volume_b)  # pyright: ignore[reportUninitializedInstanceVariable]
+
+        user = User.objects.create_user(
+            username="metadata_grouplist", password=_TEST_PASSWORD
+        )
+        self.client = Client()
+        self.client.force_login(user)
+
+    @override
+    def tearDown(self) -> None:
+        """Remove the temp comic tree."""
+        shutil.rmtree(TMP_DIR, ignore_errors=True)
+
+    def _get_metadata(self, group: str, pks: list[int]) -> dict:
+        joined = ",".join(str(p) for p in pks)
+        url = f"/api/v3/{group}/{joined}/metadata"
+        response = self.client.get(url)
+        if response.status_code != _HTTP_OK:
+            reason = f"GET {url} returned {response.status_code}: {response.content!r}"
+            raise AssertionError(reason)
+        return response.json()
+
+    # --- current-group path (``_highlight_current_group``) ---
+
+    def test_publisher_metadata_multi_id_includes_ids(self) -> None:
+        """Multi-pk publisher view emits one ``publisherList`` row per name, each with ``ids``."""
+        data = self._get_metadata("p", [self.pub_a.pk, self.pub_b.pk])
+        publisher_list = data.get("publisherList") or []
+        # Two publishers with different names ⇒ two rows.
+        assert len(publisher_list) == _EXPECTED_PUBLISHER_ROWS, publisher_list
+        names = {row["name"] for row in publisher_list}
+        assert names == {"Boom! Studios", "BOOM! Studios"}, names
+        # Every row carries non-empty ``ids`` — the bug PR #725 fixed.
+        for row in publisher_list:
+            assert row.get("ids"), row
+            assert all(isinstance(pk, int) for pk in row["ids"]), row
+
+    def test_publisher_metadata_single_id_includes_ids(self) -> None:
+        """Single-pk publisher view also includes ``ids`` (single-chip click target)."""
+        data = self._get_metadata("p", [self.pub_a.pk])
+        publisher_list = data.get("publisherList") or []
+        assert len(publisher_list) == 1, publisher_list
+        row = publisher_list[0]
+        assert row["name"] == "Boom! Studios"
+        assert row["ids"] == [self.pub_a.pk]
+
+    def test_volume_metadata_includes_number_to(self) -> None:
+        """Volume current-group view exposes ``number_to`` for ``formattedVolumeName``."""
+        volume_pk = Volume.objects.get(name="2024").pk
+        data = self._get_metadata("v", [volume_pk])
+        volume_list = data.get("volumeList") or []
+        assert len(volume_list) == 1, volume_list
+        row = volume_list[0]
+        # ``number_to`` is camelCased by the serializer.
+        assert "numberTo" in row, row
+        assert row["ids"] == [volume_pk]
+
+    # --- parent-group path (``_query_groups``) ---
+
+    def test_series_metadata_includes_publisher_parent_with_ids(self) -> None:
+        """Series view's parent ``publisherList`` is populated with ``ids``."""
+        series = Series.objects.get(name="Ser A")
+        data = self._get_metadata("s", [series.pk])
+        publisher_list = data.get("publisherList") or []
+        assert len(publisher_list) == 1, publisher_list
+        row = publisher_list[0]
+        assert row["name"] == "Boom! Studios"
+        assert row["ids"] == [self.pub_a.pk]
+
+
+class GroupListFieldNameTestCase(TestCase):
+    """Pin the ``model -> *_list`` attribute mapping the serializer reads."""
+
+    def test_publisher_field_name(self) -> None:
+        """Publisher → ``publisher_list``."""
+        assert group_list_field_name(Publisher) == "publisher_list"
+
+    def test_imprint_field_name(self) -> None:
+        """Imprint → ``imprint_list``."""
+        assert group_list_field_name(Imprint) == "imprint_list"
+
+    def test_series_field_name(self) -> None:
+        """Series → ``series_list``."""
+        assert group_list_field_name(Series) == "series_list"
+
+    def test_volume_field_name(self) -> None:
+        """Volume → ``volume_list``."""
+        assert group_list_field_name(Volume) == "volume_list"
+
+    def test_story_arc_field_name_is_overridden(self) -> None:
+        """
+        StoryArc → ``story_arc_list`` (not the default ``storyarc_list``).
+
+        Without the override the metadata response silently dropped
+        ``storyArcList`` because the serializer only reads
+        ``story_arc_list``.
+        """
+        assert group_list_field_name(StoryArc) == "story_arc_list"


### PR DESCRIPTION
## Summary

Pure refactor that follows up on [#725](https://github.com/ajslater/codex/pull/725). The metadata view's ``*_list`` projection (`publisher_list`, `imprint_list`, …) was built independently in two places — `_query_groups` (parent groups) and `_highlight_current_group` (current group) — which is exactly how the bug in #725 happened: one path drifted from the other. This change pulls the projection into a single helper so they can't drift again.

## What changed

* New `codex/views/browser/metadata/group_list.py` exports two helpers:
  * `annotate_group_list(qs)` — applies `group_by(name) + JsonGroupArray("id")` and projects `("ids", "name", [number_to])`.
  * `group_list_field_name(model)` — maps a `BrowserGroupModel` to the attribute name `GroupSerializer` reads (with the `StoryArc → story_arc_list` override that #725 introduced).
* `_query_groups` and `_highlight_current_group` now defer to those helpers — `-30` lines of duplicated `only/group_by/annotate/values` / field-name munging.
* New `tests/test_metadata_group_list.py` pins the contract:
  * HTTP regression tests for the multi-id and single-id Publisher cases (the original #725 bug), the Volume `number_to` case, and the parent-group path through Series.
  * Unit tests on `group_list_field_name` for every `BrowserGroupModel` — including the `StoryArc → story_arc_list` override that the HTTP fixture currently can't reach without more setup, but which would silently regress the response if reverted.

## Why

The plan from the post-#725 discussion: "the real bug class is 'backend deviates from the `{ids, name}` contract'. A focused win is to formalize that contract in one place." This is that.

## Test plan

- [x] `make fix` clean
- [x] `make lint` Python: `0 errors, 0 warnings, 0 notes`
- [x] `uv run pytest tests/` — 35 passed (26 existing + 9 new)
- [ ] Manual smoke: open the metadata dialog for a multi-id publisher selection — should still render chips correctly (no regression vs. main).

## Out of scope

Per the discussion thread, the frontend `vuetify-items.js` adapter stays where it is — it does view-model work (active-state injection, per-filter sort policy, `fixUniverseTitles`) that depends on the live store, not just the API shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)