### PR TITLE
fix(metadata): drop unneeded scrollbar on MetadataText values

### DIFF
--- a/frontend/src/components/metadata/metadata-text.vue
+++ b/frontend/src/components/metadata/metadata-text.vue
@@ -234,7 +234,7 @@ export default {
 }
 
 .textValue {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .expandButton {


### PR DESCRIPTION
## Summary

On Edge for Windows the metadata dialog renders tiny up/down chevron
controls next to nearly every text field (publisher, bookmark progress,
date, tagger, etc.). The chevrons are Edge's classic Windows scrollbar
arrow buttons — every `MetadataText` value div had `overflow-y: scroll`,
which forces a scrollbar to render permanently, and Chromium-based Edge
draws arrow buttons on forced scrollbars where other Chromium browsers
don't. Hence Edge-only.

The scroll was only ever needed for the two fields that get
`:max-height="100"` (Summary and Review in `metadata-body.vue`); on
everything else the forced scrollbar was decorative noise.

Switch to `overflow-y: auto` so the scrollbar only appears when content
actually overflows. The `isOverflow` measurement in `mounted()` keeps
working — `clientHeight < scrollHeight` is unaffected by `scroll` vs
`auto`.

## Test plan

- [ ] On Edge/Windows: open the metadata dialog for a comic; verify the
      up/down chevrons next to publisher, bookmark progress, date,
      tagger, and other single-line values are gone.
- [ ] In Chrome/Firefox/Safari: metadata dialog renders identically to
      before (no visible regression).
- [ ] Open a comic with a long Summary or Review: the field is still
      capped at 100px, still scrollable, and the "Show more" expand
      button still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)