### PR TITLE
Fix complexipy warnings in browser table-view dispatch helpers

### DIFF
--- a/codex/serializers/browser/page.py
+++ b/codex/serializers/browser/page.py
@@ -82,6 +82,17 @@ _COLUMN_VALUE_TRANSFORMS = {
     "language": _resolve_language,
 }
 
+# Routing metadata that ``_row_repr`` always emits regardless of the
+# user's column selection. Skipped during the per-column dispatch loop
+# because the values are pre-populated on the row dict.
+_ROUTING_COLUMNS = frozenset({"pk", "group", "ids"})
+
+
+def _apply_transform(col: str, value):
+    """Run the per-column display transform if the column has one."""
+    transform = _COLUMN_VALUE_TRANSFORMS.get(col)
+    return transform(value) if transform else value
+
 
 class BrowserCardSerializer(BrowserAggregateSerializerMixin, Serializer):
     """Browse card displayed in the browser."""
@@ -137,6 +148,61 @@ class BrowserTitleSerializer(Serializer):
     group_count = IntegerField(read_only=True, allow_null=True)
 
 
+def _emit_cover(row, instance) -> None:
+    """Populate the cover_pk / cover_custom_pk pair from a single ``cover`` request."""
+    row["cover_pk"] = getattr(instance, "cover_pk", None) or instance.pk
+    row["cover_custom_pk"] = getattr(instance, "cover_custom_pk", None)
+
+
+def _emit_issue(row, instance) -> None:
+    """Render the compound issue column as ``{number, suffix}`` on the row."""
+    # Compound from issue_number + issue_suffix on the Comic, emitted as
+    # ``{number, suffix}`` so the cell can split-justify the halves.
+    # Group rows yield empty strings for both (intersection of distinct
+    # issues across child comics is rarely meaningful).
+    row["issue"] = _format_issue(
+        getattr(instance, "issue_number", None),
+        getattr(instance, "issue_suffix", "") or "",
+    )
+
+
+def _emit_column(
+    row,
+    instance,
+    col: str,
+    row_intersections: dict,
+    m2m_keys: frozenset[str],
+    fk_keys: frozenset[str],
+) -> None:
+    """
+    Resolve and emit a single column's value onto ``row``.
+
+    Lookup order: special-case (cover / issue) → group-row intersection
+    (with country / language transform) → M2M annotation alias → FK-name
+    annotation alias (with transform) → direct attribute lookup. M2M and
+    FK-name aliases are prefixed because the unprefixed name collides
+    with the matching Comic field attribute.
+    """
+    if col == "cover":
+        _emit_cover(row, instance)
+    elif col == "issue":
+        _emit_issue(row, instance)
+    elif col in row_intersections:
+        # Group-row intersection takes precedence (and applies country /
+        # language transforms the same way the FK-alias path does).
+        row[col] = _apply_transform(col, row_intersections[col])
+    elif col in m2m_keys:
+        row[col] = getattr(instance, m2m_alias_for(col), None)
+    elif col in fk_keys:
+        row[col] = _apply_transform(col, getattr(instance, fk_alias_for(col), None))
+    else:
+        # ``getattr`` covers direct fields, F-expression annotations
+        # (publisher_name etc.), and aggregates added downstream.
+        # Columns whose value source isn't annotated yet return None;
+        # the frontend renders them as empty cells.
+        row[col] = getattr(instance, col, None)
+
+
 def _row_repr(
     instance, columns: tuple[str, ...], intersections: dict | None = None
 ) -> dict:
@@ -167,48 +233,9 @@ def _row_repr(
         intersections.get(instance.pk) if intersections else None
     ) or {}
     for col in columns:
-        if col in ("pk", "group", "ids"):
+        if col in _ROUTING_COLUMNS:
             continue
-        if col == "cover":
-            row["cover_pk"] = getattr(instance, "cover_pk", None) or instance.pk
-            row["cover_custom_pk"] = getattr(instance, "cover_custom_pk", None)
-            continue
-        if col == "issue":
-            # Compound from issue_number + issue_suffix on the Comic,
-            # emitted as ``{number, suffix}`` so the cell can split-
-            # justify the halves. Group rows yield empty strings for
-            # both (intersection of distinct issues across child
-            # comics is rarely meaningful).
-            row[col] = _format_issue(
-                getattr(instance, "issue_number", None),
-                getattr(instance, "issue_suffix", "") or "",
-            )
-            continue
-        # Group-row intersection takes precedence (and applies country /
-        # language transforms the same way the FK-alias path does).
-        if col in row_intersections:
-            value = row_intersections[col]
-            transform = _COLUMN_VALUE_TRANSFORMS.get(col)
-            row[col] = transform(value) if transform else value
-            continue
-        if col in m2m_keys:
-            # M2M aggregates live under a prefixed alias (the unprefixed
-            # name would clash with the model's M2M field attribute).
-            row[col] = getattr(instance, m2m_alias_for(col), None)
-            continue
-        if col in fk_keys:
-            # FK-name annotations also live under a prefixed alias —
-            # the unprefixed name (``country``, ``age_rating``, ...)
-            # collides with the matching Comic FK attribute.
-            value = getattr(instance, fk_alias_for(col), None)
-            transform = _COLUMN_VALUE_TRANSFORMS.get(col)
-            row[col] = transform(value) if transform else value
-            continue
-        # ``getattr`` covers direct fields, F-expression annotations
-        # (publisher_name etc.), and aggregates added downstream.
-        # Columns whose value source isn't annotated yet return None;
-        # the frontend renders them as empty cells.
-        row[col] = getattr(instance, col, None)
+        _emit_column(row, instance, col, row_intersections, m2m_keys, fk_keys)
     return row
 
 

