### PR TITLE
feat(reader): swipe to turn pages on touch devices

### DIFF
--- a/frontend/src/components/reader/pager/pager-horizontal.vue
+++ b/frontend/src/components/reader/pager/pager-horizontal.vue
@@ -4,6 +4,7 @@
     continuous
     :model-value="windowIndex"
     :reverse="isReadInReverse"
+    :touch="swipeHandlers"
   >
     <template #prev>
       <PageChangeLink direction="prev" />
@@ -87,6 +88,20 @@ export default {
       const val = this.activePage - this.pages[0];
       return Math.min(Math.max(0, val), this.book?.maxPage || 0);
     },
+    swipeHandlers() {
+      /*
+       * Override v-window's built-in touch nav so swipes route
+       * through the comic page URL like the keyboard arrows do.
+       * The default handlers call v-window's internal prev/next,
+       * which are no-ops here because all items are ``disabled``.
+       * Matching ArrowRight → ``next`` and ArrowLeft → ``prev``
+       * lets ``routeToDirection`` normalize for RTL the same way.
+       */
+      return {
+        left: () => this.routeToDirection("next"),
+        right: () => this.routeToDirection("prev"),
+      };
+    },
   },
   watch: {
     twoPages() {
@@ -119,6 +134,7 @@ export default {
   methods: {
     ...mapActions(useReaderStore, [
       "getBookSettings",
+      "routeToDirection",
       "setBookChangeFlag",
       "setActivePage",
     ]),


### PR DESCRIPTION
## Summary

- Add left/right swipe gestures to the horizontal comic reader on touch devices, mirroring the existing ArrowRight/ArrowLeft keyboard behavior.
- Implemented by overriding ``v-window``'s built-in ``touch`` prop with handlers that call ``routeToDirection``. Vuetify's touch directive already lives on that element — the defaults try to flip between v-window items, which are ``disabled`` here and rely on URL routing instead.
- RTL handling is automatic: ``routeToDirection`` normalizes the direction through ``normalizeDirection``, so manga / right-to-left books swap left/right just like the arrow keys do.
- Vertical reader mode is untouched — it already responds to native touch scrolling.

## Notes for reviewer

- This branch was already 2 commits ahead of ``develop`` before this change: the v1.12.3 version bump + news, and a merge from ``develop``. Those commits are unrelated to the swipe feature and just rode along on this branch.
- NEWS.md was not modified for the swipe feature; happy to add a bullet under v1.12.3 if you'd like.

## Test plan

- [ ] Open a comic in horizontal mode on a phone / tablet — swipe left advances a page, swipe right goes back.
- [ ] Open an RTL / manga title — swipe directions are flipped (left = previous, right = next), matching the arrow keys in RTL.
- [ ] In Chrome devtools, toggle device toolbar (Cmd-Opt-I → device icon) and confirm swipes register at the default 16px threshold.
- [ ] Two-page mode swipes still advance by a spread (delegated to the existing route logic).
- [ ] Vertical reading mode is unaffected — native scroll still works, no horizontal swipe interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)