### PR TITLE
filter orphan keys from generated browser choices json

### DIFF
--- a/codex/choices/browser.py
+++ b/codex/choices/browser.py
@@ -156,6 +156,36 @@ BROWSER_CHOICES = MappingProxyType(
     }
 )
 
+# Subset of BROWSER_CHOICES keys included in the Vuetify-list dump
+# (``browser-choices.json``). ``IDENTIFIER_SOURCES`` is omitted — the
+# frontend only consumes its raw-map form from ``browser-map.json``.
+# ``VIEW_MODE`` and ``TABLE_COVER_SIZE`` are not consumed by the
+# frontend in either form; their backing constants are used by the
+# backend (models / serializers) but no JSON dump is needed.
+BROWSER_CHOICES_VUETIFY_KEYS = frozenset(
+    {
+        "BOOKMARK_FILTER",
+        "ORDER_BY",
+        "COVER_ORDER_BY_KEYS",
+        "EXTRA_SORT_UNSUPPORTED_KEYS",
+        "TOP_GROUP",
+        "VUETIFY_NULL_CODE",
+        "SETTINGS_GROUP",
+    }
+)
+
+# Subset of BROWSER_CHOICES keys included in the raw-map dump
+# (``browser-map.json``). The frontend only destructures these three
+# keys from ``browser-map.json``; the others are consumed via their
+# Vuetify-list forms from ``browser-choices.json``.
+BROWSER_CHOICES_MAP_KEYS = frozenset(
+    {
+        "ORDER_BY",
+        "TOP_GROUP",
+        "IDENTIFIER_SOURCES",
+    }
+)
+
 DEFAULT_BROWSER_ROUTE = MappingProxyType({"group": "r", "pks": (0,), "page": 1})
 
 # Top-group values that own a dedicated browser route. For these,

--- a/codex/choices/choices_to_json.py
+++ b/codex/choices/choices_to_json.py
@@ -11,6 +11,8 @@ from caseconverter import camelcase
 from codex.choices.admin import ADMIN_FLAG_CHOICES
 from codex.choices.browser import (
     BROWSER_CHOICES,
+    BROWSER_CHOICES_MAP_KEYS,
+    BROWSER_CHOICES_VUETIFY_KEYS,
     BROWSER_DEFAULTS,
     BROWSER_TABLE_COLUMN_COSTS,
     BROWSER_TABLE_COLUMNS,
@@ -24,6 +26,15 @@ from codex.choices.statii import ADMIN_STATUS_TITLES
 
 _DEFAULTS = MappingProxyType(
     {"browser-choices.json": BROWSER_DEFAULTS, "reader-choices.json": READER_DEFAULTS}
+)
+
+# Per-file include-key filters. A filename present here emits only the
+# listed top-level keys from its source mapping; orphan keys are skipped.
+_INCLUDE_KEYS = MappingProxyType(
+    {
+        "browser-choices.json": BROWSER_CHOICES_VUETIFY_KEYS,
+        "browser-map.json": BROWSER_CHOICES_MAP_KEYS,
+    }
 )
 
 _DUMPS = MappingProxyType(
@@ -103,6 +114,9 @@ def _dump(
     parent_path: Path, fn: str, data, *, vuetify: bool, jsonize_keys: bool
 ) -> None:
     """Dump data to json file."""
+    include_keys = _INCLUDE_KEYS.get(fn)
+    if include_keys is not None and isinstance(data, Mapping):
+        data = {k: v for k, v in data.items() if k in include_keys}
     vuetify_data = (
         _to_vuetify_dict(fn, data)
         if vuetify


### PR DESCRIPTION
## Summary
- `BROWSER_CHOICES` is dumped to both `browser-choices.json` (Vuetify list) and `browser-map.json` (raw map), but the frontend consumes only one format per key. Add per-file include-key frozensets in `codex/choices/browser.py` and have `choices_to_json.py` look them up to skip orphan keys at generation time.
- Adding a new key to `BROWSER_CHOICES` now requires also listing it in at least one of the two include-sets, otherwise it'll be emitted nowhere — surfaces future orphans early.

## Orphans excluded from JSON output
**`browser-choices.json`** drops:
- `IDENTIFIER_SOURCES` — frontend imports the raw-map form from `browser-map.json` only
- `VIEW_MODE` — frontend toggle uses string literals, never reads the choices map
- `TABLE_COVER_SIZE` — single-value placeholder, no frontend UI consumes the choices map

**`browser-map.json`** drops:
- `BOOKMARK_FILTER`, `VUETIFY_NULL_CODE`, `SETTINGS_GROUP` — frontend uses the Vuetify-list form from `browser-choices.json`
- `COVER_ORDER_BY_KEYS`, `EXTRA_SORT_UNSUPPORTED_KEYS` — frontend reads them via `BROWSER_CHOICES.X` from `browser-choices.json`
- `VIEW_MODE`, `TABLE_COVER_SIZE` — same as above

The Python source consts (`BROWSER_VIEW_MODE_CHOICES`, `BROWSER_TABLE_COVER_SIZE_CHOICES`) are still used by the backend (models, serializers) so they stay in `browser.py` — only their JSON exposure is removed.

## Coverage notes
All other generated files (`admin-flag-choices`, `admin-status-titles`, `admin-jobs`, `browser-defaults`, `browser-table-*`, `reader-*`, `search-map`, `websocket-messages`) had every top-level key consumed — either statically or as a dynamic lookup table — so no other files needed filtering. Every public Python const in `codex/choices/*.py` is consumed by either the JSON generator or other backend modules.

## Test plan
- [x] `./bin/build-choices.sh` regenerates with the expected key sets
- [x] `make fix` — no changes
- [x] `make test` — 218 Python + 55 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)