### PR TITLE
dev: mangle DHCP-assigned FQDN hostnames to mDNS .local form

### DIFF
--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -72,11 +72,31 @@ PERF = not_falsy_env("PERF")
 VITE_HMR = DEBUG and not BUILD
 VITE_HOST = environ.get("VITE_HOST")
 VITE_PORT = 5173
-# Lowercased so the CSP origin matches Host headers and django-vite's
-# generated script ``src`` exactly — browsers compare CSP source
-# expressions case-sensitively, and ``socket.gethostname()`` can be
-# mixed case on macOS.
-VITE_DEV_SERVER_HOST = (VITE_HOST or socket.gethostname()).lower()
+
+
+def _vite_dev_server_host() -> str:
+    """
+    Pick the host django-vite renders into the script src and CSP.
+
+    Used for ``<script src=...>`` and the CSP allows for that script.
+    ``VITE_HOST`` is an explicit override. Otherwise we mangle a
+    DHCP-assigned FQDN (e.g. ``box.example.com``) down to the mDNS
+    form (``box.local``): the FQDN resolves via WAN DNS, and most
+    consumer routers don't NAT-loopback that back to the LAN, so the
+    browser can't reach the dev server. The mDNS form stays on the
+    LAN. Pre-mangled or single-label hostnames are passed through.
+    Lowercased throughout — CSP source expressions are case-sensitive
+    and ``socket.gethostname()`` can be mixed case on macOS.
+    """
+    if VITE_HOST:
+        return VITE_HOST.lower()
+    raw = socket.gethostname().lower()
+    if "." in raw and not raw.endswith(".local"):
+        return raw.split(".", 1)[0] + ".local"
+    return raw
+
+
+VITE_DEV_SERVER_HOST = _vite_dev_server_host()
 TZ = environ.get("TIMEZONE", environ.get("TZ"))
 DOCKER_IMAGE_DEPRECATED = environ.get("DOCKER_IMAGE_DEPRECATED", "")
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -45,13 +45,20 @@ const config = defineConfig(({ mode }) => {
   // tuning the manualChunks split.
   const ANALYZE = mode === "analyze";
   // https://github.com/vitejs/vite/issues/19242
-  // Include localhost so navigating to the dev server via
-  // ``http://localhost:9810`` works — Vite would otherwise reject
-  // the proxied request whenever the system hostname isn't
-  // ``localhost``. Loopback IPs are accepted too so curl / tooling
-  // that hits 127.0.0.1 doesn't get blocked.
+  // Match the host django-vite renders into <script src=...>.
+  // FQDNs (e.g. box.example.com) get mangled down to the mDNS form
+  // (box.local) because the FQDN resolves via WAN DNS and most
+  // consumer routers don't NAT-loopback that back to the LAN. The
+  // raw hostname is kept too in case it's already a single label or
+  // ends in .local. Loopback names included so curl / tooling that
+  // hits 127.0.0.1 or localhost:9810 don't get blocked.
+  const rawHost = hostname().toLowerCase();
+  const mDNSHost =
+    rawHost.includes(".") && !rawHost.endsWith(".local")
+      ? `${rawHost.split(".")[0]}.local`
+      : rawHost;
   const ALLOWED_HOSTS = DEV
-    ? [hostname().toLowerCase(), "localhost", "127.0.0.1", "[::1]"]
+    ? [...new Set([rawHost, mDNSHost, "localhost", "127.0.0.1", "[::1]"])]
     : [];
   let publicPathPrefix = "window.CODEX.APP_PATH";
   if (PROD) {


### PR DESCRIPTION
## Summary

Follow-up to [#738](https://github.com/ajslater/codex/pull/738). DHCP often hands out an FQDN as the system hostname (e.g. `box.example.com`). The FQDN resolves via WAN DNS to the box's public IP, and most consumer routers don't NAT-loopback that back to the LAN — so the browser can't reach the dev server even though django-vite's `dev_server_host` and Vite's `allowedHosts` were happily aligned to the FQDN after #738 landed.

Strip the domain off any non-`.local` FQDN and substitute the mDNS form. Same logic in [codex/settings/\_\_init\_\_.py](codex/settings/__init__.py) and [frontend/vite.config.js](frontend/vite.config.js) so the CSP origin and Vite's `allowedHosts` agree on what the browser is actually using. `VITE_HOST=...` env var still works as an explicit override and bypasses the mangle. Single-label hostnames and `*.local` are passed through untouched.

## Verified

| input hostname | mangled output |
| --- | --- |
| `Hooloovoo.hakama.sl8r.net` | `hooloovoo.local` |
| `Hooloovoo.local` | `hooloovoo.local` |
| `hooloovoo` | `hooloovoo` |
| `localhost` | `localhost` |

Python and JS implementations produce identical results for these cases. With FQDN input, the CSP `script-src` (`http://hooloovoo.local:5173`), CSP `connect-src` (`ws://hooloovoo.local:5173`, `http://hooloovoo.local:5173`), `DJANGO_VITE.dev_server_host` (`hooloovoo.local`), and Vite's `allowedHosts` all agree.

## Test plan

- [x] `make fix` clean
- [x] `ruff check`, `ty check`, `prettier --check`, `eslint` all pass on the changed files
- [x] `bin/test-python.sh` — 48 passed
- [x] Verified `VITE_HOST=...` env var override still bypasses the mangle
- [ ] Manual: `bin/dev-server.sh` on a box with FQDN hostname, navigate to `http://localhost:9810` — Vite client loads, HMR works
- [ ] Manual: navigate to `http://<short-hostname>.local:9810` — Vite client loads (browser resolves via mDNS, stays on LAN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)