### PR TITLE
frontend(api/v3): cleanup pass — dead code, mutations, conventions

### DIFF
--- a/frontend/src/api/v3/admin.js
+++ b/frontend/src/api/v3/admin.js
@@ -1,6 +1,5 @@
+import { HTTP } from "@/api/v3/base";
 import { serializeParams } from "@/api/v3/common";
-
-import { HTTP } from "./base";
 
 // CRUD factory — generates create/getAll/update/destroy for a given admin entity.
 const makeAdminCRUD = (entity) => {
@@ -50,9 +49,7 @@ const updateFlag = (key, data) => {
   return HTTP.put(`/admin/flag/${key}/`, data);
 };
 
-const postLibrarianTask = async (data) => {
-  return await HTTP.post("/admin/librarian/task", data);
-};
+const postLibrarianTask = (data) => HTTP.post("/admin/librarian/task", data);
 
 const getActiveLibrarianStatuses = () => {
   const params = { ts: Date.now() };
@@ -69,9 +66,7 @@ const getStats = () => {
   return HTTP.get("/admin/stats", { params });
 };
 
-const updateAPIKey = async () => {
-  return await HTTP.put("/admin/api_key");
-};
+const updateAPIKey = () => HTTP.put("/admin/api_key");
 
 // Preserve the original function-name keys for dynamic lookup by the admin store
 // (e.g. API["create" + table], API["get" + pluralTable]).

--- a/frontend/src/api/v3/auth.js
+++ b/frontend/src/api/v3/auth.js
@@ -1,50 +1,33 @@
+import { HTTP } from "@/api/v3/base";
 import { serializeParams } from "@/api/v3/common";
 
-import { HTTP } from "./base";
+const getAdminFlags = () => HTTP.get("/auth/flags/");
 
-const getAdminFlags = async () => {
-  return await HTTP.get("/auth/flags/");
-};
+const updateTimezone = () =>
+  HTTP.put("/auth/timezone/", {
+    timezone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
 
-const get_tz = () => new Intl.DateTimeFormat().resolvedOptions().timeZone;
+// Backend reads ``login`` (django-allauth field name); the form binds to
+// ``username``. Spread instead of mutating so the caller's reactive form
+// state doesn't grow a stray ``login`` field.
+const register = (credentials) =>
+  HTTP.post("/auth/register/", { ...credentials, login: credentials.username });
 
-const updateTimezone = async () => {
-  const data = {
-    timezone: get_tz(),
-  };
-  return await HTTP.put("/auth/timezone/", data);
-};
+const login = (credentials) =>
+  HTTP.post("/auth/login/", { ...credentials, login: credentials.username });
 
-const register = async (credentials) => {
-  credentials.login = credentials.username;
-  return await HTTP.post("/auth/register/", credentials);
-};
+const getProfile = () =>
+  HTTP.get("/auth/profile/", { params: serializeParams() });
 
-const login = async (credentials) => {
-  credentials.login = credentials.username;
-  return await HTTP.post("/auth/login/", credentials);
-};
+const logout = () => HTTP.post("/auth/logout/");
 
-const getProfile = async () => {
-  const params = serializeParams();
-  return await HTTP.get("/auth/profile/", { params });
-};
+const updatePassword = (credentials) =>
+  HTTP.post("/auth/change-password/", credentials);
 
-const logout = async () => {
-  return await HTTP.post("/auth/logout/");
-};
+const getToken = () => HTTP.get("/auth/token/");
 
-const updatePassword = async (credentials) => {
-  return await HTTP.post("/auth/change-password/", credentials);
-};
-
-const getToken = async () => {
-  return await HTTP.get("/auth/token/");
-};
-
-const updateToken = async () => {
-  return await HTTP.put("/auth/token/");
-};
+const updateToken = () => HTTP.put("/auth/token/");
 
 export default {
   updatePassword,

--- a/frontend/src/api/v3/browser.js
+++ b/frontend/src/api/v3/browser.js
@@ -1,8 +1,7 @@
 import { toRaw } from "vue";
 
+import { HTTP } from "@/api/v3/base";
 import { serializeParams } from "@/api/v3/common";
-
-import { HTTP } from "./base";
 
 const getBrowserHrefPath = ({ group, pks, query, ts }) => {
   const params = serializeParams(query, ts);
@@ -120,11 +119,11 @@ export const getGroupDownloadURL = ({ group, pks }, fn, settings, ts) => {
 const updateGroupBookmarks = ({ group, ids }, settings, updates) => {
   const params = serializeParams(settings);
   const queryString = new URLSearchParams(params).toString();
-  if (updates.fitTo === null) {
-    updates.fitTo = "";
-  }
+  // Backend rejects the JSON literal ``null`` for ``fitTo``; normalise
+  // without mutating the caller's reactive update payload.
+  const body = updates.fitTo === null ? { ...updates, fitTo: "" } : updates;
   const pkList = ids.join(",");
-  return HTTP.patch(`${group}/${pkList}/bookmark?${queryString}`, updates);
+  return HTTP.patch(`/${group}/${pkList}/bookmark?${queryString}`, body);
 };
 
 const getLazyImport = ({ group, pks }) => {

--- a/frontend/src/api/v3/common.js
+++ b/frontend/src/api/v3/common.js
@@ -2,35 +2,7 @@ import { toRaw } from "vue";
 
 import { useCommonStore } from "@/stores/common";
 
-import { HTTP } from "./base";
-
-const map = (obj, func) => {
-  // Generic map for arrays and objects
-  switch (obj?.constructor) {
-    case Array:
-      return obj.map((x) => func(x));
-    case Object:
-      return Object.fromEntries(
-        Object.entries(obj).map(([key, val]) => [key, func(val, key)]),
-      );
-    default:
-      return obj;
-  }
-};
-
-const filter = (obj, func) => {
-  // Generic filter for arrays and objects
-  switch (obj?.constructor) {
-    case Array:
-      return obj.filter((x) => func(x));
-    case Object:
-      return Object.fromEntries(
-        Object.entries(obj).filter(([key, val]) => func(val, key)),
-      );
-    default:
-      return obj;
-  }
-};
+import { HTTP } from "@/api/v3/base";
 
 const _keepIfNotEmpty = (val) => {
   // Keep flag for filter
@@ -58,13 +30,14 @@ const _deepClone = (obj, filterEmpty = false) => {
   switch (obj?.constructor) {
     case Array:
       return obj.map((v) => _deepClone(v, filterEmpty)).filter(_keep);
-    case Object:
+    case Object: {
       const result = {};
       for (const [key, val] of Object.entries(obj)) {
         const clonedVal = _deepClone(val, filterEmpty);
         if (_keep(clonedVal)) result[key] = clonedVal;
       }
       return result;
+    }
     default:
       return obj;
   }

--- a/frontend/src/api/v3/reader.js
+++ b/frontend/src/api/v3/reader.js
@@ -1,13 +1,10 @@
+import { HTTP } from "@/api/v3/base";
 import { serializeParams } from "@/api/v3/common";
 
-import { HTTP } from "./base";
-
-const _getBookPath = (pk) => {
-  return `c/${pk}`;
-};
+const _getBookPath = (pk) => `c/${pk}`;
 
 const getSettings = (pk, scopes, storyArcPk) => {
-  const basePath = pk ? `${_getBookPath(pk)}/settings` : "c/settings";
+  const basePath = pk ? `/${_getBookPath(pk)}/settings` : "/c/settings";
   const queryParams = { scopes: scopes.join(",") };
   if (storyArcPk) {
     queryParams.story_arc_pk = storyArcPk;
@@ -16,23 +13,17 @@ const getSettings = (pk, scopes, storyArcPk) => {
   return HTTP.get(basePath, { params });
 };
 
-const updateSettings = (data) => {
-  return HTTP.patch("c/settings", data);
-};
+const updateSettings = (data) => HTTP.patch("/c/settings", data);
 
-const resetSettings = (data) => {
-  return HTTP.delete("c/settings", { data });
-};
+const resetSettings = (data) => HTTP.delete("/c/settings", { data });
 
 const getReaderInfo = (pk, data, ts, options = {}) => {
   const params = serializeParams(data, ts);
-  const bookPath = _getBookPath(pk);
-  return HTTP.get(bookPath, { params, ...options });
+  return HTTP.get(`/${_getBookPath(pk)}`, { params, ...options });
 };
 
-const _getReaderAPIPath = (pk) => {
-  return globalThis.CODEX.API_V3_PATH + _getBookPath(pk);
-};
+const _getReaderAPIPath = (pk) =>
+  globalThis.CODEX.API_V3_PATH + _getBookPath(pk);
 
 export const getComicPageSource = ({ pk, page, mtime }) => {
   const bookAPIPath = _getReaderAPIPath(pk);
@@ -40,20 +31,23 @@ export const getComicPageSource = ({ pk, page, mtime }) => {
 };
 
 export const getComicDownloadURL = ({ pk }, fn, ts) => {
-  // Gets used by an HTTP.get so already has base path.
+  // Consumed via ``HTTP.get`` (iOS-PWA download fix), so the ``baseURL``
+  // prefix is added by xior — no leading slash here.
   const bookPath = _getBookPath(pk);
   fn = fn ? encodeURIComponent(fn) : `comic-${pk}.cbz`;
   return `${bookPath}/download/${fn}?ts=${ts}`;
 };
 
 export const getDownloadPageURL = ({ pk, page, mtime }) => {
-  // Gets used by an HTTP.get so already has base path.
+  // Consumed via ``HTTP.get``, so no leading slash (see above).
   const bookPath = _getBookPath(pk);
   return `${bookPath}/${page}/page.jpg?ts=${mtime}`;
 };
 
 export const getPDFInBrowserURL = ({ pk, mtime }) => {
-  // Raw URL needs leading slash
+  // Consumed by ``<embed src=...>``, not ``HTTP.get`` — needs an
+  // absolute path so the browser doesn't resolve it relative to the
+  // current SPA route.
   const bookPath = _getBookPath(pk);
   return `/${bookPath}/book.pdf?ts=${mtime}`;
 };


### PR DESCRIPTION
## Summary

QoL pass on \`frontend/src/api/v3/\` — pure refactor following the directory review. No caller changes, no behaviour change for the inputs callers actually pass; closes a couple of latent footguns (input mutation) along the way.

## Changes

**A1.** Drop unused \`map\` and \`filter\` helpers in [common.js](frontend/src/api/v3/common.js) — declared but neither exported nor called. ESLint should have caught these; \`no-unused-vars\` must be off in the config.

**A2.** Replace input-mutation patterns with non-mutating spreads in [auth.js](frontend/src/api/v3/auth.js) (\`register\` / \`login\`) and [browser.js](frontend/src/api/v3/browser.js) (\`updateGroupBookmarks\`). \`browser.js\` already learned this lesson once for the \`{show: _show, ...query}\` rest spread in \`getGroupDownloadURL\`; same pattern, two more places.

**A3.** Inline the snake_case \`get_tz\` into \`updateTimezone\` — used once, body is a single expression.

**A4.** Wrap \`case Object: { … }\` in \`_deepClone\` with a block scope so the \`const result\` declaration doesn't leak.

**B1.** Drop the \`async () => return await HTTP.…\` shape from [auth.js](frontend/src/api/v3/auth.js) (every function) and [admin.js](frontend/src/api/v3/admin.js) (\`postLibrarianTask\`, \`updateAPIKey\`). The bare-expression form is what the rest of the directory uses.

**B2.** Unify cross-module import path on \`@/api/v3/base\` instead of \`./base\`. Every file already used \`@/api/v3/common\` for the sibling helper, so the alias path is the dominant convention.

**B5.** Normalise HTTP-call paths to leading-slash form. [reader.js](frontend/src/api/v3/reader.js) was the only file using bare \`c/…\` paths, and [browser.js:127](frontend/src/api/v3/browser.js:127) (\`updateGroupBookmarks\`) was the lone outlier in its own file. **xior's \`joinPath\` strips trailing slash from \`baseURL\` and leading slash from path before joining**, so both forms produce identical URLs in production — the change is purely conventional. \`getPDFInBrowserURL\` still emits a leading-slash absolute path because it's consumed by \`<embed src=…>\`, not by xior; updated its comment to say so.

## B4 reviewed, *not* changed

I'd flagged \`serializeParams()\` no-arg vs inline \`{ts: Date.now()}\` as inconsistent. After looking at \`useCommonStore().timestamp\` ([stores/common.js:47,95](frontend/src/stores/common.js:47)), they are deliberately different mechanisms:

* **Sticky cache key** — \`useCommonStore().timestamp\` is set once on load and ticked only on librarian-completion WebSocket events ([stores/socket.js:160,197](frontend/src/stores/socket.js:160)) and reader navigation ([reader-toolbar-top.vue:152](frontend/src/components/reader/toolbars/top/reader-toolbar-top.vue:152)). Multi-component fan-out shares one response per "event boundary."
* **Real-time timestamp** — \`{ts: Date.now()}\` bypasses caches entirely. Used by \`getActiveLibrarianStatuses\` / \`getAllLibrarianStatuses\` / \`getStats\` because they want fresh data on every poll.

So they look identical at the call site but mean different things. Left alone.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bun run test:ci\` — vitest passes
- [x] xior URL handling verified by reading \`node_modules/xior/dist/xior.umd.js\` — \`joinPath\` normalises leading/trailing slashes
- [ ] Manual: log in / log out / register flow (auth.js touched)
- [ ] Manual: open the reader (reader.js touched), download a comic (download URL builder), download a single page (download URL builder), bookmark a multi-comic group (\`updateGroupBookmarks\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)