### PR TITLE
refresh stale stats across inode rotation (Phase 3)

### DIFF
--- a/codex/librarian/fs/poller/poller.py
+++ b/codex/librarian/fs/poller/poller.py
@@ -138,10 +138,66 @@ class LibraryPollerThread(NamedThread, WorkerStatusMixin):
 
         return SnapshotDiff(db_snap, disk_snap)
 
+    def _refresh_stale_stats(self, diff: SnapshotDiff) -> None:
+        """
+        Sync DB stat to current disk stat for unchanged-content / rotated-inode paths.
+
+        Without this, the May-1 fix that stopped flagging every comic
+        modified on Docker remount left DB inodes permanently stale —
+        once a remount rotated the kernel's inode space, the
+        ``_find_moved_paths`` lookup keys diverged from disk reality
+        and stayed that way until the next true delete/add cycle. The
+        ``_is_move_compatible`` guard suppresses the corruption that
+        produced, but legitimate cross-remount renames still degrade
+        to delete+add (and the user loses the comic.pk's bookmarks).
+
+        Refresh in-place: rewrite ``stat`` only, do not bump
+        ``updated_at``. The file's content is unchanged from the
+        user's perspective; the bookmark/cover-cache "freshness"
+        invariants must hold.
+
+        Skipped on ``force=True`` polls because force routes every
+        path through the import pipeline (where ``presave`` already
+        rewrites stats), and we'd rather not double-write.
+        """
+        if not diff.stale_stat_refreshes:
+            return
+        # Bucket by model so each table takes one bulk_update.
+        by_model: dict[type, list[tuple[str, list]]] = {}
+        for refresh in diff.stale_stat_refreshes:
+            by_model.setdefault(refresh.model, []).append(
+                (refresh.path, list(refresh.disk_stat))
+            )
+        total = 0
+        for model, payloads in by_model.items():
+            paths = [p for p, _ in payloads]
+            stat_by_path = dict(payloads)
+            rows = list(model.objects.filter(path__in=paths).only("pk", "path", "stat"))
+            for row in rows:
+                row.stat = stat_by_path[row.path]
+            if rows:
+                model.objects.bulk_update(rows, fields=["stat"])
+                total += len(rows)
+        if total:
+            msg = (
+                f"Refreshed stale stat on {total} unchanged-content paths "
+                "(inode rotated, content matches)."
+            )
+            self.log.debug(msg)
+
     def _queue_poll_events(self, library: Library, *, force: bool) -> None:
         """Run the snapshot diff and emit a single ImportTask for the library."""
         diff = self._get_diff(library, force=force)
-        if not diff or diff.is_empty():
+        if diff is None:
+            return
+
+        # Refresh DB stats for paths whose content matches but whose
+        # inode rotated (Docker remount, in-place file replacement).
+        # Force polls already rewrite stats through the import path.
+        if not force:
+            self._refresh_stale_stats(diff)
+
+        if diff.is_empty():
             self.log.debug(f"Nothing changed for {library.path}")
             return
 

--- a/codex/librarian/fs/poller/snapshot.py
+++ b/codex/librarian/fs/poller/snapshot.py
@@ -2,9 +2,10 @@
 
 import os
 from collections.abc import Iterator
-from itertools import chain
 from pathlib import Path
 from stat import S_ISDIR
