### PR TITLE
Fix radon complexity warnings across browser table-view code + tests

### DIFF
--- a/codex/views/browser/annotate/order.py
+++ b/codex/views/browser/annotate/order.py
@@ -404,29 +404,16 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
             agg_func = Max if reverse else Min
         return agg_func(self.rel_prefix + comic_order_path(key))
 
-    def annotate_extra_order_values(self, qs):
-        """
-        Annotate per-extra ``order_value`` aliases on group querysets.
-
-        Comic queries don't go through this path — their multi-sort
-        tail references direct Comic fields, M2M aliases annotated
-        by ``_add_table_view_sort_annotations``, or
-        ``bookmark_updated_at`` / ``filename`` aliases annotated by
-        ``annotate_comic_extra_specials``. Group querysets need a
-        parallel ``_table_extra_value_<idx>`` annotation per extra
-        so the ORDER BY tail can reference an aggregated child-comic
-        value. Skipped outside table-view mode so cover requests
-        don't carry these aliases unnecessarily.
-        """
-        if (
+    def _should_annotate_extras(self, qs) -> bool:
+        """Return True when the query needs per-extra ``_table_extra_value_<n>`` aliases."""
+        return not (
             self.TARGET == "metadata"
             or qs.model is Comic
             or self.params.get("view_mode") != "table"
-        ):
-            return qs
-        extras = self.params.get("order_extra_keys") or ()
-        if not extras:
-            return qs
+        )
+
+    def _build_extra_annotations(self, qs, extras) -> dict:
+        """Return the per-extra ``alias → expression`` map for the extras list."""
         annotations: dict = {}
         for idx, entry in enumerate(extras):
             key = entry.get("key")
@@ -443,12 +430,33 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
                 # missing column.
                 expr = F("sort_name")
             annotations[self.extra_order_value_alias(idx)] = expr
-        if annotations:
-            if self.TARGET == "browser":
-                qs = qs.annotate(**annotations)
-            else:
-                qs = qs.alias(**annotations)
-        return qs
+        return annotations
+
+    def annotate_extra_order_values(self, qs):
+        """
+        Annotate per-extra ``order_value`` aliases on group querysets.
+
+        Comic queries don't go through this path — their multi-sort
+        tail references direct Comic fields, M2M aliases annotated
+        by ``_add_table_view_sort_annotations``, or
+        ``bookmark_updated_at`` / ``filename`` aliases annotated by
+        ``annotate_comic_extra_specials``. Group querysets need a
+        parallel ``_table_extra_value_<idx>`` annotation per extra
+        so the ORDER BY tail can reference an aggregated child-comic
+        value. Skipped outside table-view mode so cover requests
+        don't carry these aliases unnecessarily.
+        """
+        if not self._should_annotate_extras(qs):
+            return qs
+        extras = self.params.get("order_extra_keys") or ()
+        if not extras:
+            return qs
+        annotations = self._build_extra_annotations(qs, extras)
+        if not annotations:
+            return qs
+        if self.TARGET == "browser":
+            return qs.annotate(**annotations)
+        return qs.alias(**annotations)
 
     def annotate_order_aggregates(self, qs: QuerySet, *, for_cover: bool = False):
         """Annotate common aggregates between browser and metadata."""

--- a/codex/views/browser/intersections.py
+++ b/codex/views/browser/intersections.py
@@ -352,6 +352,37 @@ def _build_simple_m2m_intersection_query(
     )
 
 
