### PR TITLE
fix codespell config silently skipping all files

### DIFF
--- a/codex/views/opds/v2/progression.py
+++ b/codex/views/opds/v2/progression.py
@@ -123,7 +123,7 @@ class OPDS2ProgressionView(
     @property
     def _locations(self) -> dict[str, Any]:
         """Build the Locations object."""
-        # The OPDS v2 progression spec secifies position as > 0.
+        # The OPDS v2 progression spec specifies position as > 0.
         position = max(self._obj.page + 1, 0)
         return {
             "position": position,

--- a/frontend/bin/lint.sh
+++ b/frontend/bin/lint.sh
@@ -10,3 +10,6 @@ bun run lint
 bin/lint-darwin.sh
 
 uv run bin/roman.py -i .prettierignore .
+
+# Spelling
+uv run --group lint codespell --toml ../pyproject.toml .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,8 +210,8 @@ reportUnusedParameter = false
 [tool.codespell]
 builtin = "clear,code,rare"
 check-hidden = true
-ignore-words-list = "coverd,falsy,ro,searchd,thead,versio,ws"
-skip = "*~,.*,./bun.lock,./codex/_vendor,./codex/static,./codex/static_build,./comics,./config,./dist,./frontend/coverage,./node_modules,./package.json,./site,./test-results,/uv.lock"
+ignore-words-list = "assertin,browseable,coverd,crate,doubleclick,falsy,iff,pre-selected,re-use,re-using,ro,searchd,ser,thead,versio,wan,warmup,ws"
+skip = "*~,bun.lock,coverage,node_modules,package.json,test-results,uv.lock,./.claude,./.git,./.github,./.venv,./codex/_vendor,./codex/static,./codex/static_build,./comics,./config,./dist,./site"
 
 [tool.complexipy]
 failed = true


### PR DESCRIPTION
## Summary

- The `.*` glob in `[tool.codespell].skip` was matching every walked path (because `os.walk('.')` prefixes paths with `./`), so `make lint` was silently scanning nothing while nvim per-file checks still surfaced real typos.
- Replaces `.*` with explicit hidden-dir paths (`./.claude,./.git,./.github,./.venv`), switches well-known names (`node_modules`, `bun.lock`, `package.json`, `coverage`, `test-results`, `uv.lock`) to basename patterns so they skip correctly from any working directory, and fixes a `/uv.lock` typo.
- Wires codespell into `frontend/bin/lint.sh` (sharing the parent's config via `--toml ../pyproject.toml`) so frontend code gets spell-checked as part of the frontend lint pass.
- Adds legitimate technical terms surfaced once codespell started actually running: `wan` (network), `crate` (Rust), `iff` ("if and only if" in docstrings), `ser`/`Ser` (test fixture abbrev for Series), `assertin` (`assertIn` unittest method), `browseable`, `doubleclick`, `re-use`, `re-using`, `pre-selected`, `warmup`.
- Fixes one real typo uncovered: `secifies` → `specifies` in `codex/views/opds/v2/progression.py`.

## Test plan

- [x] `bin/lint-python.sh` exits 0 on develop's content
- [x] `frontend/bin/lint.sh` exits 0
- [x] Confirmed `codespell .` from project root and `codespell --toml ../pyproject.toml .` from `frontend/` both find typos when present and pass cleanly otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)