### PR TITLE
fix(browser): restore card-mode order_value caption for mixed-children groups

### DIFF
--- a/codex/views/browser/annotate/order.py
+++ b/codex/views/browser/annotate/order.py
@@ -288,23 +288,32 @@ class BrowserAnnotateOrderView(BrowserOrderByView, SharedAnnotationsMixin):
 
     def _group_m2m_order_value(self, qs):
         """Group-row M2M order_value, falling back to ``sort_name``."""
-        isort_expr = m2m_intersection_sort_expr(qs.model, self.order_key)
-        if isort_expr is not None:
-            return qs, isort_expr
+        # Intersection sort matches the table-view cell display. Cover
+        # view's caption can't render M2M intersection and the rule
+        # would leave most cards with a NULL sort key, so card mode
+        # falls back to sort_name.
+        if self.params.get("view_mode") == "table":
+            isort_expr = m2m_intersection_sort_expr(qs.model, self.order_key)
+            if isort_expr is not None:
+                return qs, isort_expr
         if qs.model is Volume:
             qs = qs.alias(sort_name=F("name"))
         return qs, F("sort_name")
 
     def _group_scalar_order_value(self, qs):
-        """Group-row scalar / FK-name order_value (intersection-aware)."""
-        # Display uses intersection — a value renders only when every
-        # child comic agrees — so the sort key matches that rule.
-        # Falls back to the legacy aggregate path when the column /
-        # group model isn't wired so adding a new registry scalar
-        # doesn't silently regress its sort.
-        isort_expr = scalar_intersection_sort_expr(qs.model, self.order_key)
-        if isort_expr is not None:
-            return isort_expr
+        """Group-row scalar / FK-name order_value."""
+        # Table view uses intersection so the sort key matches the
+        # displayed cell (blank when children disagree). Cover view's
+        # card caption shows order_value directly — intersection there
+        # would blank the caption for any group with mixed children,
+        # which is the regression we're avoiding. Falls back to the
+        # legacy aggregate path when the column / group model isn't
+        # wired so adding a new registry scalar doesn't silently
+        # regress its sort.
+        if self.params.get("view_mode") == "table":
+            isort_expr = scalar_intersection_sort_expr(qs.model, self.order_key)
+            if isort_expr is not None:
+                return isort_expr
         agg_func = _ORDER_AGGREGATE_FUNCS[self.order_key]
         agg_func = self.order_agg_func if agg_func == Min else agg_func
         field = self.rel_prefix + comic_order_path(self.order_key)

--- a/tests/test_browser_ordering.py
+++ b/tests/test_browser_ordering.py
@@ -657,6 +657,72 @@ class BrowserOrderByIntegrationTestCase(TestCase):
         # intersection-sort key is NULL.
         assert names == ["Beta", "Alpha", "Mixed"], names
 