+
+from django.db.models import Model
 
 from codex.librarian.fs.filters import (
     match_comic,
@@ -29,6 +30,10 @@ class Snapshot:
         self._ignore_device = ignore_device
         self._stat_info: dict[str, os.stat_result] = {}
         self._device_inode_to_path: dict[tuple[int, int], str] = {}
+        # ``DatabaseSnapshot`` populates this with the source model for
+        # each path so the poller can refresh stale stats by model.
+        # ``DiskSnapshot`` leaves it empty.
+        self._path_to_model: dict[str, type[Model]] = {}
 
     def _inode(self, st: os.stat_result) -> tuple[int, int]:
         """Build a device:inode Key."""
@@ -70,6 +75,20 @@ class Snapshot:
     def is_cover(self, path: str) -> bool:
         """Return whether path is a cover."""
         return self._covers_only or match_folder_cover(Path(path))
+
+    def stat(self, path: str) -> os.stat_result:
+        """Return the raw stat for a path."""
+        return self._stat_info[path]
+
+    def model_for_path(self, path: str) -> type[Model] | None:
+        """
+        Return the source model for a DB-snapshot path, or None.
+
+        Only meaningful on ``DatabaseSnapshot``. Used by Phase-3 stale-
+        stat refresh to bulk-update each affected row by its native
+        model.
+        """
+        return self._path_to_model.get(path)
 
 
 class DiskSnapshot(Snapshot):
@@ -156,19 +175,27 @@ class DatabaseSnapshot(Snapshot):
         self._set_lookups(self._root, root_stat)
 
         models = self._COVERS_ONLY_MODELS if self._covers_only else self._MODELS
-        for wp in chain.from_iterable(self._walk(self._root, models)):
+        for model, wp in self._walk(self._root, models):
             st = self._create_stat(wp, force=self._force)
             self._set_lookups(wp["path"], st)
+            # Track which model owns each path so the poller's stale-
+            # stat refresh can bulk-update by model. Model order in
+            # ``_MODELS`` puts ``Comic`` after ``Folder``, so on the
+            # rare path collision the comic-owned mapping wins —
+            # matches the legacy ``_set_lookups`` overwrite behavior.
+            self._path_to_model[wp["path"]] = model
 
     @staticmethod
-    def _walk(root: str, models: tuple) -> Iterator:
-        """Yield querysets of {path, stat} dicts for each model."""
+    def _walk(root: str, models: tuple) -> Iterator[tuple[type[Model], dict]]:
+        """Yield (model, {path, stat} dict) for every row across all models."""
         for model in models:
-            yield (
+            qs = (
                 model.objects.filter(library__path=root)
                 .order_by("path")
                 .values("path", "stat")
             )
+            for wp in qs:
+                yield model, wp
 
     def _create_stat(self, wp: dict, *, force: bool) -> os.stat_result:
         """Turn a database JSON stat array into an os.stat_result."""

--- a/codex/librarian/fs/poller/snapshot_diff.py
+++ b/codex/librarian/fs/poller/snapshot_diff.py
@@ -5,13 +5,26 @@ Supports inode-based move detection and optional device-ignoring for
 Docker/complex filesystems.
 """
 
+import os
 from dataclasses import dataclass
+
+from django.db.models import Model
 
 from codex.librarian.fs.events import (
     FSChange,
     FSEvent,
 )
 from codex.librarian.fs.poller.snapshot import Snapshot
+
+
+@dataclass(frozen=True, slots=True)
+class StaleStatRefresh:
+    """A path whose stored stat needs refreshing without re-import."""
+
+    path: str
+    model: type[Model]
+    disk_stat: os.stat_result
+
 
 _DIFF_FIELD_EVENT_MAP: tuple[tuple[str, FSChange, bool, bool], ...] = (
     # diff_attr, change_type, is_directory, is_cover
@@ -123,6 +136,48 @@ class SnapshotDiff:
         self.covers_moved = []
         self.files_moved = []
         self._init_moved(data, ref)
+
+        self.stale_stat_refreshes: tuple[StaleStatRefresh, ...] = (
+            self._find_stale_stat_refreshes(data)
+        )
+
+    @staticmethod
+    def _find_stale_stat_refreshes(data: _DiffData) -> tuple[StaleStatRefresh, ...]:
+        """
+        Identify unchanged-content paths whose stored inode no longer matches disk.
+
+        Filter ``data.unchanged`` down to entries that ``_find_modified_paths``
+        did not promote into ``data.modified`` (mtime+size still match).
+        When the inode for one of those still differs, the file's
+        content is the same but its filesystem identity rotated under
+        us — the Docker bind-mount remount case. Without refreshing
+        those stats, the DB's inode keyspace stays permanently stale,
+        so the next ``_find_moved_paths`` call with a real delete or
+        add can match an arbitrary disk path on a numerical
+        coincidence (the corruption ``_is_move_compatible`` was added
+        to suppress).
+
+        Caller refreshes the DB stat for these paths without bumping
+        ``updated_at`` — content hasn't changed. ``model_for_path``
+        returns ``None`` for entries with no DB row (e.g. the library
+        root itself, which the snapshot adds outside of the per-model
+        walk); skip those.
+        """
+        refreshes: list[StaleStatRefresh] = []
+        for path in sorted(data.unchanged - data.modified):
+            if data.ref.inode(path) == data.snapshot.inode(path):
+                continue
+            model = data.ref.model_for_path(path)
+            if model is None:
+                continue
+            refreshes.append(
+                StaleStatRefresh(
+                    path=path,
+                    model=model,
+                    disk_stat=data.snapshot.stat(path),
+                )
+            )
+        return tuple(refreshes)
 
     def _is_stats_equal(self, data: _DiffData, old_path: str, new_path: str) -> bool:
         """Return whether mtime and size match."""

--- a/tests/test_poller_stat_refresh.py
+++ b/tests/test_poller_stat_refresh.py
@@ -1,0 +1,105 @@
+"""Integration test: poller refreshes stale Comic.stat without bumping updated_at."""
+
+import os
+import shutil
+from pathlib import Path
+from typing import override
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from codex.librarian.fs.poller.poller import LibraryPollerThread
+from codex.librarian.fs.poller.snapshot_diff import SnapshotDiff, StaleStatRefresh
+from codex.models import Comic, Imprint, Library, Publisher, Series, Volume
+
+_TMP_DIR = Path("/tmp/codex.tests.poller_stat_refresh")  # noqa: S108
+_STALE_STAT: tuple = (33188, 12345, 0, 0, 0, 0, 100, 0, 1.0, 0)
+
+
+def _create_comic_with_stale_stat() -> Comic:
+    """Create a Comic row whose stored stat lies about its inode."""
+    _TMP_DIR.mkdir(exist_ok=True, parents=True)
+    comic_path = _TMP_DIR / "stale.cbz"
+    comic_path.touch()
+    library = Library.objects.create(path=str(_TMP_DIR))
+    publisher = Publisher.objects.create(name="P")
+    imprint = Imprint.objects.create(name="I", publisher=publisher)
+    series = Series.objects.create(name="S", imprint=imprint, publisher=publisher)
+    volume = Volume.objects.create(
+        name="2024", series=series, imprint=imprint, publisher=publisher
+    )
+    comic = Comic.objects.create(
+        library=library,
+        path=str(comic_path),
+        issue_number=1,
+        name="stale",
+        publisher=publisher,
+        imprint=imprint,
+        series=series,
+        volume=volume,
+        size=100,
+        year=2024,
+        month=1,
+        day=1,
+    )
+    # Bake a stale stat directly via UPDATE so the row's updated_at
+    # snapshot we capture below is the post-create one, not a
+    # post-stat-write one.
+    Comic.objects.filter(pk=comic.pk).update(stat=list(_STALE_STAT))
+    comic.refresh_from_db()
+    return comic
+
+
+def _new_poller_thread() -> LibraryPollerThread:
+    """Build a poller without starting the threading machinery."""
+    thread = LibraryPollerThread.__new__(LibraryPollerThread)
+    thread.log = MagicMock()
+    return thread
+
+
+def _diff_with_refreshes(
+    refreshes: tuple[StaleStatRefresh, ...],
+) -> SnapshotDiff:
+    diff = SnapshotDiff.__new__(SnapshotDiff)
+    diff.stale_stat_refreshes = refreshes
+    return diff
+
+
+class StaleStatRefreshTestCase(TestCase):
+    """``LibraryPollerThread._refresh_stale_stats`` writes stat without updated_at."""
+
+    @override
+    def tearDown(self) -> None:
+        shutil.rmtree(_TMP_DIR, ignore_errors=True)
+
+    def test_stat_refresh_writes_stat_and_does_not_bump_updated_at(self) -> None:
+        """Stat field is rewritten; updated_at and content fields stay put."""
+        comic = _create_comic_with_stale_stat()
+        original_updated_at = comic.updated_at
+
+        # Simulate a Docker remount: same content, brand-new inode.
+        fresh_inode = 99999
+        fresh_stat = os.stat_result((33188, fresh_inode, 0, 0, 0, 0, 100, 0, 1.0, 0))
+        diff = _diff_with_refreshes(
+            (StaleStatRefresh(path=comic.path, model=Comic, disk_stat=fresh_stat),)
+        )
+
+        _new_poller_thread()._refresh_stale_stats(diff)  # noqa: SLF001
+
+        comic.refresh_from_db()
+        # The stored stat now reflects disk's fresh inode...
+        assert comic.stat is not None
+        assert comic.stat[1] == fresh_inode
+        # ...but the row's updated_at didn't advance, so bookmark
+        # "fresh" semantics aren't disturbed.
+        assert comic.updated_at == original_updated_at
+
+    def test_stat_refresh_noop_when_diff_empty(self) -> None:
+        """An empty stale-stat list must not touch the DB at all."""
+        comic = _create_comic_with_stale_stat()
+        diff = _diff_with_refreshes(())
+
+        _new_poller_thread()._refresh_stale_stats(diff)  # noqa: SLF001
+
+        comic.refresh_from_db()
+        assert comic.stat == list(_STALE_STAT)

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 from codex.librarian.fs.poller.snapshot import Snapshot
 from codex.librarian.fs.poller.snapshot_diff import SnapshotDiff
+from codex.models import Comic, Folder
 
 # os.stat_result tuple positions: mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime
 _DIR_MODE = 0o040755  # drwxr-xr-x
@@ -15,7 +16,11 @@ def _stat(*, mode: int, ino: int, size: int, mtime: float = 1.0) -> os.stat_resu
     return os.stat_result((mode, ino, 0, 0, 0, 0, size, 0, mtime, 0))
 
 
-def _snapshot(entries: dict[str, os.stat_result]) -> Snapshot:
+def _snapshot(
+    entries: dict[str, os.stat_result],
+    *,
+    models: dict[str, type] | None = None,
+) -> Snapshot:
     """Build a Snapshot directly from a path→stat map, bypassing disk/db."""
     snap = Snapshot.__new__(Snapshot)
     snap._root = "/comics"  # noqa: SLF001
@@ -26,6 +31,7 @@ def _snapshot(entries: dict[str, os.stat_result]) -> Snapshot:
     snap._device_inode_to_path = {  # noqa: SLF001
         (0, st.st_ino): path for path, st in entries.items()
     }
+    snap._path_to_model = dict(models) if models else {}  # noqa: SLF001
     return snap
 
 
@@ -131,3 +137,87 @@ def test_unchanged_paths_are_unaffected_by_guards() -> None:
     disk = _snapshot({"/comics/a.cbz": stat})
     diff = SnapshotDiff(db, disk)
     assert diff.is_empty()
+
+
+def test_stale_stat_refresh_emitted_for_inode_rotation_only() -> None:
+    """Path with same content but different inode → queue a stat refresh."""
+    fresh_ino = 999
+    db = _snapshot(
+        {
+            "/comics/a.cbz": _stat(mode=_FILE_MODE, ino=100, size=1000),
+            "/comics/b.cbz": _stat(mode=_FILE_MODE, ino=200, size=2000),
+        },
+        models={"/comics/a.cbz": Comic, "/comics/b.cbz": Comic},
+    )
+    disk = _snapshot(
+        {
+            # a.cbz: same mtime+size, fresh inode (Docker-remount fingerprint)
+            "/comics/a.cbz": _stat(mode=_FILE_MODE, ino=fresh_ino, size=1000),
+            # b.cbz: identical to DB, no refresh needed
+            "/comics/b.cbz": _stat(mode=_FILE_MODE, ino=200, size=2000),
+        },
+    )
+    diff = SnapshotDiff(db, disk)
+    refreshes = diff.stale_stat_refreshes
+    assert len(refreshes) == 1
+    assert refreshes[0].path == "/comics/a.cbz"
+    assert refreshes[0].model is Comic
+    assert refreshes[0].disk_stat.st_ino == fresh_ino
+    # The path is still "unchanged" — no diff event fires for it.
+    assert not diff.files_modified
+    assert not diff.files_moved
+
+
+def test_stale_stat_refresh_skipped_when_content_changed() -> None:
+    """If mtime or size differs, the path is modified — not stale-stat."""
+    db = _snapshot(
+        {"/comics/a.cbz": _stat(mode=_FILE_MODE, ino=100, size=1000, mtime=1.0)},
+        models={"/comics/a.cbz": Comic},
+    )
+    disk = _snapshot(
+        {
+            # mtime changed → real modification, not just a stale stat
+            "/comics/a.cbz": _stat(mode=_FILE_MODE, ino=999, size=1000, mtime=2.0)
+        }
+    )
+    diff = SnapshotDiff(db, disk)
+    assert diff.stale_stat_refreshes == ()
+    assert diff.files_modified == ["/comics/a.cbz"]
+
+
+def test_stale_stat_refresh_handles_folder_paths() -> None:
+    """Inode rotation on a directory path also queues a refresh."""
+    db = _snapshot(
+        {"/comics/Some Series": _stat(mode=_DIR_MODE, ino=50, size=128)},
+        models={"/comics/Some Series": Folder},
+    )
+    disk = _snapshot(
+        {"/comics/Some Series": _stat(mode=_DIR_MODE, ino=777, size=128)},
+    )
+    diff = SnapshotDiff(db, disk)
+    assert len(diff.stale_stat_refreshes) == 1
+    assert diff.stale_stat_refreshes[0].model is Folder
+
+
+def test_stale_stat_refresh_skips_paths_without_model() -> None:
+    """Library root has no DB row; never emit a refresh for it."""
+    db = _snapshot(
+        # No model entry for the bare root; DatabaseSnapshot adds the
+        # root via Path.stat(), not the per-model walk.
+        {"/comics": _stat(mode=_DIR_MODE, ino=1, size=128)},
+        models={},
+    )
+    disk = _snapshot(
+        {"/comics": _stat(mode=_DIR_MODE, ino=2, size=128)},
+    )
+    diff = SnapshotDiff(db, disk)
+    assert diff.stale_stat_refreshes == ()
+
+
+def test_stale_stat_refresh_empty_when_inodes_match() -> None:
+    """No drift, no refreshes — the common case."""
+    stat = _stat(mode=_FILE_MODE, ino=42, size=1000)
+    db = _snapshot({"/comics/a.cbz": stat}, models={"/comics/a.cbz": Comic})
+    disk = _snapshot({"/comics/a.cbz": stat})
+    diff = SnapshotDiff(db, disk)
+    assert diff.stale_stat_refreshes == ()


### PR DESCRIPTION
## Summary

Closes the loop that #735 left open: refresh DB stats when an inode rotates without content changing, so the diff's lookup keyspace stays synchronized with disk reality across Docker bind-mount remounts.

### Why

The May 1 fix that stopped flagging every comic modified when inodes rotate (689bbc4f) correctly silenced the false-modify storm Docker remounts produced — but it left DB stat rows permanently lying about disk reality afterward. Once a remount rotated the kernel's inode space, every `_find_moved_paths` call ran against a lookup table that no longer matched any of the inodes the disk would emit.

#735's `_is_move_compatible` guard suppresses the corruption that mismatch produced (file rows whose `path` was rewritten to a directory). But suppression isn't repair: legitimate cross-remount renames still degrade to delete+add, and the user loses bookmarks tied to the recreated `comic.pk`.

This PR refreshes the DB stat in place — `bulk_update(fields=["stat"])` only, `updated_at` is **not** bumped because the file's content hasn't changed.

### Trigger condition

A path P qualifies for refresh when:
1. P is in `data.unchanged` (present in both DB and disk snapshots)
2. P is **not** in `data.modified` (mtime and size match disk)
3. `db_snap.inode(P) != disk_snap.inode(P)` (inode rotated under us)

That predicate fingerprints the Docker remount case and the rsync-with-timestamps file-replacement case. It produces zero refreshes when inodes are stable, so the common case has no DB writes.

### Where in the cycle

`_queue_poll_events`, between `_get_diff` and the import-task build:

```
1. Build DatabaseSnapshot
2. Build DiskSnapshot
3. SnapshotDiff(db, disk)
4. (NEW) _refresh_stale_stats(diff)  — only if not force
5. If diff.is_empty() → return
6. Build ImportTask from diff events → queue
```

Skipped on `force=True` polls because force routes every path through the import pipeline (where `presave()` already rewrites stats), and double-writing serves no purpose.

### Implementation notes

- `DatabaseSnapshot` now tracks the source model for each path in a new `_path_to_model` map. `Snapshot.model_for_path()` exposes it; `DiskSnapshot` leaves it empty.
- `SnapshotDiff` exposes `stale_stat_refreshes: tuple[StaleStatRefresh, ...]`. Each carries `path`, `model`, and the fresh disk `os.stat_result`.
- The poller buckets refreshes by model so each affected table takes exactly one `bulk_update` per cycle.

### Operational

- Zero DB writes on cycles where inodes are stable.
- One `bulk_update` per affected model on a remount.
- Idempotent: a second cycle after a successful refresh sees no inode drift and emits zero refreshes.

## Test plan

- [x] `make fix` and `make lint` clean (preexisting `remark` exit-1 unrelated)
- [x] `pytest tests/` — 48 passed (5 new diff-layer unit tests, 2 new Django integration tests, 41 pre-existing)
- [ ] Run codex on a database that's been corrupted by the original bug; confirm post-restart stats refresh and no further phantom moves are logged
- [ ] Force-restart Docker container so kernel reassigns inodes; confirm next poll emits "Refreshed stale stat on N unchanged-content paths" and `updated_at` on those rows is unchanged
- [ ] Manual `--force` poll: confirm the refresh path is skipped (force path handles its own stat updates via `presave`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)