### PR TITLE
fix Ctrl+C hang from cover ProcessPoolExecutor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ border-radius: 128px;
 - Fixes
     - Fix occasional recreation of comics on docker or network filesystems.
     - Fix double polling of some libraries.
+    - Fix Codex sometimes hanging on shutdown after Ctrl+C.
 
 ## v1.11.4
 

--- a/codex/librarian/covers/create.py
+++ b/codex/librarian/covers/create.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import contextlib
 import os
+import signal
 from abc import ABC
-from concurrent.futures import CancelledError, ProcessPoolExecutor, as_completed
+from concurrent.futures import (
+    BrokenExecutor,
+    CancelledError,
+    ProcessPoolExecutor,
+    as_completed,
+)
 from io import BytesIO
 from pathlib import Path
 from queue import Empty
@@ -32,6 +38,22 @@ _COVER_RATIO = 1.5372233400402415  # modal cover ratio
 THUMBNAIL_WIDTH = 165
 THUMBNAIL_HEIGHT = round(THUMBNAIL_WIDTH * _COVER_RATIO)
 _THUMBNAIL_SIZE = (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
+
+
+def _init_cover_worker() -> None:
+    """
+    Detach cover workers from the parent's SIGINT.
+
+    Workers share the foreground process group with the librarian, so
+    a terminal ^C delivers SIGINT to every worker too. ``_process_worker``
+    blocks on ``call_queue.get()`` with no try/except around the loop,
+    so a raised KeyboardInterrupt kills the worker mid-call — which
+    leaves the pool's ``_ExecutorManagerThread`` in a broken state and
+    can hang ``p.join()`` during interpreter shutdown's ``_python_exit``
+    atexit hook. Ignoring SIGINT here lets the librarian own pool
+    teardown via the normal None-sentinel path in ``stop()``.
+    """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
 def _save_cover_to_cache(cover_path_str: str, data: bytes) -> None:
@@ -142,18 +164,23 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
         ``librarian.cover_workers``) caps the worker count.
         """
         if self._cover_pool is None:
-            self._cover_pool = ProcessPoolExecutor(max_workers=COVER_WORKERS)
+            self._cover_pool = ProcessPoolExecutor(
+                max_workers=COVER_WORKERS, initializer=_init_cover_worker
+            )
         return self._cover_pool
 
     @override
     def stop(self) -> None:
         """Stop the thread and shut down the worker pool."""
         if self._cover_pool is not None:
-            # Don't wait for outstanding tasks; the thread is
-            # shutting down and any in-flight cover work would just
-            # be discarded by the consumer (re-rendered on next
-            # request via the 202-poll path).
-            self._cover_pool.shutdown(wait=False, cancel_futures=True)
+            # Workers ignore SIGINT (see ``_init_cover_worker``), so the
+            # librarian owns teardown. Cancel pending work and SIGTERM
+            # in-flight workers — any current cover would be re-rendered
+            # on the next request via the 202-poll path. Then wait for
+            # the executor manager thread to finish reaping workers so
+            # ``_python_exit``'s atexit hook doesn't have to.
+            self._cover_pool.terminate_workers()  # ty: ignore[unresolved-attribute]  # pyright: ignore[reportAttributeAccessIssue]
+            self._cover_pool.shutdown(wait=True)
             self._cover_pool = None
         super().stop()
 
@@ -254,11 +281,12 @@ class CoverCreateThread(QueuedThread, CoverPathMixin, ABC):
         for future in as_completed(futures):
             try:
                 pk, _cover_path_str, err = future.result()
-            except CancelledError:
-                # ``stop()`` shuts the pool with ``cancel_futures=True``
-                # before ``SHUTDOWN_MSG`` lands — outstanding futures
-                # raise here. Drop them; the burst handler's ``finally``
-                # still finishes the status cleanly.
+            except (CancelledError, BrokenExecutor):
+                # ``stop()`` cancels pending futures and SIGTERMs in-flight
+                # workers before ``SHUTDOWN_MSG`` lands — pending futures
+                # raise CancelledError, in-flight ones raise BrokenExecutor.
+                # Drop both; the burst handler's ``finally`` still finishes
+                # the status cleanly.
                 break
             if err:
                 self.log.warning(f"Could not create cover thumbnail for pk={pk}: {err}")


### PR DESCRIPTION
## Summary

- Cover workers added in v1.11.0 (#714) inherit the librarian's foreground process group, so a terminal `^C` delivered SIGINT to every worker. Python's `_process_worker` blocks on `call_queue.get()` with no try/except around the loop, so a raised `KeyboardInterrupt` killed the worker mid-call and left the pool's `_ExecutorManagerThread` broken — `p.join()` then hung inside the interpreter-shutdown atexit hook, blocking the librarian process exit and (transitively) the main process's `librarian.join()`. Result: shutdown stopped at "LibrarianDaemon finished." and never reached `codex_shutdown()`'s "Goodbye." line.
- New `_init_cover_worker` initializer sets `SIGINT → SIG_IGN` in workers so only main + librarian handle the signal.
- `CoverCreateThread.stop()` now calls `terminate_workers()` (Python 3.14) to SIGTERM in-flight workers, then `shutdown(wait=True)` so the executor manager thread reaps workers before the librarian's `_shutdown` returns — no more deferred cleanup at atexit.
- Widened the `as_completed` catch to include `BrokenExecutor`, since terminating in-flight workers makes their futures raise that instead of `CancelledError`.

The "*reliably*" qualifier in the bug report matches the lazy-init pattern: sessions where no covers were rendered never spawn the pool, so they shut down fine; sessions that triggered cover rendering hang.

## Test plan

- [x] `make fix` clean
- [x] `make lint` (Python side) — ruff, basedpyright, ty, vulture, complexipy, codespell, hadolint, actionlint, mbake all pass
- [x] `bin/test-python.sh` — 48 passed
- [ ] Manual: start codex, browse to populate the cover pool, `^C`, confirm shutdown reaches "Goodbye." and the shell prompt returns
- [ ] Manual: `^C` while a cover-creation burst is in flight; confirm shutdown still completes promptly (terminate_workers SIGTERMs in-flight workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)