### PR TITLE
fix snapshot inode-collision corruption + cleanup migration

### DIFF
--- a/codex/librarian/fs/poller/snapshot_diff.py
+++ b/codex/librarian/fs/poller/snapshot_diff.py
@@ -130,17 +130,50 @@ class SnapshotDiff:
             new_path
         ) and data.ref.size(old_path) == data.snapshot.size(new_path)
 
+    @staticmethod
+    def _is_move_compatible(data: _DiffData, src: str, dest: str) -> bool:
+        """
+        Reject inode-match pairs that can't be a real rename.
+
+        ``Snapshot._inode`` collapses cross-filesystem inodes into a
+        single keyspace (``_ignore_device=True``), so a comic file's
+        stored inode can collide with an unrelated directory's inode
+        from a different mount. Without these guards the importer
+        rewrites the comic's ``path`` and ``stat`` to the directory
+        target, leaving a phantom Comic-as-folder row behind and
+        spawning a fresh Comic for the original file on the next
+        cycle (orphaning bookmarks).
+
+        Two cheap sanity checks make the inode match load-bearing only
+        when it's plausibly a rename:
+
+        - File type must match. A real rename never crosses ``stat()``
+          file-type bits — files become files, directories stay
+          directories. Mode mismatches are always inode collisions.
+        - For files, size must match too. Renames preserve size, and
+          two unrelated archives are vanishingly unlikely to share an
+          exact byte count. Directory ``st_size`` varies with entry
+          count and is unreliable, so this check applies to files
+          only.
+        """
+        src_is_dir = data.ref.is_dir(src)
+        if src_is_dir != data.snapshot.is_dir(dest):
+            return False
+        return src_is_dir or data.ref.size(src) == data.snapshot.size(dest)
+
     def _find_moved_paths(self, data: _DiffData) -> None:
         """Detect moves by matching inodes between deleted and added sets."""
         for old_path in tuple(data.deleted):
             inode = data.ref.inode(old_path)
-            if new_path := data.snapshot.path(inode):
+            new_path = data.snapshot.path(inode)
+            if new_path and self._is_move_compatible(data, old_path, new_path):
                 data.deleted.remove(old_path)
                 data.moved.add((old_path, new_path))
 
         for new_path in tuple(data.added):
             inode = data.snapshot.inode(new_path)
-            if old_path := data.ref.path(inode):
+            old_path = data.ref.path(inode)
+            if old_path and self._is_move_compatible(data, old_path, new_path):
                 data.added.remove(new_path)
                 data.moved.add((old_path, new_path))
 