--- a/codex/views/browser/order_by.py
+++ b/codex/views/browser/order_by.py
@@ -117,6 +117,37 @@ class BrowserOrderByView(BrowserGroupMtimeView):
         """Return the queryset alias used for the n-th extra key on a group queryset."""
         return f"_table_extra_value_{idx}"
 
+    def _comic_extra_fields(self, key: str) -> list[str]:
+        """Resolve a single extra-key to its Comic ORDER BY field list."""
+        # ``child_count`` doesn't apply on Comic rows (every comic has
+        # implicit count 1). The frontend grays out the unsupported
+        # keys, but a stored payload could still hit; fall back to
+        # ``sort_name`` so the ORDER BY tail still binds.
+        if key in BROWSER_EXTRA_SORT_UNSUPPORTED_KEYS or key == "child_count":
+            return ["sort_name"]
+        return self._add_comic_order_by(key, None)
+
+    def _comic_extra_order_by(self, extras) -> list[str]:
+        """Build the ORDER BY tail for a Comic-row queryset."""
+        tail: list[str] = []
+        for entry in extras:
+            key = entry.get("key")
+            if not key:
+                continue
+            prefix = "-" if entry.get("reverse") else ""
+            tail.extend(prefix + field for field in self._comic_extra_fields(key))
+        return tail
+
+    def _group_extra_order_by(self, extras) -> list[str]:
+        """Build the ORDER BY tail for a group-row queryset."""
+        tail: list[str] = []
+        for idx, entry in enumerate(extras):
+            if not entry.get("key"):
+                continue
+            prefix = "-" if entry.get("reverse") else ""
+            tail.append(prefix + self.extra_order_value_alias(idx))
+        return tail
+
     def _add_extra_order_by(self, qs) -> list[str]:
         """
         Build the ``ORDER BY`` tail from ``order_extra_keys``.
@@ -132,31 +163,9 @@ class BrowserOrderByView(BrowserGroupMtimeView):
         extras = self.params.get("order_extra_keys") or ()
         if not extras or self.params.get("view_mode") != "table":
             return []
-        tail: list[str] = []
         if qs.model is Comic:
-            for entry in extras:
-                key = entry.get("key")
-                if not key:
-                    continue
-                if key in BROWSER_EXTRA_SORT_UNSUPPORTED_KEYS or key == "child_count":
-                    # ``child_count`` doesn't apply on Comic rows
-                    # (every comic has implicit count 1). The
-                    # frontend grays out the unsupported keys, but
-                    # a stored payload could still hit; fall back to
-                    # ``sort_name`` so the ORDER BY tail still binds.
-                    extra_fields = ["sort_name"]
-                else:
-                    extra_fields = self._add_comic_order_by(key, None)
-                prefix = "-" if entry.get("reverse") else ""
-                tail.extend(prefix + field for field in extra_fields)
-            return tail
-        for idx, entry in enumerate(extras):
-            key = entry.get("key")
-            if not key:
-                continue
-            prefix = "-" if entry.get("reverse") else ""
-            tail.append(prefix + self.extra_order_value_alias(idx))
-        return tail
+            return self._comic_extra_order_by(extras)
+        return self._group_extra_order_by(extras)
 
     def add_order_by(
         self, qs, order_key="", comic_sort_names=None, *, for_cover: bool = False


### PR DESCRIPTION
## Summary

- ``_row_repr`` (page serializer) and ``_add_extra_order_by`` (order-by view) sat at cognitive complexity **22**, above the project's complexipy threshold of 15.
- Both functions decomposed into smaller named helpers; no behavior change.

## What changed

### ``codex/serializers/browser/page.py``

- New ``_emit_column`` (elif chain over column type) handles the per-column dispatch loop body.
- ``_emit_cover`` and ``_emit_issue`` cover the two special cases that don't fit the single ``row[col] = value`` shape.
- New ``_apply_transform(col, value)`` dedupes the country / language transform pattern that ran on both the intersection branch and the FK-name branch.
- Routing-column shortcut (``pk`` / ``group`` / ``ids``) is now a module-level ``_ROUTING_COLUMNS`` frozenset.

### ``codex/views/browser/order_by.py``

- ``_comic_extra_order_by`` and ``_group_extra_order_by`` carry the two queryset-flavor branches.
- ``_comic_extra_fields`` hoists the unsupported-key / ``child_count`` fallback out of the inner loop.
- ``_add_extra_order_by`` is now a 3-line dispatcher.

## Test plan

- [x] ``complexipy`` reports no functions over the threshold
- [x] ``ruff check`` clean on the two files
- [x] 193 backend pytest tests pass
- [x] 27 frontend vitest tests pass (untouched, but ran for safety)

## Notes for the reviewer

- The radon rank-C items that surface in ``bin/lint-complexity.sh`` are pre-existing (came in with the merged #745) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)