### PR TITLE
fix(dev): make Vite dev server reachable from LAN browsers

### DIFF
--- a/bin/dev-server.sh
+++ b/bin/dev-server.sh
@@ -12,8 +12,6 @@ export PYTHONWARNINGS=always
 #export CODEX_THROTTLE_OPDS=10
 #export CODEX_THROTTLE_USER=10
 export DJANGO_SETTINGS_MODULE=codex.settings
-# If I need to test mobile, then use only ONE network interface (wifi) and comment out this variable
-export VITE_HOST=localhost
 #uv run python3 -X tracemalloc ./codex/run.py
 #uv run righttyper --all-files --overwrite codex/run.py
 uv run python3 ./codex/run.py

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -57,9 +57,46 @@ const config = defineConfig(({ mode }) => {
     rawHost.includes(".") && !rawHost.endsWith(".local")
       ? `${rawHost.split(".")[0]}.local`
       : rawHost;
+  // Mirror Django's ``_vite_dev_server_host``: explicit
+  // ``VITE_HOST`` override, otherwise the mDNS-mangled hostname.
+  // This is the name baked into the @vite/client's ``serverHost``
+  // and ``directSocketHost`` strings, so it must be resolvable
+  // from *every* browser that loads the page — not just the host.
+  // Without setting ``server.hmr.host`` Vite falls back to
+  // ``localhost`` whenever ``server.host`` is ``true``, which makes
+  // LAN browsers connect to their own loopback and get
+  // ERR_CONNECTION_REFUSED for HMR + module fetches.
+  const HMR_HOST = process.env.VITE_HOST?.toLowerCase() || mDNSHost;
   const ALLOWED_HOSTS = DEV
-    ? [...new Set([rawHost, mDNSHost, "localhost", "127.0.0.1", "[::1]"])]
+    ? [
+        ...new Set([
+          HMR_HOST,
+          rawHost,
+          mDNSHost,
+          "localhost",
+          "127.0.0.1",
+          "[::1]",
+        ]),
+      ]
     : [];
+  // Vite 6+ defaults ``server.cors.origin`` to a regex matching
+  // only loopback / ``.localhost`` hosts. When the Django dev
+  // server is browsed at e.g. ``http://hooloovoo.local:9810``, the
+  // browser sends ``Origin: http://hooloovoo.local:9810`` while
+  // fetching ``<script src="http://hooloovoo.local:5173/...">``.
+  // That origin doesn't match Vite's default regex, so the dev
+  // server replies with ``Vary: Origin`` but no
+  // ``Access-Control-Allow-Origin`` and the script load is blocked.
+  // Mirror ``allowedHosts`` into a CORS regex that accepts any
+  // port so browser-side fetches from Django (or anything else on
+  // the same hostname) work.
+  const reEscape = (s) => s.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&");
+  const CORS_ORIGIN = DEV
+    ? // eslint-disable-next-line security/detect-non-literal-regexp
+      new RegExp(
+        `^https?://(${ALLOWED_HOSTS.map(reEscape).join("|")})(?::\\d+)?$`,
+      )
+    : undefined;
   let publicPathPrefix = "window.CODEX.APP_PATH";
   if (PROD) {
     publicPathPrefix += ".substring(1)";
@@ -172,6 +209,8 @@ const config = defineConfig(({ mode }) => {
     server: {
       host: true,
       allowedHosts: ALLOWED_HOSTS,
+      cors: { origin: CORS_ORIGIN },
+      hmr: { host: HMR_HOST },
       strictPort: true,
     },
     test: {


### PR DESCRIPTION
## Summary

Three coupled issues prevented browsing the dev server from a second
Mac on the LAN (with the host advertised via mDNS as e.g. `hooloovoo.local`).
None reproduce on the host itself, which made the symptoms misleading.

### `bin/dev-server.sh`

Dropped `export VITE_HOST=localhost`. The line overrode the auto-derivation
in `codex/settings/__init__.py:_vite_dev_server_host()`, so django-vite
rendered `<script src="http://localhost:5173/...">` regardless of mDNS,
and any browser that wasn't on the host Mac tried to load the bundle
from its own loopback.

### `frontend/vite.config.js`

- **`server.cors.origin`** — Vite 6+ defaults `server.cors.origin` to a
  regex that only matches `localhost` / `127.0.0.1` / `[::1]`. Browsers
  hitting Django at `http://<host>:9810` and then fetching from
  `http://<host>:5173` got `Vary: Origin` back but no
  `Access-Control-Allow-Origin`, so the scripts were blocked. Mirror
  `allowedHosts` into a port-agnostic CORS regex.
- **`server.hmr.host`** — With `server.host: true` and no explicit
  `hmr.host`, Vite bakes `localhost` into the HMR client's
  `directSocketHost` and `socketHost` strings. Remote browsers opened
  the HMR WebSocket against their own loopback (`ERR_CONNECTION_REFUSED`).
  Set `hmr.host` to the same `VITE_HOST` / mDNS-mangled hostname Django
  uses for `<script src>` so the embedded URL agrees with where the page
  actually loaded the module from.
- **`allowedHosts`** — Include the resolved `HMR_HOST` so an explicit
  `VITE_HOST=...` override (one that doesn't match `os.hostname()`) is
  also trusted by Vite's host-header check and the new CORS regex.

Vite still hardcodes `localhost` into one more string — the diagnostic
`serverHost` variable in `@vite/client` — but that's only used inside a
console error message template when HMR fails, never for an actual fetch.
Influencing it would require pinning `server.host` to a single name,
which loses loopback access from the host machine.

## Test plan

- [ ] On the host machine: `./bin/dev-server.sh` and `bun run dev` (in
      `frontend/`) start cleanly; browsing `http://<host>.local:9810/`
      loads the app with HMR working.
- [ ] On a second Mac on the LAN: browsing the same URL loads the app,
      script tags resolve, HMR WebSocket connects.
- [ ] `curl -s http://<host>.local:5173/static/@vite/client | grep -E 'serverHost|directSocketHost'`
      shows `directSocketHost` = `<host>.local:5173/...` (only `serverHost`
      should still be `localhost`, which is cosmetic per above).
- [ ] `curl -sI -H "Origin: http://<host>.local:9810" http://<host>.local:5173/static/@vite/client`
      returns an `Access-Control-Allow-Origin` header.
- [ ] Localhost workflow on the host (`http://localhost:9810/`) still
      works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)