### PR TITLE
Fix `make ty` warnings in browser table-view code

### DIFF
--- a/codex/views/browser/columns.py
+++ b/codex/views/browser/columns.py
@@ -147,7 +147,7 @@ def default_columns_filtered(
     cols = default_columns_for(top_group)
     if not cols:
         return cols
-    show_map = show if isinstance(show, dict) else {}
+    show_map: dict = show if isinstance(show, dict) else {}
     blocked = {
         col for col, flag in _SHOW_GATED_COLUMNS.items() if not show_map.get(flag)
     }

--- a/codex/views/browser/intersections.py
+++ b/codex/views/browser/intersections.py
@@ -27,7 +27,14 @@ from django.db.models import CharField, Count, F, Min, Q, Sum, Value
 from django.db.models.expressions import RawSQL
 
 from codex.models import Comic
-from codex.models.groups import Folder, Imprint, Publisher, Series, Volume
+from codex.models.groups import (
+    BrowserGroupModel,
+    Folder,
+    Imprint,
+    Publisher,
+    Series,
+    Volume,
+)
 from codex.views.browser.columns import fk_name_columns, m2m_columns
 from codex.views.const import MODEL_REL_MAP
 
@@ -103,7 +110,7 @@ _SCALAR_FIELD_PATHS: MappingProxyType[str, str] = MappingProxyType(
 )
 
 
-def _intersection_relation(group_model: type) -> str | None:
+def _intersection_relation(group_model: type[BrowserGroupModel]) -> str | None:
     """
     Return the ORM lookup that traverses Comic → group for intersections.
 
@@ -516,7 +523,7 @@ _SIMPLE_M2M_FIELDS = MappingProxyType(
 
 
 def _build_simple_m2m_intersection_sort_sql(
-    group_model: type, column: str
+    group_model: type[BrowserGroupModel], column: str
 ) -> RawSQL | None:
     """
     Return a correlated-subquery RawSQL for the intersection sort key.
@@ -530,7 +537,7 @@ def _build_simple_m2m_intersection_sort_sql(
     if field_name is None or correlation is None:
         return None
     field = Comic._meta.get_field(field_name)
-    through = field.remote_field.through  # pyright: ignore[reportAttributeAccessIssue]
+    through = field.remote_field.through  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]
     through_table = through._meta.db_table
     m2m_id_col = f"{field.m2m_reverse_field_name()}_id"  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]
     related_model = field.related_model
@@ -618,7 +625,9 @@ def _wrap_intersection_sort(
     )"""  # noqa: S608
 
 
-def _build_universes_intersection_sort_sql(group_model: type) -> RawSQL | None:
+def _build_universes_intersection_sort_sql(
+    group_model: type[BrowserGroupModel],
+) -> RawSQL | None:
     """Universes display as ``name:designation`` (or just ``name`` when blank)."""
     correlation = _comic_correlation_sql(group_model)
     if correlation is None:
@@ -639,7 +648,9 @@ def _build_universes_intersection_sort_sql(group_model: type) -> RawSQL | None:
     return RawSQL(sql, [])  # noqa: S611
 
 
-def _build_credits_intersection_sort_sql(group_model: type) -> RawSQL | None:
+def _build_credits_intersection_sort_sql(
+    group_model: type[BrowserGroupModel],
+) -> RawSQL | None:
     """Credits display as ``Person (Role)`` (or ``Person`` when role is null)."""
     correlation = _comic_correlation_sql(group_model)
     if correlation is None:
@@ -665,7 +676,9 @@ def _build_credits_intersection_sort_sql(group_model: type) -> RawSQL | None:
     return RawSQL(sql, [])  # noqa: S611
 
 
-def _build_identifiers_intersection_sort_sql(group_model: type) -> RawSQL | None:
+def _build_identifiers_intersection_sort_sql(
+    group_model: type[BrowserGroupModel],
+) -> RawSQL | None:
     """Render identifiers intersection as ``[source:]type:key`` per shared row."""
     correlation = _comic_correlation_sql(group_model)
     if correlation is None:
@@ -686,7 +699,9 @@ def _build_identifiers_intersection_sort_sql(group_model: type) -> RawSQL | None
     return RawSQL(sql, [])  # noqa: S611
 
 
-def _build_story_arcs_intersection_sort_sql(group_model: type) -> RawSQL | None:
+def _build_story_arcs_intersection_sort_sql(
+    group_model: type[BrowserGroupModel],
+) -> RawSQL | None:
     """Story arcs go through ``StoryArcNumber``; group by the parent ``StoryArc``."""
     correlation = _comic_correlation_sql(group_model)
     if correlation is None:
@@ -708,7 +723,9 @@ def _build_story_arcs_intersection_sort_sql(group_model: type) -> RawSQL | None:
     return RawSQL(sql, [])  # noqa: S611
 
 
-def _comic_correlation_sql(group_model: type) -> tuple[str, str, str] | None:
+def _comic_correlation_sql(
+    group_model: type[BrowserGroupModel],
+) -> tuple[str, str, str] | None:
     """
     Return the SQL fragments correlating Comic rows to the outer group row.
 
