### PR TITLE
Add optional failed-login log for fail2ban et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,17 @@ to 2 queries per second.
 - `CODEX_AUTH_REMOTE_USER` will allow unauthenticated logins with the
   Remote-User HTTP header. This can be very insecure if not configured properly.
   Please read the Remote-User docs devoted to it below.
+- `CODEX_AUTH_FAILED_LOGIN_LOG=1` will append every failed login attempt (form
+  login and OPDS Basic auth) to a separate log file for consumption by banning
+  tools like fail2ban, CrowdSec, or sshguard. Disabled by default. See the
+  [Failed-Login Log](#failed-login-log) section below.
+- `CODEX_AUTH_FAILED_LOGIN_LOG_PATH` overrides the failed-login log path.
+  Defaults to `$CODEX_LOG_DIR/failed_logins.log`.
+- `CODEX_AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR=0` makes the failed-login log
+  use `REMOTE_ADDR` instead of the leftmost `X-Forwarded-For` entry. Default is
+  `1` (trust XFF), which is correct when Codex sits behind a reverse proxy. Set
+  to `0` when Codex is exposed directly so that clients can't forge
+  `X-Forwarded-For` to poison the log.
 
 ### Reverse Proxy
 
@@ -440,6 +451,72 @@ or single sign on software to send this token.
 ```nginx
 set              user_token 'user-token-taken-from-web-ui';
 proxy_set_header Authorization "Bearer $user_token";
+```
+
+### Failed-Login Log
+
+Codex can append every failed login attempt to a dedicated log file in a format
+easy for IP-banning tools (fail2ban, CrowdSec, sshguard, etc.) to parse. The
+feature is off by default. Enable it by setting `CODEX_AUTH_FAILED_LOGIN_LOG=1`
+or in `codex.toml`:
+
+```toml
+[auth]
+failed_login_log = true
+# failed_login_log_path = ""                       # defaults to <log_dir>/failed_logins.log
+# failed_login_log_trust_forwarded_for = true      # set false if exposed directly
+```
+
+A single signal receiver covers both the form login at `/api/v3/auth/login/` and
+OPDS HTTP Basic auth — no separate setup per endpoint. Failures still appear in
+the main `codex.log`; the dedicated file is an additional copy filtered to just
+these records.
+
+Each line looks like:
+
+```
+2026-05-10 12:34:56 | Failed login from 192.168.1.42 user=alice
+```
+
+#### X-Forwarded-For trust
+
+The client IP is taken from the leftmost `X-Forwarded-For` entry when
+`failed_login_log_trust_forwarded_for = true` (the default), falling back to
+`REMOTE_ADDR`. This is correct when Codex sits behind a reverse proxy that sets
+the header (the typical Docker deployment).
+
+If Codex is exposed directly on its port, set
+`failed_login_log_trust_forwarded_for = false` — otherwise a client can set
+their own `X-Forwarded-For: 8.8.8.8` and your banning tool will ban that address
+instead of the real attacker.
+
+#### Example fail2ban filter
+
+`/etc/fail2ban/filter.d/codex.conf`:
+
+```ini
+[Definition]
+failregex = ^\s*\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| Failed login from <HOST> user=.*$
+ignoreregex =
+```
+
+`/etc/fail2ban/jail.d/codex.conf`:
+
+```ini
+[codex]
+enabled  = true
+filter   = codex
+logpath  = /path/to/codex/config/logs/failed_logins.log
+maxretry = 5
+findtime = 10m
+bantime  = 1h
+```
+
+Validate the filter against a real log with `fail2ban-regex` before enabling the
+jail:
+
+```sh
+fail2ban-regex /path/to/codex/config/logs/failed_logins.log /etc/fail2ban/filter.d/codex.conf
 ```
 
 ### Restricted Memory Environments

--- a/codex/failed_login_log.py
+++ b/codex/failed_login_log.py
@@ -1,0 +1,100 @@
+"""
+Dedicated log of failed-login attempts.
+
+Designed for consumption by IP-banning tools (fail2ban, CrowdSec, sshguard,
+etc.) that tail a log and match offending addresses by regex. One record per
+failed credential attempt is emitted with ``logger.bind(failed_login=True)``,
+which the dedicated loguru sink in :mod:`codex.startup.loguru` filters into a
+separate file. The main stdout / codex.log sinks see the record too.
+
+The :class:`RequestContextMiddleware` stashes each request in a
+:class:`~contextvars.ContextVar` so the signal handler can recover the client
+IP even when the caller did not propagate ``request=`` into Django's
+:func:`~django.contrib.auth.authenticate`. ``rest_registration``'s default
+login authenticator omits the request, so without this fallback every form-
+login failure would log a dash for the IP.
+"""
+
+from contextvars import ContextVar
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Final
+
+from asgiref.sync import markcoroutinefunction
+from loguru import logger
+
+from codex.settings import AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+_FAILED_LOGIN_KEY: Final = "failed_login"
+_MISSING: Final = "-"
+_failed_login_logger = logger.bind(**{_FAILED_LOGIN_KEY: True})
+_current_request: ContextVar["HttpRequest | None"] = ContextVar(
+    "codex_current_request", default=None
+)
+
+
+def get_client_ip(request: "HttpRequest | None") -> str:
+    """Return the client IP, preferring leftmost X-Forwarded-For when trusted."""
+    if request is None:
+        return _MISSING
+    if AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR and (
+        forwarded := request.META.get("HTTP_X_FORWARDED_FOR", "").strip()
+    ):
+        return forwarded.split(",", 1)[0].strip() or _MISSING
+    return request.META.get("REMOTE_ADDR") or _MISSING
+
+
+def failed_login_filter(record) -> bool:
+    """Loguru sink filter: keep only records tagged via ``logger.bind``."""
+    return bool(record["extra"].get(_FAILED_LOGIN_KEY))
+
+
+def on_login_failed(sender, credentials=None, request=None, **_kwargs) -> None:
+    """Receiver for ``django.contrib.auth.signals.user_login_failed``."""
+    del sender
+    if request is None:
+        request = _current_request.get()
+    ip = get_client_ip(request)
+    username = (credentials or {}).get("username") or _MISSING
+    _failed_login_logger.warning(f"Failed login from {ip} user={username}")
+
+
+class RequestContextMiddleware:
+    """
+    Stash the active request in a contextvar for the signal handler.
+
+    DRF's :class:`~rest_framework.authentication.BasicAuthentication` does
+    propagate ``request=`` into :func:`django.contrib.auth.authenticate`, so
+    OPDS basic-auth failures already arrive at the signal with a request.
+    ``rest_registration``'s default login authenticator does not, so the
+    contextvar is the only way to recover the IP for form-login failures.
+    """
+
+    sync_capable = True
+    async_capable = True
+
+    def __init__(self, get_response) -> None:
+        """Initialize response method."""
+        self.get_response = get_response
+        self._async = iscoroutinefunction(get_response)
+        if self._async:
+            markcoroutinefunction(self)  # ty: ignore[invalid-argument-type]
+
+    async def _acall(self, request):
+        token = _current_request.set(request)
+        try:
+            return await self.get_response(request)
+        finally:
+            _current_request.reset(token)
+
+    def __call__(self, request):
+        """Set the current-request contextvar around the inner call."""
+        if self._async:
+            return self._acall(request)
+        token = _current_request.set(request)
+        try:
+            return self.get_response(request)
+        finally:
+            _current_request.reset(token)

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -142,6 +142,20 @@ LOG_ROTATION = "10 MB"
 ##############################
 
 AUTH_REMOTE_USER = get_bool(CODEX_CONFIG, "auth.remote_user", default=False)
+AUTH_FAILED_LOGIN_LOG = get_bool(CODEX_CONFIG, "auth.failed_login_log", default=False)
+_AUTH_FAILED_LOGIN_LOG_PATH_CONFIG = get_str(
+    CODEX_CONFIG, "auth.failed_login_log_path", default=""
+)
+AUTH_FAILED_LOGIN_LOG_PATH = (
+    Path(_AUTH_FAILED_LOGIN_LOG_PATH_CONFIG)
+    if _AUTH_FAILED_LOGIN_LOG_PATH_CONFIG
+    else LOG_DIR / "failed_logins.log"
+)
+AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR = get_bool(
+    CODEX_CONFIG,
+    "auth.failed_login_log_trust_forwarded_for",
+    default=True,
+)
 
 ##############################
 # Codex Config: Browser      #
@@ -497,6 +511,8 @@ def _get_middleware(features: FeatureFlags) -> tuple[str, ...]:
     ]
     if AUTH_REMOTE_USER:
         middleware.append("codex.authentication.HttpRemoteUserMiddleware")
