### PR TITLE
dev: fix Vite HMR blocked by stale service worker CSP

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,10 @@ border-radius: 128px;
     - Fix occasional recreation of comics on docker or network filesystems.
     - Fix double polling of some libraries.
     - Fix Codex sometimes hanging on shutdown after Ctrl+C.
-    - Dev: fix Vite HMR CSP blocking scripts when system hostname isn't `localhost`.
+    - Dev: fix Vite HMR CSP blocking scripts when system hostname isn't
+      `localhost`.
+    - Dev: stop the PWA service worker from intercepting cross-origin Vite HMR
+      fetches with a stale CSP.
 
 ## v1.11.4
 

--- a/codex/templates/pwa/serviceworker.js
+++ b/codex/templates/pwa/serviceworker.js
@@ -20,18 +20,34 @@ self.addEventListener("install", (event) => {
 // Clear old caches on activate
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames
-          .filter((cacheName) => cacheName.startsWith(CACHE_PREFIX))
-          .filter((cacheName) => cacheName !== STATIC_CACHE_NAME)
-          .map((cacheName) => caches.delete(cacheName)),
-      );
-    }),
+    Promise.all([
+      // Pair with skipWaiting() so the new SW takes control of
+      // already-open pages immediately. Without this, replacing a
+      // stale SW (e.g. one with a stale CSP) would need a second
+      // reload to take effect.
+      self.clients.claim(),
+      caches.keys().then((cacheNames) => {
+        return Promise.all(
+          cacheNames
+            .filter((cacheName) => cacheName.startsWith(CACHE_PREFIX))
+            .filter((cacheName) => cacheName !== STATIC_CACHE_NAME)
+            .map((cacheName) => caches.delete(cacheName)),
+        );
+      }),
+    ]),
   );
 });
 // Serve from Cache
 self.addEventListener("fetch", (event) => {
+  // Pass through non-GET and cross-origin requests so the browser
+  // handles them under the page's CSP rather than the SW's snapshot
+  // taken at install time. Vite HMR talks to a separate origin
+  // (5173) and would otherwise be blocked by a stale SW CSP that
+  // pre-dates the dev-only overlay.
+  const url = new URL(event.request.url);
+  if (event.request.method !== "GET" || url.origin !== self.location.origin) {
+    return;
+  }
   event.respondWith(
     caches
       .match(event.request)

--- a/codex/urls/pwa.py
+++ b/codex/urls/pwa.py
@@ -24,8 +24,12 @@ urlpatterns = [
         name="serviceworker_register",
     ),
     path(
+        # No ``cache_page``: the SW's CSP is captured by the browser
+        # at install time from this response, and the browser only
+        # swaps the SW when its bytes change. A stale server-side
+        # cache pins both content and CSP.
         "serviceworker.js",
-        cache_page(COMMON_TIMEOUT)(ServiceWorkerView.as_view()),
+        ServiceWorkerView.as_view(),
         name="serviceworker",
     ),
 ]


### PR DESCRIPTION
## Summary

Follow-up to #738 / #739. The Vite HMR CSP overlay was correctly added to the page CSP, but cross-origin Vite client fetches (`http://hostname:5173/static/@vite/client`) were still being blocked from inside the PWA service worker:

```
serviceworker.js:39 Connecting to 'http://hooloovoo.local:5173/static/@vite/client' violates the following Content Security Policy directive: "connect-src 'self' ws: wss: https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/swagger-ui.css.map"
```

The CSP shown to the SW is missing both the `vite_hmr` and `schema_graph` overlays (both DEBUG-gated) — i.e. it's the snapshot the SW captured at install time, before the dev-only overlays existed. Service workers don't refresh their CSP unless their script bytes change, and `cache_page(COMMON_TIMEOUT)` on the SW URL was pinning the response server-side for an hour, blocking the byte-level diff that triggers SW updates.

## Changes

- **`codex/templates/pwa/serviceworker.js`** — `fetch` handler passes through non-GET and cross-origin requests, so Vite HMR is governed by the page CSP rather than the SW's snapshot. Also a more conventional SW shape: there's no point caching cross-origin responses.
- **`codex/templates/pwa/serviceworker.js`** — added `self.clients.claim()` in `activate` to pair with the existing `skipWaiting()`, so the replacement SW takes over open tabs in one reload instead of two.
- **`codex/urls/pwa.py`** — dropped `cache_page` from `/serviceworker.js`. Browsers handle SW update detection themselves; a server-side cache only pins content and CSP.

## Test plan

- [x] `Client().get('/serviceworker.js')` — confirmed `connect-src` now lists `ws://hostname:5173`, `http://hostname:5173`, and the `script-src` Vite origin.
- [x] `make fix` / `bun run lint` clean (the pre-existing `remark` "Cannot process specified file" error is unrelated and present on develop without these changes).
- [ ] Reload codex dev server in browser; confirm Vite HMR no longer throws CSP violations from `serviceworker.js`. (Existing stale SW gets replaced on first reload thanks to byte change + `clients.claim`.)
- [ ] Sanity-check a same-origin GET still hits the SW cache flow (offline fallback for the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)