### PR TITLE
reader: ?hide_text=1 to suppress visible OCR text on PDF pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@ border-radius: 128px;
 
 ## v1.11.5
 
+- Features
+    - Reader: add `?hide_text=1` query param for PDF pages — suppresses
+      visible text rendering on badly-OCR'd scans where the OCR layer
+      doubles up against the page's raster.
 - Fixes
     - Fix occasional recreation of comics on docker or network filesystems.
     - Fix double polling of some libraries.

--- a/codex/views/reader/page.py
+++ b/codex/views/reader/page.py
@@ -88,6 +88,13 @@ class ReaderPageView(BookmarkAuthMixin, AuthFilterAPIView):
             if self.request.GET.get("pixmap", "").lower() not in FALSY
             else ""
         )
+        # ``?hide_text=1`` suppresses visible text rendering on PDF
+        # pages — useful for badly-OCR'd scans that draw the OCR
+        # layer with rendering mode 0 (visible) on top of the page's
+        # raster, doubling the text. Forwarded straight through
+        # comicbox to the pdffile backend; non-PDF archives ignore
+        # it.
+        hide_text = self.request.GET.get("hide_text", "").lower() not in FALSY
         # Process-wide LRU of open Comicbox archives — the web reader's
         # prev/curr/next prefetch fires 3-5 page hits on the same archive
         # within a second, and ``cacheBook`` mode bursts a whole-book
@@ -96,7 +103,15 @@ class ReaderPageView(BookmarkAuthMixin, AuthFilterAPIView):
         # held inside ``archive_cache.open(...)`` serializes extraction
         # because ZipFile / RarFile / PDF backends aren't thread-safe.
         with archive_cache.open(path) as cb:
-            page_image = cb.get_page_by_index(page, pdf_format=pdf_format)
+            # ``hide_text`` requires comicbox > 3.0.0 / comicbox-pdffile
+            # > 0.5.0; pyright's lock-file-pinned typeshed lags behind
+            # the editable install used during dev. Drop the ignore once
+            # both deps land on PyPI and ``pyproject.toml`` is bumped.
+            page_image = cb.get_page_by_index(
+                page,
+                pdf_format=pdf_format,
+                hide_text=hide_text,  # pyright: ignore[reportCallIssue]  # ty: ignore[unknown-argument]
+            )
         if not page_image:
             page_image = b""
 
@@ -115,6 +130,7 @@ class ReaderPageView(BookmarkAuthMixin, AuthFilterAPIView):
         parameters=[
             OpenApiParameter("bookmark", OpenApiTypes.BOOL, default=True),
             OpenApiParameter("pixmap", OpenApiTypes.BOOL, default=False),
+            OpenApiParameter("hide_text", OpenApiTypes.BOOL, default=False),
         ],
         responses={
             (200, content_type): OpenApiTypes.BINARY,


### PR DESCRIPTION
## Summary

Some scanned PDFs draw their OCR layer with rendering mode 0 (visible) on top of the page's rasterized scan, doubling the text under any renderer that respects the content stream — including PDF.js as embedded by vue-pdf-embed. Setting `textLayer={false}` client-side doesn't help because that prop only gates the selectable overlay, not text drawn into the canvas from the content stream.

This PR plumbs a new `?hide_text=1` query param through the reader page view down to the PDF backend. With it set, every PDF page is served with `3 Tr` (text rendering mode = invisible) prepended to its content stream — visible glyphs go away, but text content stays in the file so PDF.js's selectable text overlay continues to work for selection / search.

## Dependency chain

- pdffile: ajslater/pdffile#19 — exposes the `hide_text` knob on `read_pdf` / `read_pixmap` / `read`.
- comicbox: ajslater/comicbox#129 — forwards `hide_text` from `get_page_by_index` etc. through to `PDFFile.read`.
- this PR — wires the query param to the comicbox call.

The pyright/ty `# ignore`s on the call site cover the dev gap until those two land on PyPI and this repo's `pyproject.toml` deps are bumped to the released versions. They're a one-line cleanup follow-up after the bump.

## Test plan

- [x] `make fix` clean
- [x] `make lint` clean (the only error is the pre-existing `remark` config issue on `develop` — see [codex#738](https://github.com/ajslater/codex/pull/738))
- [x] `bin/test-python.sh` — 48 passed
- [x] End-to-end verified through `archive_cache.open(...).get_page_by_index(..., hide_text=True)` on a real badly-OCR'd PDF: bytes differ from baseline, rendered output differs, text stays extractable
- [ ] Manual: navigate the reader to a problem PDF, confirm `?hide_text=1` URL serves the un-doubled rendering and that selection still works in vue-pdf-embed

## Out of scope

- UI knob for the toggle (settings drawer / per-comic preference) — the query param is the minimum surface; happy to follow up with a reader setting if you want a clickable affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)