--- a/codex/migrations/0041_cleanup_phantom_comic_as_folder_rows.py
+++ b/codex/migrations/0041_cleanup_phantom_comic_as_folder_rows.py
@@ -1,0 +1,173 @@
+"""
+Delete corrupt Comic rows whose ``path`` points at a directory.
+
+Background
+==========
+
+Through v1.11.4 the snapshot diff matched moves by ``(device, inode)``
+with ``device`` forced to 0 to ride out Docker bind-mount remounts.
+That fix protected against false-modify storms on remount but left a
+much rarer collision unguarded: a comic file's stored inode could
+randomly equal an unrelated *directory's* current disk inode on a
+different device. The diff treated that as a rename, the importer
+rewrote the Comic row's ``path`` to the directory, and
+``Comic.presave()`` re-read disk stat — picking up the directory's
+mode bits and size — leaving a "phantom Comic-as-folder" row in the
+database. The original comic file then re-imported as a fresh row
+on the next cycle, orphaning bookmarks.
+
+The companion code change (``SnapshotDiff._is_move_compatible``)
+prevents new rows from being corrupted; this migration cleans up
+rows already corrupted by past runs.
+
+Detection
+=========
+
+A corrupt row has all of:
+
+- A non-comic-suffix ``path`` (the original importer bug's
+  page_count==0 phantoms had this too — migration 0039 cleaned
+  those up but only when ``page_count == 0``; corruption from the
+  inode-collision path inherits the original comic's page_count
+  and slipped through).
+- A ``stat[0]`` mode field with the directory bit set, OR a
+  ``Path(path)`` that resolves to a directory on disk now.
+
+We require *both* a non-comic suffix and a directory signal so a
+genuinely-named comic with a transient stat read isn't deleted by
+mistake.
+
+Safety
+======
+
+If the comics volume is unmounted at migration time, every
+``Path.is_dir()`` returns False and we'd do nothing — fine. But
+``stat[0]``-based detection still fires from the stored data, so
+add the same FS-reachable sentinel migration 0039 uses: only
+proceed if at least one comic-suffix path stats as a real file.
+"""
+
+import re
+from pathlib import Path
+from stat import S_ISDIR
+
+from django.db import migrations
+from loguru import logger
+
+_COMIC_SUFFIX_RE = re.compile(r"^\.(cbz|cbr|cbt|cb7|pdf)$", re.IGNORECASE)
+_SENTINEL_LIMIT = 32
+_STAT_LEN = 10
+_STAT_MODE_INDEX = 0
+
+
+def _is_comic_path(path_str: str) -> bool:
+    if not path_str:
+        return False
+    suffix = Path(path_str).suffix
+    return bool(suffix) and _COMIC_SUFFIX_RE.match(suffix) is not None
+
+
+def _comics_fs_reachable(model) -> tuple[bool, int]:
+    """
+    Probe up to ``_SENTINEL_LIMIT`` comic-suffix paths to verify the FS is mounted.
+
+    Mirrors migration 0039's approach. Returns ``(reachable, attempts)``.
+    Reachable as soon as one comic-suffix path stats as a file. If no
+    successes, the FS is unreachable and the caller skips the cleanup.
+    """
+    attempts = 0
+    for comic in model.objects.only("path").iterator():
+        path_str = comic.path or ""
+        if not _is_comic_path(path_str):
+            continue
+        attempts += 1
+        try:
+            if Path(path_str).is_file():
+                return True, attempts
+        except OSError:
+            pass
+        if attempts >= _SENTINEL_LIMIT:
+            break
+    return False, attempts
+
+
+def _stat_says_directory(stat_value) -> bool:
+    """Whether the stored stat array's mode bits mark this row as a directory."""
+    if not stat_value or len(stat_value) != _STAT_LEN:
+        return False
+    mode = stat_value[_STAT_MODE_INDEX]
+    if not isinstance(mode, int):
+        return False
+    return S_ISDIR(mode)
+
+
+def _path_says_directory(path_str: str) -> bool:
+    """Whether the path resolves to a directory on disk right now."""
+    try:
+        return Path(path_str).is_dir()
+    except OSError:
+        return False
+
+
+def _find_corrupt_comic_pks(model) -> tuple[int, ...]:
+    """Find Comic rows whose path points at a directory (or non-comic non-file)."""
+    delete_pks: list[int] = []
+    qs = model.objects.only("pk", "path", "stat")
+    for comic in qs.iterator():
+        path_str = comic.path or ""
+        if _is_comic_path(path_str):
+            # Genuinely a comic archive name; leave it alone even if
+            # the stored stat is bogus — that's a different repair.
+            continue
+        if _stat_says_directory(comic.stat) or _path_says_directory(path_str):
+            delete_pks.append(comic.pk)
+    return tuple(delete_pks)
+
+
+def _cleanup_phantom_comic_as_folder_rows(apps, _schema_editor) -> None:
+    """Delete Comic rows whose path is a directory."""
+    model = apps.get_model("codex", "Comic")
+
+    reachable, sentinel_attempts = _comics_fs_reachable(model)
+    if not reachable:
+        if sentinel_attempts == 0:
+            msg = (
+                "Skipping phantom Comic-as-folder cleanup: no comic-suffix "
+                "paths in the database to use as a stat sentinel."
+            )
+            logger.info(msg)
+        else:
+            msg = (
+                f"Skipping phantom Comic-as-folder cleanup: probed "
+                f"{sentinel_attempts} comic-suffix paths and none stat as "
+                "files. If your comics volume is not mounted, restart with "
+                "it attached so this cleanup can run."
+            )
+            logger.warning(msg)
+        return
+
+    delete_pks = _find_corrupt_comic_pks(model)
+    if not delete_pks:
+        return
+    msg = (
+        f"Deleting {len(delete_pks)} phantom Comic-as-folder rows from "
+        "codex_comic. Affected bookmarks will be lost — see PR notes."
+    )
+    logger.info(msg)
+    model.objects.filter(pk__in=delete_pks).delete()
+
+
+def _noop(_apps, _schema_editor) -> None:
+    """Reverse no-op (data migrations stay applied on rollback)."""
+
+
+class Migration(migrations.Migration):
+    """One-time cleanup of Comic rows whose path points at a directory."""
+
+    dependencies = [
+        ("codex", "0040_reset_global_cache_book"),
+    ]
+
+    operations = [
+        migrations.RunPython(_cleanup_phantom_comic_as_folder_rows, _noop),
+    ]

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -1,0 +1,133 @@
+"""Test the snapshot diff move-detection guards."""
+
+import os
+from logging import getLogger
+
+from codex.librarian.fs.poller.snapshot import Snapshot
+from codex.librarian.fs.poller.snapshot_diff import SnapshotDiff
+
+# os.stat_result tuple positions: mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime
+_DIR_MODE = 0o040755  # drwxr-xr-x
+_FILE_MODE = 0o100644  # -rw-r--r--
+
+
+def _stat(*, mode: int, ino: int, size: int, mtime: float = 1.0) -> os.stat_result:
+    return os.stat_result((mode, ino, 0, 0, 0, 0, size, 0, mtime, 0))
+
+
+def _snapshot(entries: dict[str, os.stat_result]) -> Snapshot:
+    """Build a Snapshot directly from a path→stat map, bypassing disk/db."""
+    snap = Snapshot.__new__(Snapshot)
+    snap._root = "/comics"  # noqa: SLF001
+    snap.log = getLogger("test")
+    snap._covers_only = False  # noqa: SLF001
+    snap._ignore_device = True  # noqa: SLF001
+    snap._stat_info = dict(entries)  # noqa: SLF001
+    snap._device_inode_to_path = {  # noqa: SLF001
+        (0, st.st_ino): path for path, st in entries.items()
+    }
+    return snap
+
+
+def test_real_file_rename_is_detected() -> None:
+    """Sanity: a legitimate file move (same inode, same size) is still a move."""
+    db = _snapshot(
+        {
+            "/comics/a.cbz": _stat(mode=_FILE_MODE, ino=42, size=1000),
+        }
+    )
+    disk = _snapshot(
+        {
+            "/comics/b.cbz": _stat(mode=_FILE_MODE, ino=42, size=1000),
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    assert diff.files_moved == [("/comics/a.cbz", "/comics/b.cbz")]
+    assert not diff.files_deleted
+    assert not diff.files_added
+
+
+def test_real_directory_rename_is_detected() -> None:
+    """Sanity: a directory rename (same inode, type both dir) is a move."""
+    db = _snapshot(
+        {
+            "/comics/Old": _stat(mode=_DIR_MODE, ino=99, size=128),
+        }
+    )
+    disk = _snapshot(
+        {
+            "/comics/New": _stat(mode=_DIR_MODE, ino=99, size=200),  # size differs
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    # Directory moves don't require size match because dir st_size
+    # varies with entry count.
+    assert diff.dirs_moved == [("/comics/Old", "/comics/New")]
+
+
+def test_file_to_directory_inode_collision_is_not_a_move() -> None:
+    """A file in DB and a dir on disk sharing an inode must not be paired."""
+    db = _snapshot(
+        {
+            "/comics/Powers Gods #001.cbz": _stat(
+                mode=_FILE_MODE, ino=1104, size=220_000_000
+            ),
+        }
+    )
+    disk = _snapshot(
+        {
+            "/comics/Wolverine Saga (1989)": _stat(mode=_DIR_MODE, ino=1104, size=224),
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    # The file is gone, the directory is new — no phantom rename.
+    assert not diff.files_moved
+    assert not diff.dirs_moved
+    assert diff.files_deleted == ["/comics/Powers Gods #001.cbz"]
+    assert diff.dirs_added == ["/comics/Wolverine Saga (1989)"]
+
+
+def test_directory_to_file_inode_collision_is_not_a_move() -> None:
+    """A dir in DB and a file on disk sharing an inode must not be paired."""
+    db = _snapshot(
+        {
+            "/comics/Old Folder": _stat(mode=_DIR_MODE, ino=77, size=128),
+        }
+    )
+    disk = _snapshot(
+        {
+            "/comics/some.cbz": _stat(mode=_FILE_MODE, ino=77, size=50_000),
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    assert not diff.dirs_moved
+    assert not diff.files_moved
+    assert diff.dirs_deleted == ["/comics/Old Folder"]
+    assert diff.files_added == ["/comics/some.cbz"]
+
+
+def test_file_to_file_size_mismatch_is_not_a_move() -> None:
+    """Two unrelated files sharing an inode but with different sizes don't pair."""
+    db = _snapshot(
+        {
+            "/comics/a.cbz": _stat(mode=_FILE_MODE, ino=200, size=100),
+        }
+    )
+    disk = _snapshot(
+        {
+            "/comics/b.cbz": _stat(mode=_FILE_MODE, ino=200, size=999),
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    assert not diff.files_moved
+    assert diff.files_deleted == ["/comics/a.cbz"]
+    assert diff.files_added == ["/comics/b.cbz"]
+
+
+def test_unchanged_paths_are_unaffected_by_guards() -> None:
+    """Paths present in both snapshots must not become spurious moves."""
+    stat = _stat(mode=_FILE_MODE, ino=5, size=1000)
+    db = _snapshot({"/comics/a.cbz": stat})
+    disk = _snapshot({"/comics/a.cbz": stat})
+    diff = SnapshotDiff(db, disk)
+    assert diff.is_empty()


### PR DESCRIPTION
## Summary

Two-part fix for the snapshot diff bug that turns Comic rows into phantom Comic-as-folder rows.

### The bug

`Snapshot._inode` always collapses device IDs to 0 (`_ignore_device=True`), so a comic file's stored inode can collide with a totally unrelated directory's inode on a different mount. `_find_moved_paths` accepted any inode match as a rename, the importer overwrote the Comic's `path` to the directory target, `Comic.presave()` re-read disk stat (picking up the directory's mode bits), and the original comic file then re-imported as a fresh Comic row on the next cycle — orphaning the user's bookmark on the old row.

The corruption is silent and accumulates over many cycles. In a production database I audited, 19 Comic rows out of 877 had `stat[0]` directory mode bits and paths pointing at real folders on disk:

```
4215 /comics/Marvel/Wolverine Saga (1989)        ← was Powers Gods #001.cbz before
3942 /comics/Drawn & Quarterly/Hark A Vagrant…   ← was Achewood Recipes.cbz before
5313 /comics/DC Comics/Absolute Wonder Woman …   ← was Supergirl #001.cbz before
… 16 more
```

The `_ignore_device=True` setting itself is intentional — it rides out Docker bind-mount remounts where every inode rotates without file content changing. So the right fix isn't to remove device-ignoring; it's to gate move detection on signals that survive remounts but reject cross-type collisions.

### Phase 1 — `_is_move_compatible` guard

In `SnapshotDiff._find_moved_paths`, before accepting an inode-matched pair as a rename, require:

- **Type compatibility:** `ref.is_dir(src) == snapshot.is_dir(dest)`. A comic file can't legitimately rename into a directory.
- **Size match for files:** if both ends are files, require `st_size` to match. Real renames preserve byte count; cross-device inode coincidences essentially never do. Directory `st_size` varies with entry count and is unreliable, so this check is files-only.

Six unit tests in `tests/test_snapshot_diff.py` cover the legitimate-rename path (file & dir) and each of the corruption shapes (file→dir, dir→file, file→file size mismatch).

### Phase 2 — cleanup migration

`0041_cleanup_phantom_comic_as_folder_rows.py` deletes rows that the bug already corrupted. A row qualifies for deletion when:

- Its `path` lacks a comic suffix, AND
- Its stored `stat[0]` has the directory mode bit set OR `Path(path).is_dir()` resolves to True now.

Reuses migration 0039's sentinel-stat probe: if no comic-suffix path can be `stat()`'d as a real file, the comics volume is unmounted and the migration skips rather than delete against a phantom-empty disk.

Migration 0039's `_remove_non_comic_comics` only targeted rows with `page_count == 0` (the original importer-bug signature). Rows corrupted by this inode-collision path inherit their original `page_count` and were missed.

**Bookmarks on deleted rows are lost.** Considered preserving them by capturing the `(library, path)` set before delete and re-attaching after the next poll recreates the correct Comic, but the complexity wasn't justified given the small blast radius (~2% of comics in the production sample).

### Not in this PR

- Phase 3 (refresh DB stats across Docker remounts) — would restore legitimate move detection after remounts. The May 1 fix that introduced `_ignore_device=True` semantically left DB inodes stale forever. Intentionally separate PR — it's a behavioral change.

## Test plan

- [x] `make fix` and `make lint` clean (preexisting `remark` exit-1 unrelated)
- [x] `pytest tests/` — 41 passed (35 prior + 6 new)
- [x] Verified migration matches all 19 corrupt rows in the production-shaped DB
- [ ] Run codex on a database that previously had the corruption; confirm migration deletes the rows and the next poll cycle does NOT recreate phantom Comic-as-folder entries
- [ ] Run codex on a fresh install with comics volume mounted; confirm migration is a no-op
- [ ] Run codex with the comics volume unmounted on first start; confirm migration logs the sentinel warning and skips, no rows deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)