+def _initialize_simple_m2m_buckets(
+    batched_cols: list[str],
+    group_pks: list[int],
+    result: dict[int, dict[str, Any]],
+) -> None:
+    """Pre-fill empty intersection lists so empty-result groups still get ``[]``."""
+    for gpk in group_pks:
+        bucket = result[gpk]
+        for col in batched_cols:
+            bucket.setdefault(col, [])
+
+
+def _union_simple_m2m_queries(queries: list):
+    """Combine sub-queries with ``UNION ALL`` (or pass through a single query)."""
+    if len(queries) == 1:
+        return queries[0]
+    return queries[0].union(*queries[1:], all=True)
+
+
+def _collect_simple_m2m_intersections(
+    combined,
+    counts: dict[int, int],
+) -> dict[tuple[str, int], list[str]]:
+    """Group UNION rows by ``(field, group_pk)``, keeping intersection-passing values."""
+    intersection_per: dict[tuple[str, int], list[str]] = defaultdict(list)
+    for field_name, group_pk, value, cnt in combined:
+        if cnt == counts.get(group_pk, 0):
+            intersection_per[(field_name, group_pk)].append(value)
+    return intersection_per
+
+
 def _compute_simple_m2m_intersections_batched(
     cols: list[str],
     group_pks: list[int],
@@ -370,32 +401,19 @@ def _compute_simple_m2m_intersections_batched(
     match the group's total comic count — that's the intersection
     rule.
     """
-    queries = [
-        _build_simple_m2m_intersection_query(col, comic_to_group, group_pks)
-        for col in cols
-        if col in _SIMPLE_M2M_BATCH_FIELDS
-    ]
-
+    batched_cols = [c for c in cols if c in _SIMPLE_M2M_BATCH_FIELDS]
     # Initialize empty lists for every requested simple column up
     # front so groups whose intersection is empty get ``[]`` rather
     # than missing keys.
-    batched_cols = [c for c in cols if c in _SIMPLE_M2M_BATCH_FIELDS]
-    for gpk in group_pks:
-        bucket = result[gpk]
-        for col in batched_cols:
-            bucket.setdefault(col, [])
+    _initialize_simple_m2m_buckets(batched_cols, group_pks, result)
+    queries = [
+        _build_simple_m2m_intersection_query(col, comic_to_group, group_pks)
+        for col in batched_cols
+    ]
     if not queries:
         return
-
-    if len(queries) == 1:
-        combined = queries[0]
-    else:
-        combined = queries[0].union(*queries[1:], all=True)
-
-    intersection_per: dict[tuple[str, int], list[str]] = defaultdict(list)
-    for field_name, group_pk, value, cnt in combined:
-        if cnt == counts.get(group_pk, 0):
-            intersection_per[(field_name, group_pk)].append(value)
+    combined = _union_simple_m2m_queries(queries)
+    intersection_per = _collect_simple_m2m_intersections(combined, counts)
     for (field_name, gpk), values in intersection_per.items():
         result[gpk][field_name] = sorted(values)
 

--- a/codex/views/browser/order_by.py
+++ b/codex/views/browser/order_by.py
@@ -61,10 +61,8 @@ class BrowserOrderByView(BrowserGroupMtimeView):
             self._order_key = order_key
         return self._order_key
 
-    def _add_comic_order_by(
-        self, order_key, comic_sort_names, *, for_cover: bool = False
-    ) -> list:
-        """Order by for comics (and covers)."""
+    def _normalize_comic_order_key(self, order_key: str, *, for_cover: bool) -> str:
+        """Resolve a Comic-row ``order_key`` to its canonical sort form."""
         if not order_key:
             order_key = self.order_key
         if order_key == "child_count":
@@ -76,41 +74,60 @@ class BrowserOrderByView(BrowserGroupMtimeView):
         # alphabetical title is what the cover subquery wants anyway.
         if for_cover and order_key in m2m_columns():
             order_key = "sort_name"
+        return order_key
+
+    def _comic_sort_name_head(self, comic_sort_names) -> list[str]:
+        """Build the ORDER BY head used for the canonical ``sort_name`` sort."""
+        if not comic_sort_names:
+            comic_sort_names = self._comic_sort_names
+        return [
+            *comic_sort_names,
+            "issue_number",
+            "issue_suffix",
+            "collection_title",
+            "sort_name",
+        ]
+
+    @staticmethod
+    def _comic_indexed_head(order_key: str) -> list[str]:
+        """Build the ORDER BY head for a Comic-indexed (non-M2M, non-virtual) key."""
+        # Comic orders on indexed fields directly — allegedly faster
+        # than using tmp b-trees (annotations) and since that's every
+        # cover sort, it's worth it.
+        head = [comic_order_path(order_key)]
+        # Comic order micro optimizations.
+        if order_key == "story_arc_number":
+            head.append("date")
+        elif order_key == "bookmark_updated_at":
+            head.append("bookmark_updated_at")
+        return head
+
+    def _comic_order_fields_head(self, order_key: str, comic_sort_names) -> list:
+        """Pick the ORDER BY field list for a normalized Comic ``order_key``."""
         if order_key == "sort_name":
-            if not comic_sort_names:
-                comic_sort_names = self._comic_sort_names
-            order_fields_head = [
-                *comic_sort_names,
-                "issue_number",
-                "issue_suffix",
-                "collection_title",
-                "sort_name",
-            ]
-        elif order_key == "issue":
+            return self._comic_sort_name_head(comic_sort_names)
+        if order_key == "issue":
             # Compound issue sort: number first, suffix as secondary.
             # The ``issue`` order_by enum value is virtual — it expands
             # to two real Comic fields here so SQL ORDER BY does the
             # natural multi-field sort that matches how the compound
             # ``Issue`` table column is rendered.
-            order_fields_head = ["issue_number", "issue_suffix"]
-        elif order_key in m2m_columns():
+            return ["issue_number", "issue_suffix"]
+        if order_key in m2m_columns():
             # M2M sort: ``ORDER BY <alias>`` where the alias is the
             # JsonGroupArray annotation added by the table-view path.
             # Identical M2M sets yield identical aggregate strings,
             # so equivalent rows cluster together — the property the
             # user actually cares about.
-            order_fields_head = [m2m_alias_for(order_key)]
-        else:
-            # Comic orders on indexed fields directly
-            # Which is allegedly faster than using tmp b-trees (annotations)
-            # And since that's every cover sort, it's worth it.
-            order_fields_head = [comic_order_path(order_key)]
-            # Comic order micro optimizations
-            if order_key == "story_arc_number":
-                order_fields_head += ["date"]
-            elif order_key == "bookmark_updated_at":
-                order_fields_head += ["bookmark_updated_at"]
-        return order_fields_head
+            return [m2m_alias_for(order_key)]
+        return self._comic_indexed_head(order_key)
+
+    def _add_comic_order_by(
+        self, order_key, comic_sort_names, *, for_cover: bool = False
+    ) -> list:
+        """Order by for comics (and covers)."""
+        order_key = self._normalize_comic_order_key(order_key, for_cover=for_cover)
+        return self._comic_order_fields_head(order_key, comic_sort_names)
 
     @staticmethod
     def extra_order_value_alias(idx: int) -> str:

--- a/tests/test_browser_settings_table.py
+++ b/tests/test_browser_settings_table.py
@@ -160,6 +160,27 @@ class BrowserTableSettingsRoundTripTestCase(TestCase):
         assert response.status_code == _HTTP_OK, response.content
         return response.json()
 
+    def _save_named_view(self, name: str) -> dict:
+        """POST a fresh saved view, then look it up by name in the list."""
+        save_resp = self.client.post(
+            f"{_SETTINGS_URL}/saved",
+            data=json.dumps({"name": name}),
+            content_type="application/json",
+        )
+        assert save_resp.status_code == _HTTP_CREATED, save_resp.content
+        list_resp = self.client.get(f"{_SETTINGS_URL}/saved")
+        assert list_resp.status_code == _HTTP_OK, list_resp.content
+        return next(
+            entry
+            for entry in list_resp.json()["savedSettings"]
+            if entry["name"] == name
+        )
+
+    def _load_saved_settings(self, pk: int) -> dict:
+        load_resp = self.client.get(f"{_SETTINGS_URL}/saved/{pk}")
+        assert load_resp.status_code == _HTTP_OK, load_resp.content
+        return load_resp.json()["settings"]
+
     def test_default_get_includes_new_fields(self):
         body = self._get()
         # Response is camelCased.
@@ -221,32 +242,17 @@ class BrowserTableSettingsRoundTripTestCase(TestCase):
             {"key": "year", "reverse": False},
             {"key": "issue", "reverse": True},
         ]
-        patch = self._patch(
-            {
-                "viewMode": "table",
-                "tableColumns": cols,
-                "tableCoverSize": "sm",
-                "orderExtraKeys": extras,
-            }
-        )
+        live_payload = {
+            "viewMode": "table",
+            "tableColumns": cols,
+            "tableCoverSize": "sm",
+            "orderExtraKeys": extras,
+        }
+        patch = self._patch(live_payload)
         assert patch.status_code == _HTTP_OK, patch.content
 
         # Save under a fresh name (exercises the create branch).
-        save_resp = self.client.post(
-            f"{_SETTINGS_URL}/saved",
-            data=json.dumps({"name": "TaggingView"}),
-            content_type="application/json",
-        )
-        assert save_resp.status_code == _HTTP_CREATED, save_resp.content
-
-        # List saved views to grab the new pk.
-        list_resp = self.client.get(f"{_SETTINGS_URL}/saved")
-        assert list_resp.status_code == _HTTP_OK, list_resp.content
-        saved = next(
-            entry
-            for entry in list_resp.json()["savedSettings"]
-            if entry["name"] == "TaggingView"
-        )
+        saved = self._save_named_view("TaggingView")
 
         # Reset current settings so loading the saved view actually
         # changes state (and proves the values came from the saved
@@ -254,13 +260,9 @@ class BrowserTableSettingsRoundTripTestCase(TestCase):
         self.client.delete(_SETTINGS_URL)
 
         # Load and assert every table-view field round-trips.
-        load_resp = self.client.get(f"{_SETTINGS_URL}/saved/{saved['pk']}")
-        assert load_resp.status_code == _HTTP_OK, load_resp.content
-        body = load_resp.json()["settings"]
-        assert body["viewMode"] == "table"
-        assert body["tableColumns"] == cols
-        assert body["tableCoverSize"] == "sm"
-        assert body["orderExtraKeys"] == extras
+        body = self._load_saved_settings(saved["pk"])
+        actual = {field: body[field] for field in live_payload}
+        assert actual == live_payload
 
     def test_delete_resets_table_view_fields(self):
         # First customize

--- a/tests/test_browser_table_response.py
+++ b/tests/test_browser_table_response.py
@@ -20,6 +20,28 @@ _HTTP_OK: Final = 200
 _HTTP_BAD_REQUEST: Final = 400
 TMP_DIR = Path("/tmp/codex.tests.browser_table_response")  # noqa: S108
 
+# Through-tables touched by the simple-M2M intersection batch helper.
+# A single ``UNION ALL`` query mentions all of these in its SQL, so
+# substring-counting the captured query text is enough to distinguish
+# the batched path from the per-column-loop path.
+_SIMPLE_M2M_THROUGH_TABLES: Final = (
+    "codex_comic_genres",
+    "codex_comic_tags",
+    "codex_comic_characters",
+    "codex_comic_teams",
+    "codex_comic_locations",
+    "codex_comic_stories",
+    "codex_comic_series_groups",
+)
+
+
+def _count_through_table_queries(captured_queries) -> int:
+    """Count how many captured queries reference any simple-M2M through table."""
+    return sum(
+        any(table in q["sql"] for table in _SIMPLE_M2M_THROUGH_TABLES)
+        for q in captured_queries
+    )
+
 
 class FormatIssueTestCase(TestCase):
     """Pin the compound issue-cell formatter."""
@@ -126,6 +148,34 @@ class BrowserTablePageResponseTestCase(TestCase):
         response = self.client.get(url)
         assert response.status_code == _HTTP_OK, response.content
         return response.json()
+
+    def _create_sibling_comic(
+        self, anchor: Comic, name: str, issue_number: int
+    ) -> Comic:
+        """
+        Create a Comic in the same publisher / imprint / series / volume as ``anchor``.
+
+        Used by tests that need a small fixture of comics under one
+        series to exercise group-row aggregation. ``size`` and
+        ``page_count`` are deliberately uniform so cumulative-sum
+        assertions in those tests stay deterministic without per-call
+        plumbing.
+        """
+        path = TMP_DIR / f"{name.lower()}.cbz"
+        path.touch()
+        return Comic.objects.create(
+            library=anchor.library,
+            path=path,
+            issue_number=issue_number,
+            name=name,
+            publisher=anchor.publisher,
+            imprint=anchor.imprint,
+            series=anchor.series,
+            volume=anchor.volume,
+            size=42 + issue_number,
+            year=2024,
+            page_count=20,
+        )
 
     def test_cover_view_returns_cards_with_empty_rows(self) -> None:
         """Cover mode: ``rows`` is present but empty; cards are populated."""
@@ -352,7 +402,6 @@ class BrowserTablePageResponseTestCase(TestCase):
 
     def test_table_view_m2m_sort_groups_identical_sets(self) -> None:
         """Comics with the same genre set sort to the same equivalence class."""
-        from codex.models import Library
         from codex.models.named import Genre
 
         # Two comics in the same series sharing identical genre sets.
@@ -361,98 +410,45 @@ class BrowserTablePageResponseTestCase(TestCase):
         # genres should sort to one end.
         first_comic = Comic.objects.first()
         assert first_comic is not None
-        library = Library.objects.first()
-        assert library is not None
-        publisher = first_comic.publisher
-        imprint = first_comic.imprint
-        series = first_comic.series
-        volume = first_comic.volume
 
         action = Genre.objects.create(name="Action")
         drama = Genre.objects.create(name="Drama")
         comedy = Genre.objects.create(name="Comedy")
 
         first_comic.genres.add(action, drama)
-
-        path_b = TMP_DIR / "b.cbz"
-        path_b.touch()
-        comic_b = Comic.objects.create(
-            library=library,
-            path=path_b,
-            issue_number=2,
-            name="B",
-            publisher=publisher,
-            imprint=imprint,
-            series=series,
-            volume=volume,
-            size=43,
-            year=2024,
-            page_count=20,
-        )
+        comic_b = self._create_sibling_comic(first_comic, "B", 2)
         comic_b.genres.add(action, drama)  # same set as first_comic
-        path_c = TMP_DIR / "c.cbz"
-        path_c.touch()
-        comic_c = Comic.objects.create(
-            library=library,
-            path=path_c,
-            issue_number=3,
-            name="C",
-            publisher=publisher,
-            imprint=imprint,
-            series=series,
-            volume=volume,
-            size=44,
-            year=2024,
-            page_count=20,
-        )
+        comic_c = self._create_sibling_comic(first_comic, "C", 3)
         comic_c.genres.add(comedy)
-        path_d = TMP_DIR / "d.cbz"
-        path_d.touch()
-        comic_d = Comic.objects.create(
-            library=library,
-            path=path_d,
-            issue_number=4,
-            name="D",
-            publisher=publisher,
-            imprint=imprint,
-            series=series,
-            volume=volume,
-            size=45,
-            year=2024,
-            page_count=20,
-        )
-        # comic_d has no genres
+        # comic_d has no genres so it sorts to one end.
+        comic_d = self._create_sibling_comic(first_comic, "D", 4)
 
         self._set_view_mode_table()
-        # Sort by genres ascending.
         self.client.patch(
             "/api/v3/r/settings",
             data=json.dumps({"orderBy": "genres", "orderReverse": False}),
             content_type="application/json",
         )
-        body = self._browse_series(columns="cover,name,genres")
-        rows = body["rows"]
-        expected_row_count = 4
-        assert len(rows) == expected_row_count
-        # Group rows by their genre set (after the JsonGroupArray sort).
+        rows = self._browse_series(columns="cover,name,genres")["rows"]
         sets = [tuple(r.get("genres") or []) for r in rows]
-        # The two "Action,Drama" rows should be adjacent.
-        action_drama_indexes = [
-            i for i, s in enumerate(sets) if set(s) == {"Action", "Drama"}
-        ]
-        expected_action_drama = 2
-        assert len(action_drama_indexes) == expected_action_drama
-        assert action_drama_indexes[1] - action_drama_indexes[0] == 1
-        # No-genres comic appears once (empty list / null).
-        empty_indexes = [i for i, s in enumerate(sets) if not s]
-        assert len(empty_indexes) == 1
-        # Verify the unique-genre-set comic appears once.
-        comedy_indexes = [i for i, s in enumerate(sets) if set(s) == {"Comedy"}]
-        assert len(comedy_indexes) == 1
-        # comic_b/comic_c/comic_d existed by id; spot-check pks.
-        pks = [r["pk"] for r in rows]
-        for c in (first_comic, comic_b, comic_c, comic_d):
-            assert c.pk in pks
+        self._assert_genre_sort_classes(sets)
+        # Spot-check that every fixture comic is in the result.
+        pks = {r["pk"] for r in rows}
+        expected_pks = {c.pk for c in (first_comic, comic_b, comic_c, comic_d)}
+        assert expected_pks <= pks
+
+    @staticmethod
+    def _assert_genre_sort_classes(sets: list[tuple[str, ...]]) -> None:
+        """Assert the four-row genre fixture forms the expected equivalence classes."""
+        # Fixture: two "Action,Drama" rows, one "Comedy" row, one
+        # empty row. JsonGroupArray sorts equal sets together so the
+        # two A/D rows must be adjacent in the result list.
+        action_drama = frozenset({"Action", "Drama"})
+        classes = [frozenset(s) for s in sets]
+        expected = (action_drama, action_drama, frozenset({"Comedy"}), frozenset())
+        assert sorted(classes, key=str) == sorted(expected, key=str)
+        ad_indexes = [i for i, c in enumerate(classes) if c == action_drama]
+        assert ad_indexes[1] - ad_indexes[0] == 1
 
     def test_table_view_group_intersection_scalar_all_share(self) -> None:
         """Series row: ``year`` shows the value when every child comic shares it."""
@@ -650,26 +646,13 @@ class BrowserTablePageResponseTestCase(TestCase):
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get(url)
         assert response.status_code == _HTTP_OK, response.content
-        # Through-table queries land on tables named
-        # ``codex_comic_<m2m>``. The batched UNION emits one SQL
-        # statement that references multiple through tables. Per-
-        # column path emits one statement per through-table.
-        through_query_count = sum(
-            "codex_comic_genres" in q["sql"]
-            or "codex_comic_tags" in q["sql"]
-            or "codex_comic_characters" in q["sql"]
-            or "codex_comic_teams" in q["sql"]
-            or "codex_comic_locations" in q["sql"]
-            or "codex_comic_stories" in q["sql"]
-            or "codex_comic_series_groups" in q["sql"]
-            for q in ctx.captured_queries
-        )
         # Pre-fix: 7 separate queries (one per visible simple-M2M
         # column). Post-fix: a single UNION-ALL query references all
         # seven through-tables.
         max_expected_through_queries = 3
-        assert through_query_count <= max_expected_through_queries, (
-            f"got {through_query_count} through-table queries:\n"
+        through_count = _count_through_table_queries(ctx.captured_queries)
+        assert through_count <= max_expected_through_queries, (
+            f"got {through_count} through-table queries:\n"
             + "\n".join(
                 q["sql"] for q in ctx.captured_queries if "codex_comic_" in q["sql"]
             )


### PR DESCRIPTION
## Summary

All five files reported by ``bin/lint-complexity.sh`` (radon ``cc --min C`` plus the ``mi --min B`` for ``test_browser_table_response.py``) are now under threshold. Pure decomposition / consolidation — no behavior change.

## What changed

### Production code

| Function | CC before | CC after | Change |
|----------|-----------|----------|--------|
| ``intersections._compute_simple_m2m_intersections_batched`` | 12 | 6 | Extracted ``_initialize_simple_m2m_buckets``, ``_union_simple_m2m_queries``, ``_collect_simple_m2m_intersections``. Main function reads as a 6-line pipeline. |
| ``order_by.BrowserOrderByView._add_comic_order_by`` | 11 | 1 | Split into ``_normalize_comic_order_key`` (key resolution) and ``_comic_order_fields_head`` / ``_comic_sort_name_head`` / ``_comic_indexed_head`` (head-building branches). Top-level method is a 2-line orchestrator. |
| ``annotate.order.BrowserAnnotateOrderView.annotate_extra_order_values`` | 11 | 6 | Hoisted the early-return predicate into ``_should_annotate_extras`` and the per-extra annotation map into ``_build_extra_annotations``. |

### Tests

| Function | CC before | CC after | Change |
|----------|-----------|----------|--------|
| ``test_save_view_round_trips_table_fields`` | 11 | 4 | Extracted ``_save_named_view`` and ``_load_saved_settings`` round-trip helpers; collapsed four field-by-field assertions into a single dict-equality check against the live patch payload. |
| ``test_table_view_m2m_sort_groups_identical_sets`` | 19 | 5 | Extracted ``_create_sibling_comic`` factory (replaces three ~12-line ``Comic.objects.create`` blocks) and ``_assert_genre_sort_classes``. The equivalence-class assertion uses ``frozenset`` + ``sorted`` for a single equality check. |
| ``test_table_view_simple_m2m_intersections_share_one_union_query`` | 11 | 5 | Extracted the seven-table ``or`` chain into a module-level ``_SIMPLE_M2M_THROUGH_TABLES`` tuple + a ``_count_through_table_queries`` helper that uses ``any()``. |

### File-level MI

- ``tests/test_browser_table_response.py``: B (17.08) → A (19.66). Driven entirely by the function-level fixes above; no other restructuring.

## Test plan

- [x] ``bin/lint-complexity.sh`` clean (no functions over CC 10, no files at MI grade B)
- [x] ``complexipy`` clean (no functions over CC 15)
- [x] ``ruff check`` clean
- [x] 193 backend pytest tests pass

## Reviewer notes

- The new ``_create_sibling_comic`` test helper is private to the test class and replicates the ``setUp`` Comic-creation shape with a uniform ``size = 42 + issue_number`` formula. Per-call ``size`` keeps cumulative-sum assertions in adjacent tests deterministic. (Existing tests didn't use the helper because their assertions don't constrain ``size`` in ways that conflict with the formula — but if a future test does, override locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)