### PR TITLE
Smart canonical-order column insertion in table picker

### DIFF
--- a/frontend/src/components/browser/table/browser-table-column-picker.vue
+++ b/frontend/src/components/browser/table/browser-table-column-picker.vue
@@ -195,6 +195,57 @@ function _registryEntry(key) {
     : undefined;
 }
 
+/*
+ * Canonical column rank: the index a key would have if you flattened
+ * `_CATEGORIES` into one ordered list. Used by ``smartInsertIndex``
+ * to place newly-toggled columns into their natural slot when the
+ * existing draft is in canonical order. Keys not in any category
+ * (orphans surfaced under "Other") get rank ``Infinity`` so they
+ * always sort to the tail.
+ */
+const _CANONICAL_RANK = (() => {
+  const ranks = new Map();
+  let i = 0;
+  for (const cat of _CATEGORIES) {
+    for (const key of cat.columns) {
+      ranks.set(key, i);
+      i += 1;
+    }
+  }
+  return ranks;
+})();
+
+function _rank(key) {
+  return _CANONICAL_RANK.has(key)
+    ? _CANONICAL_RANK.get(key)
+    : Number.POSITIVE_INFINITY;
+}
+
+/*
+ * Decide where to insert ``key`` into ``draft``. If the draft's
+ * existing keys are already in strictly-increasing canonical-rank
+ * order, splice the new key into the unique slot that keeps the
+ * sequence sorted — e.g. toggling on ``favorite`` lands it right
+ * after ``cover``, toggling on ``imprint_name`` lands it after
+ * ``publisher_name`` (or after ``cover`` / ``favorite`` if neither
+ * publisher exists). If the draft is out of canonical order — the
+ * user has manually rearranged columns — fall back to appending so
+ * we don't surprise them by reshuffling around their layout.
+ */
+export function smartInsertIndex(draft, key) {
+  const ranks = draft.map(_rank);
+  for (let i = 1; i < ranks.length; i += 1) {
+    /* eslint-disable-next-line security/detect-object-injection */
+    if (ranks[i - 1] >= ranks[i]) return draft.length;
+  }
+  const target = _rank(key);
+  for (let i = 0; i < ranks.length; i += 1) {
+    /* eslint-disable-next-line security/detect-object-injection */
+    if (target < ranks[i]) return i;
+  }
+  return draft.length;
+}
+
 export default {
   // eslint-disable-next-line no-secrets/no-secrets
   name: "BrowserTableColumnPicker",
@@ -312,10 +363,14 @@ export default {
       if (on) {
         if (!this.draft.includes(key)) {
           /*
-           * New columns are appended to the end of the order list.
-           * The user can drag them into position from there.
+           * Slot the new column into canonical position when the
+           * draft is already in canonical order; otherwise append
+           * (the user has rearranged things — don't second-guess
+           * their layout).
            */
-          this.draft = [...this.draft, key];
+          const next = [...this.draft];
+          next.splice(smartInsertIndex(this.draft, key), 0, key);
+          this.draft = next;
         }
       } else {
         this.draft = this.draft.filter((k) => k !== key);

--- a/frontend/tests/unit/browser-table-column-picker.test.js
+++ b/frontend/tests/unit/browser-table-column-picker.test.js
@@ -1,0 +1,114 @@
+/*
+ * Pure-function tests for ``smartInsertIndex`` exported from the
+ * browser table column picker. The helper consumes an ordered draft
+ * of column keys and a key to insert, returning the splice index.
+ *
+ * Algorithm under test: if the draft's canonical ranks (defined by
+ * ``_CATEGORIES`` flattened) are strictly increasing, splice the
+ * new key into the unique slot that keeps the sequence sorted;
+ * otherwise append. Orphans (keys not in any category) rank at
+ * ``+Infinity`` and always sort to the tail.
+ */
+import { describe, expect, it } from "vitest";
+
+import { smartInsertIndex } from "@/components/browser/table/browser-table-column-picker.vue";
+
+/*
+ * Canonical-rank reference for the cases below — kept here so the
+ * test reads as a story rather than an opaque number puzzle:
+ *   cover=0, favorite=1, publisher_name=2, imprint_name=3,
+ *   series_name=4, volume_name=5, issue=6, name=7, child_count=8,
+ *   file_name=9, size=10, page_count=11, file_type=12,
+ *   year=13, …
+ */
+
+describe("smartInsertIndex — canonical-order drafts", () => {
+  it("inserts favorite right after cover", () => {
+    const draft = ["cover", "name", "child_count"];
+    expect(smartInsertIndex(draft, "favorite")).toBe(1);
+  });
+
+  it("inserts favorite first when cover is absent", () => {
+    const draft = ["name", "child_count"];
+    expect(smartInsertIndex(draft, "favorite")).toBe(0);
+  });
+
+  it("inserts imprint_name after publisher_name when both are present", () => {
+    const draft = ["cover", "publisher_name", "name", "child_count"];
+    expect(smartInsertIndex(draft, "imprint_name")).toBe(2);
+  });
+
+  it("inserts imprint_name after favorite when publisher is absent", () => {
+    const draft = ["cover", "favorite", "name"];
+    expect(smartInsertIndex(draft, "imprint_name")).toBe(2);
+  });
+
+  it("inserts imprint_name after cover when neither publisher nor favorite exists", () => {
+    const draft = ["cover", "name"];
+    expect(smartInsertIndex(draft, "imprint_name")).toBe(1);
+  });
+
+  it("inserts series_name after the other publishing groups", () => {
+    const draft = ["cover", "publisher_name", "imprint_name", "name"];
+    expect(smartInsertIndex(draft, "series_name")).toBe(3);
+  });
+
+  it("appends when the new key sorts after every existing key", () => {
+    const draft = ["cover", "favorite", "name"];
+    expect(smartInsertIndex(draft, "child_count")).toBe(3);
+  });
+
+  it("inserts at the head when the new key sorts before every existing key", () => {
+    /* size precedes page_count in `_CATEGORIES.File` — keep it canonical. */
+    const draft = ["size", "page_count"];
+    expect(smartInsertIndex(draft, "cover")).toBe(0);
+  });
+
+  it("handles an empty draft", () => {
+    expect(smartInsertIndex([], "favorite")).toBe(0);
+  });
+
+  it("handles a single-element draft (canonical-after)", () => {
+    expect(smartInsertIndex(["cover"], "favorite")).toBe(1);
+  });
+
+  it("handles a single-element draft (canonical-before)", () => {
+    expect(smartInsertIndex(["name"], "cover")).toBe(0);
+  });
+});
+
+describe("smartInsertIndex — non-canonical drafts fall back to append", () => {
+  it("appends when the user has rearranged columns out of canonical order", () => {
+    /* name (rank 7) sitting before cover (rank 0) — user-sorted. */
+    const draft = ["name", "cover", "publisher_name"];
+    expect(smartInsertIndex(draft, "favorite")).toBe(draft.length);
+  });
+
+  it("appends when even one adjacent pair is reversed", () => {
+    /* publisher (rank 2) before favorite (rank 1) — barely out of order. */
+    const draft = ["cover", "publisher_name", "favorite", "name"];
+    expect(smartInsertIndex(draft, "imprint_name")).toBe(draft.length);
+  });
+});
+
+describe("smartInsertIndex — orphans (rank +Infinity)", () => {
+  it("treats a draft ending in an orphan as still sorted", () => {
+    /*
+     * If a column lives outside `_CATEGORIES` (surfaced under
+     * "Other"), it ranks at +∞ — a draft that ends with one is
+     * still considered canonically sorted.
+     */
+    const draft = ["cover", "name", "__not_a_real_column__"];
+    expect(smartInsertIndex(draft, "favorite")).toBe(1);
+  });
+
+  it("appends a new orphan to a canonical draft", () => {
+    const draft = ["cover", "name"];
+    expect(smartInsertIndex(draft, "__not_a_real_column__")).toBe(2);
+  });
+
+  it("appends when an orphan sits before a known key (out of order)", () => {
+    const draft = ["cover", "__not_a_real_column__", "name"];
+    expect(smartInsertIndex(draft, "favorite")).toBe(draft.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Browser table-view column picker now slots newly-toggled columns into their natural canonical position — favorite lands after cover, imprint after publisher, series after the publishing group, etc.
- Detection rule: if the draft is in strictly-increasing canonical-rank order (rank = index in flattened `_CATEGORIES`), splice into the unique sorted slot. If the user has manually rearranged the draft out of canonical order, fall back to appending so we don't reshuffle their layout.
- Pure-function helper `smartInsertIndex` exported from the picker SFC and covered by 16 new vitest cases.

## Why
Always-append meant every newly-toggled column landed at the tail and required a drag to position. Most drafts (defaults plus light additions) are still in canonical order, so we can place the new column correctly without touching anything the user has intentionally arranged.

## What changed
- `frontend/src/components/browser/table/browser-table-column-picker.vue`: precompute `_CANONICAL_RANK` from `_CATEGORIES`, add `smartInsertIndex(draft, key)`, wire `toggleColumn` to use it.
- `frontend/tests/unit/browser-table-column-picker.test.js`: new — covers canonical-order insertion, append-on-non-canonical fallback, edge cases (empty/single-element drafts), and orphan keys (rank `+∞`).

## Out of scope (intentionally)
- "All" button, drag-reorder, and reset-to-defaults are unchanged.
- No "longest-prefix-sorted" or majority-sorted heuristic — strict sortedness is the only "smart" branch; everything else appends. Keeps the behavior predictable.

## Test plan
- [x] `make lint-frontend` clean
- [x] `bun run test:ci` — 5 files, 55 tests, all pass (16 new in this PR)
- [ ] Manual: open the picker on each top-group, toggle favorite / imprint / publisher / series in various combinations and confirm placement matches expectations
- [ ] Manual: drag a column out of canonical order, then toggle a new column on, confirm it appends (not reshuffled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)