+    if AUTH_FAILED_LOGIN_LOG:
+        middleware.append("codex.failed_login_log.RequestContextMiddleware")
     middleware += [
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/codex/settings/codex.toml.default
+++ b/codex/settings/codex.toml.default
@@ -44,3 +44,14 @@
 # Allows authentication without authorization via the Remote-User header.
 # Only enable if you have authorization in front of Codex. Dangerous.
 # remote_user = false
+# Log failed login attempts to a separate file. Useful as input for
+# banning tools like fail2ban, CrowdSec, or sshguard.
+# Line format: "<ISO timestamp> | Failed login from <ip> user=<username>"
+# Example fail2ban failregex:
+#   ^\s*\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| Failed login from <HOST> user=.*$
+# failed_login_log = false
+# Path to the failed-login log. Defaults to <log_dir>/failed_logins.log.
+# failed_login_log_path = ""
+# When behind a reverse proxy, trust X-Forwarded-For for the client IP.
+# Disable if Codex is exposed directly (otherwise clients can forge their IP).
+# failed_login_log_trust_forwarded_for = true

--- a/codex/settings/config.py
+++ b/codex/settings/config.py
@@ -51,6 +51,9 @@ _ENV_OVERRIDES: dict[str, str] = {
     "CODEX_THROTTLE_OPENSEARCH": "throttle.opensearch",
     # Auth
     "CODEX_AUTH_REMOTE_USER": "auth.remote_user",
+    "CODEX_AUTH_FAILED_LOGIN_LOG": "auth.failed_login_log",
+    "CODEX_AUTH_FAILED_LOGIN_LOG_PATH": "auth.failed_login_log_path",
+    "CODEX_AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR": "auth.failed_login_log_trust_forwarded_for",
     # Debug
     "CODEX_DEBUG_LOG_AUTH_HEADERS": "debug.log_auth_headers",
     "CODEX_DEBUG_SLOW_QUERY_LIMIT": "debug.slow_query_limit",

--- a/codex/signals/django_signals.py
+++ b/codex/signals/django_signals.py
@@ -51,6 +51,7 @@ def connect_signals() -> None:
 
     from codex.models import Library
     from codex.models.favorite import FAVORITE_MODEL_GROUP_CODES
+    from codex.settings import AUTH_FAILED_LOGIN_LOG
 
     post_save.connect(_on_library_changed, sender=Library)
     post_delete.connect(_on_library_changed, sender=Library)
@@ -61,3 +62,10 @@ def connect_signals() -> None:
     # senders.
     for model in FAVORITE_MODEL_GROUP_CODES:
         post_delete.connect(_on_favorite_target_deleted, sender=model)
+
+    if AUTH_FAILED_LOGIN_LOG:
+        from django.contrib.auth.signals import user_login_failed
+
+        from codex.failed_login_log import on_login_failed
+
+        user_login_failed.connect(on_login_failed)

--- a/codex/startup/loguru.py
+++ b/codex/startup/loguru.py
@@ -5,7 +5,15 @@ from typing import Any
 
 from loguru import logger
 
-from codex.settings import DEBUG, LOG_PATH, LOG_RETENTION, LOG_ROTATION, LOGLEVEL
+from codex.settings import (
+    AUTH_FAILED_LOGIN_LOG,
+    AUTH_FAILED_LOGIN_LOG_PATH,
+    DEBUG,
+    LOG_PATH,
+    LOG_RETENTION,
+    LOG_ROTATION,
+    LOGLEVEL,
+)
 
 
 def _log_format() -> str:
@@ -45,3 +53,20 @@ def loguru_init() -> None:
         retention=LOG_RETENTION,
         compression="xz",
     )
+    if AUTH_FAILED_LOGIN_LOG:
+        # Lazy import keeps the failed_login_log module out of the import
+        # graph when the feature is off (the module imports from settings
+        # at load time, which is fine but avoidable when unused).
+        from codex.failed_login_log import failed_login_filter
+
+        AUTH_FAILED_LOGIN_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        logger.add(
+            AUTH_FAILED_LOGIN_LOG_PATH,
+            format="{time:YYYY-MM-DD HH:mm:ss} | {message}",
+            level="WARNING",
+            rotation=LOG_ROTATION,
+            retention=LOG_RETENTION,
+            compression="xz",
+            enqueue=True,
+            filter=failed_login_filter,
+        )

--- a/tests/test_failed_login_log.py
+++ b/tests/test_failed_login_log.py
@@ -1,0 +1,157 @@
+"""Tests for the optional failed-login log feature."""
+
+from typing import Final, override
+from unittest.mock import patch
+
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_login_failed
+from django.test import RequestFactory, TestCase
+from loguru import logger
+
+from codex.failed_login_log import (
+    RequestContextMiddleware,
+    _current_request,
+    failed_login_filter,
+    get_client_ip,
+    on_login_failed,
+)
+
+_TEST_PASSWORD: Final = "test-pw-hush-S106"  # noqa: S105
+_WRONG_PASSWORD: Final = "wrong-pw-hush-S106"  # noqa: S105
+
+
+class _CaptureSink:
+    """Loguru sink that appends formatted records to a list."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def __call__(self, msg) -> None:
+        self.lines.append(str(msg).rstrip("\n"))
+
+
+class GetClientIpTests(TestCase):
+    """Cover the IP-extraction helper."""
+
+    @override
+    def setUp(self) -> None:
+        """Build a fresh RequestFactory for each test."""
+        self.rf = RequestFactory()  # pyright: ignore[reportUninitializedInstanceVariable]
+
+    def test_none_request(self) -> None:
+        """Missing request resolves to the missing-value sentinel."""
+        assert get_client_ip(None) == "-"
+
+    def test_remote_addr_only(self) -> None:
+        """REMOTE_ADDR is returned when no XFF header is present."""
+        request = self.rf.get("/", REMOTE_ADDR="10.0.0.5")
+        assert get_client_ip(request) == "10.0.0.5"
+
+    def test_forwarded_leftmost(self) -> None:
+        """X-Forwarded-For wins, leftmost entry is returned."""
+        request = self.rf.get(
+            "/",
+            HTTP_X_FORWARDED_FOR="203.0.113.7, 10.0.0.5",
+            REMOTE_ADDR="10.0.0.5",
+        )
+        assert get_client_ip(request) == "203.0.113.7"
+
+    def test_forwarded_disabled(self) -> None:
+        """Disabling trust falls back to REMOTE_ADDR even when XFF present."""
+        request = self.rf.get(
+            "/",
+            HTTP_X_FORWARDED_FOR="203.0.113.7",
+            REMOTE_ADDR="10.0.0.5",
+        )
+        with patch(
+            "codex.failed_login_log.AUTH_FAILED_LOGIN_LOG_TRUST_FORWARDED_FOR",
+            new=False,
+        ):
+            assert get_client_ip(request) == "10.0.0.5"
+
+    def test_empty_forwarded_falls_back(self) -> None:
+        """Blank XFF doesn't shadow REMOTE_ADDR."""
+        request = self.rf.get("/", HTTP_X_FORWARDED_FOR="   ", REMOTE_ADDR="10.0.0.9")
+        assert get_client_ip(request) == "10.0.0.9"
+
+
+class OnLoginFailedTests(TestCase):
+    """Exercise the signal receiver via a captured loguru sink."""
+
+    @override
+    def setUp(self) -> None:
+        """Attach an in-memory sink and a user for credential tests."""
+        self.sink = _CaptureSink()  # pyright: ignore[reportUninitializedInstanceVariable]
+        self.sink_id = logger.add(  # pyright: ignore[reportUninitializedInstanceVariable]
+            self.sink,
+            level="WARNING",
+            format="{message}",
+            filter=failed_login_filter,
+        )
+        self.user = User.objects.create_user(  # pyright: ignore[reportUninitializedInstanceVariable]
+            username="alice", password=_TEST_PASSWORD
+        )
+        user_login_failed.connect(on_login_failed)
+        self.rf = RequestFactory()  # pyright: ignore[reportUninitializedInstanceVariable]
+
+    @override
+    def tearDown(self) -> None:
+        """Tear down the sink and disconnect the signal."""
+        user_login_failed.disconnect(on_login_failed)
+        logger.remove(self.sink_id)
+
+    def _wait_for_lines(self, count: int = 1) -> None:
+        """Drain loguru's enqueue buffer before asserting."""
+        logger.complete()
+        assert len(self.sink.lines) >= count, self.sink.lines
+
+    def test_receiver_logs_ip_and_username(self) -> None:
+        """Direct authenticate() with request propagates the IP into the log."""
+        request = self.rf.post("/login/", REMOTE_ADDR="198.51.100.42")
+        result = authenticate(
+            request=request, username="alice", password=_WRONG_PASSWORD
+        )
+        assert result is None
+        self._wait_for_lines()
+        assert "Failed login from 198.51.100.42 user=alice" in self.sink.lines[-1]
+
+    def test_receiver_uses_context_when_request_omitted(self) -> None:
+        """Caller-omitted request is recovered from the contextvar."""
+        request = self.rf.post("/login/", REMOTE_ADDR="198.51.100.99")
+        token = _current_request.set(request)
+        try:
+            result = authenticate(username="alice", password=_WRONG_PASSWORD)
+            assert result is None
+        finally:
+            _current_request.reset(token)
+        self._wait_for_lines()
+        assert "198.51.100.99" in self.sink.lines[-1]
+
+    def test_unknown_user_logs_username(self) -> None:
+        """Nonexistent username still produces a log line — fail2ban needs it."""
+        request = self.rf.post("/login/", REMOTE_ADDR="198.51.100.10")
+        authenticate(request=request, username="ghost", password=_WRONG_PASSWORD)
+        self._wait_for_lines()
+        assert "user=ghost" in self.sink.lines[-1]
+        assert "198.51.100.10" in self.sink.lines[-1]
+
+
+class RequestContextMiddlewareTests(TestCase):
+    """Sanity-check the contextvar middleware in isolation."""
+
+    def test_sync_sets_and_resets_contextvar(self) -> None:
+        """Sync path sets the contextvar during the call and clears it after."""
+        rf = RequestFactory()
+        request = rf.get("/x")
+        seen = {}
+
+        def _inner(_req):
+            seen["during"] = _current_request.get()
+            return "response"
+
+        middleware = RequestContextMiddleware(_inner)
+        result = middleware(request)
+        assert result == "response"
+        assert seen["during"] is request
+        assert _current_request.get() is None


### PR DESCRIPTION
## Summary

- Adds an **optional, default-off** feature that appends one parseable line per failed credential attempt to a dedicated log file at `<log_dir>/failed_logins.log`.
- Configurable via three new keys under `[auth]` in `codex.toml` (or matching `CODEX_AUTH_*` env vars). Disabled deployments pay zero overhead — no extra middleware, no extra sink, no extra signal receiver.
- Hooks `django.contrib.auth.signals.user_login_failed`, which fires for both rest_registration's form login and DRF's `BasicAuthentication` (OPDS), so a single receiver covers both attack vectors.

## Why

Codex's OPDS endpoints accept HTTP Basic Auth and `/api/v3/auth/login/` accepts username/password — both internet-facing and attractive brute-force targets when a Codex instance is exposed publicly. Operators had no way to feed those failures into a banning tool. This adds a consumer-agnostic line format that fail2ban, CrowdSec, sshguard, or any tail-and-regex tool can use.

## How it works

- **Single sink**: `codex/startup/loguru.py` registers a dedicated loguru sink filtered by `logger.bind(failed_login=True)`. The tagged record also passes the default stdout/codex.log filters, so admins still see auth failures in the main log; no format leak because the main format string doesn't render `extra`.
- **Signal receiver**: lives in `codex/failed_login_log.py`, wired conditionally inside the existing `connect_signals()`.
- **Request-context middleware**: `rest_registration`'s default `authenticate_by_login_data` calls `auth.authenticate(...)` **without** passing `request=`, so the signal would otherwise arrive with `request=None` and we'd log `-` for the IP. A small `RequestContextMiddleware` stashes the active request in a `contextvars.ContextVar` (works for both sync and ASGI/Granian) and the receiver falls back to it. DRF's `BasicAuthentication` already propagates `request=` so OPDS goes through the direct path.
- **XFF trust**: defaults to true (matching the project's existing `USE_X_FORWARDED_HOST = True` posture) but is toggleable via `auth.failed_login_log_trust_forwarded_for` so direct-exposed deployments can opt out and avoid header-spoofed log poisoning.

## Log line format

```
2026-05-10 12:34:56 | Failed login from 192.168.1.42 user=alice
```

Example fail2ban `failregex`:
```
^\s*\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| Failed login from <HOST> user=.*$
```

## Files

- `codex/failed_login_log.py` (new) — receiver, IP helper, sink filter, middleware
- `tests/test_failed_login_log.py` (new) — 9 tests covering IP extraction, signal receiver capture, contextvar fallback, middleware
- `codex/settings/codex.toml.default` — three new keys with worked fail2ban regex example
- `codex/settings/config.py`, `codex/settings/__init__.py` — env mappings, typed settings, conditional middleware registration
- `codex/startup/loguru.py` — dedicated sink (conditional)
- `codex/signals/django_signals.py` — signal wired in existing `connect_signals()`

## Test plan

- [x] `make fix && make lint && make ty` clean
- [x] `pytest tests/test_failed_login_log.py -v` — all 9 new tests pass (~85% coverage of the new module)
- [x] `make test-python` — 227 passed, suite unaffected (feature is default-off)
- [ ] Manual smoke test: set `CODEX_AUTH_FAILED_LOGIN_LOG=1`, hit `/api/v3/auth/login/` with bad creds, hit an OPDS endpoint with bad Basic auth, confirm `config/logs/failed_logins.log` matches the regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)