+    def test_cover_mode_group_order_value_uses_aggregate(self) -> None:
+        """
+        Cover view's group order_value is an aggregate, not an intersection.
+
+        Regression: the table-view PR routed group-row scalar sort
+        through ``scalar_intersection_sort_expr`` for every view mode.
+        That's correct for table view (sort matches the intersection
+        cell display) but blanks the order_value caption beneath
+        cover-mode cards for any group whose children disagree on
+        the sorted field. Series with mixed years rendered the card
+        caption as null; the user reported the same for Publish Date
+        across publishers, series, and folders.
+
+        Setup matches ``test_year_sort_matches_intersection_display``
+        — Alpha (clean 2020), Beta (single 2021), Mixed (2018 + 2024)
+        — but the request uses ``viewMode=cover``. Every group row
+        must come back with a non-null ``orderValue`` so the card
+        caption renders.
+        """
+        library = Library.objects.first()
+        publisher = Publisher.objects.get(name="ZZ Press")
+        imprint = Imprint.objects.get(name="ZZ Imprint")
+        series_mixed = Series.objects.create(
+            name="Mixed", imprint=imprint, publisher=publisher
+        )
+        volume_mixed = Volume.objects.create(
+            name="2030",
+            series=series_mixed,
+            imprint=imprint,
+            publisher=publisher,
+        )
+        for issue, year in ((1, 2018), (2, 2024)):
+            path = TMP_DIR / f"mixed-{issue}.cbz"
+            path.touch()
+            Comic.objects.create(
+                library=library,
+                path=path,
+                issue_number=issue,
+                name=f"mixed-{issue}",
+                publisher=publisher,
+                imprint=imprint,
+                series=series_mixed,
+                volume=volume_mixed,
+                size=100 + issue,
+                year=year,
+                page_count=10 + issue,
+            )
+
+        url = f"/api/v3/p/{publisher.pk}/1"
+        self._patch_settings(
+            {"viewMode": "cover", "orderBy": "year", "orderReverse": False}
+        )
+        response = self.client.get(url)
+        assert response.status_code == _HTTP_OK, response.content
+        groups = response.json().get("groups", [])
+        by_name = {g["name"]: g for g in groups}
+        # Aggregate (Min year asc): Mixed=2018, Alpha=2020, Beta=2021.
+        # None must be null — the user-visible regression was a null
+        # caption on Mixed (children disagree). The serializer emits
+        # ``order_value`` as a CharField so values come back stringified.
+        assert by_name["Alpha"]["orderValue"] == "2020"
+        assert by_name["Beta"]["orderValue"] == "2021"
+        assert by_name["Mixed"]["orderValue"] == "2018", (
+            f"Mixed orderValue should be Min(year)=2018, got {by_name['Mixed']['orderValue']!r}"
+        )
+
     def test_primary_sort_by_year_on_group_rows(self) -> None:
         """Min aggregate over a direct integer field (``year``) sorts correctly."""
         # Alpha has two comics, both year=2020 → Min year = 2020.


### PR DESCRIPTION
## Summary

- The browser table-view PR ([#745](https://github.com/ajslater/codex/pull/745)) routed group-row scalar / M2M sort through `scalar_intersection_sort_expr` / `m2m_intersection_sort_expr` for *every* view mode. Intersection returns `NULL` when a group's children disagree on the sorted field — correct for table view (sort matches the intersection cell display) but it blanks the `order_value` caption beneath cover-mode cards for any group with mixed children. The user reported this for Publish Date across publishers, series, and folders.
- Gate the intersection branch on `view_mode == "table"` in `_group_scalar_order_value` and `_group_m2m_order_value` so cover mode falls back to the pre-table-view aggregate (`Min`/`Max`/`Avg`/`Sum`) for scalars and `sort_name` for M2M.
- Add a regression test that reproduces the reported scenario: a "Mixed" series whose children disagree on year used to return `orderValue: null`; now it returns the `Min` aggregate.

## Why

In cover mode, `order_value` is the caption rendered beneath each browser card. The intersection rule is correct for table view (cell display matches sort) but is the wrong rule for cover view, where the caption is meant to show the aggregated value the rows are sorted by — `Min(year)` for ASC, `Max(year)` for DESC, etc. The table-view PR didn't gate by view mode, so cover-mode users started seeing blank captions for any mixed-children group.

The `_extra_group_expr` path that also uses these intersection expressions is already correctly gated behind `_should_annotate_extras` (which checks `view_mode == "table"`), so no change is needed there.

## Test plan

- [x] Added `test_cover_mode_group_order_value_uses_aggregate` — verified it fails on the pre-fix code (Mixed series → `orderValue=None`) and passes after the fix (Mixed → `"2018"`).
- [x] Existing `test_year_sort_matches_intersection_display` still passes (table-mode behavior unchanged).
- [x] All 62 tests in `tests/test_browser_ordering.py` pass.
- [x] `tests/test_browser_table_response.py`, `tests/test_browser_columns_registry.py`, `tests/test_browser_settings_table.py` all pass (84 tests).
- [x] `make lint` clean.
- [x] `make ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)