@@ -727,7 +744,7 @@ def _comic_correlation_sql(group_model: type) -> tuple[str, str, str] | None:
     """
     if group_model is Folder:
         folders_field = Comic._meta.get_field("folders")
-        through = folders_field.remote_field.through  # pyright: ignore[reportAttributeAccessIssue]
+        through = folders_field.remote_field.through  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]
         through_table = through._meta.db_table
         group_table = Folder._meta.db_table
         extra_join = f"INNER JOIN {through_table} cf ON cf.comic_id = c.id"
@@ -753,7 +770,9 @@ def _comic_correlation_sql(group_model: type) -> tuple[str, str, str] | None:
     return "", where, total_count
 
 
-def scalar_intersection_sort_expr(group_model: type, column: str) -> RawSQL | None:
+def scalar_intersection_sort_expr(
+    group_model: type[BrowserGroupModel], column: str
+) -> RawSQL | None:
     """
     Build a sort-key RawSQL for scalar / FK-name group-row sort.
 
@@ -832,7 +851,9 @@ def scalar_intersection_sort_expr(group_model: type, column: str) -> RawSQL | No
     return RawSQL(sql, [])  # noqa: S611
 
 
-def m2m_intersection_sort_expr(group_model: type, column: str) -> RawSQL | None:
+def m2m_intersection_sort_expr(
+    group_model: type[BrowserGroupModel], column: str
+) -> RawSQL | None:
     """
     Build a sort-key RawSQL for the given (group_model, M2M column).
 


### PR DESCRIPTION
## Summary

``make ty`` reported 5 diagnostics (4 in ``intersections.py``, 1 in ``columns.py``). All fixed by tightening type signatures rather than blanket ignores — the only ``# ty: ignore`` additions match existing ``# pyright: ignore`` comments for the same Django-field shape.

## What changed

### ``codex/views/browser/columns.py``

- ``default_columns_filtered``: annotate ``show_map: dict`` explicitly. ty was inferring ``dict[Never, Never]`` from the ``show if isinstance(show, dict) else {}`` ternary because the ``{}`` branch had no inferred element types. The annotation gives ty enough information for ``.get(flag)`` (where ``flag: str``) to type-check.

### ``codex/views/browser/intersections.py``

- Tighten the ``group_model`` parameter on every helper that calls ``MODEL_REL_MAP.get(...)`` or ``group_model._meta``: ``type`` → ``type[BrowserGroupModel]``. Functions touched: ``_intersection_relation``, ``_comic_correlation_sql``, ``_build_simple_m2m_intersection_sort_sql``, ``_build_universes_intersection_sort_sql``, ``_build_credits_intersection_sort_sql``, ``_build_identifiers_intersection_sort_sql``, ``_build_story_arcs_intersection_sort_sql``, ``scalar_intersection_sort_expr``, ``m2m_intersection_sort_expr``.
  
  After the tightening, ``if group_model is Folder`` narrowing preserves the ``BrowserGroupModel`` bound, so the subsequent ``MODEL_REL_MAP.get(group_model)`` and ``group_model._meta.db_table`` calls type-check cleanly.

- Add ``# ty: ignore[unresolved-attribute]`` to two ``field.remote_field.through`` accesses (lines 540 and 736). ``ManyToManyRel.through`` is exposed at runtime but not in stubs — the same reason both lines already carried ``# pyright: ignore[reportAttributeAccessIssue]``. The ``ty`` ignore is now adjacent to the matching pyright ignore (line 542 already had both).

## Test plan

- [x] ``make ty`` clean
- [x] ``ruff check`` clean
- [x] ``ruff format --check`` clean
- [x] 193 backend pytest tests pass

## Reviewer notes

- ``BrowserGroupModel`` is the existing base class for Publisher / Imprint / Series / Volume / Folder / StoryArc / Comic. The tightened parameter type is what every caller of these functions already passes (each ``qs.model`` is one of those), so this is a no-op at runtime — pure documentation of the existing contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)