### PR TITLE
fix(librarian): allow .codex-cover dotfiles through ignore filter

### DIFF
--- a/codex/librarian/fs/filters.py
+++ b/codex/librarian/fs/filters.py
@@ -34,9 +34,14 @@ _IGNORED_BASENAME_PREFIXES: tuple[str, ...] = (".",)
 
 def is_ignored_basename(name: str) -> bool:
     """Return True when ``name`` matches any registered ignore rule."""
-    return name in _IGNORED_BASENAMES or any(
-        name.startswith(prefix) for prefix in _IGNORED_BASENAME_PREFIXES
-    )
+    if name in _IGNORED_BASENAMES:
+        return True
+    if not any(name.startswith(prefix) for prefix in _IGNORED_BASENAME_PREFIXES):
+        return False
+    # Folder-cover dotfiles (``.codex-cover.jpg`` etc.) are intentional
+    # user-supplied covers, not OS noise — the dotfile filter must let
+    # them through so the cover predicate downstream can claim them.
+    return not match_folder_cover(Path(name))
 
 
 def is_ignored_path(path: Path | str, root: Path | str | None = None) -> bool:

--- a/tests/test_fs_filters_ignore.py
+++ b/tests/test_fs_filters_ignore.py
@@ -41,6 +41,22 @@ class TestIsIgnoredPath:
         root = "/Users/aj/.archive"
         assert is_ignored_path(Path(f"{root}/comic.cbz"), root=root) is False
 
+    def test_folder_cover_dotfile_passes(self) -> None:
+        # ``.codex-cover.jpg`` looks like a hidden file but is the
+        # user-supplied per-folder cover. The dotfile filter must let
+        # it through so the cover importer can claim it.
+        assert is_ignored_path(Path("/lib/comics/series/.codex-cover.jpg")) is False
+        assert is_ignored_basename(".codex-cover.jpg") is False
+        assert is_ignored_basename(".codex-cover.webp") is False
+        assert is_ignored_basename(".codex-cover.png") is False
+
+    def test_folder_cover_dotfile_without_image_ext_still_ignored(self) -> None:
+        # ``.codex-cover`` (no extension) or non-image extensions are
+        # not real folder covers — keep them filtered as ordinary
+        # dotfiles.
+        assert is_ignored_basename(".codex-cover") is True
+        assert is_ignored_basename(".codex-cover.txt") is True
+
     def test_subtree_ignored_still_caught_with_root(self) -> None:
         root = "/Users/aj/.archive"
         path = Path(f"{root}/.tmp/comic.cbz")
@@ -102,6 +118,16 @@ class TestDiskSnapshotSkipsDotfiles:
         # Neither the dot-dir nor any descendant should appear.
         assert not any(".git" in Path(p).parts for p in snap.paths)
 
+    def test_folder_cover_dotfile_picked_up(self) -> None:
+        # Regression: the dotfile filter used to swallow user-supplied
+        # ``.codex-cover.jpg`` files before the cover predicate could
+        # claim them, breaking custom folder covers.
+        (_TEST_LIB_ROOT / "comic.cbz").touch()
+        (_TEST_LIB_ROOT / ".codex-cover.jpg").touch()
+        snap = DiskSnapshot(str(_TEST_LIB_ROOT), getLogger("test"), covers_only=False)
+        names = {Path(p).name for p in snap.paths}
+        assert ".codex-cover.jpg" in names
+
 
 class TestCodexWatchFilter:
     """The watchfiles filter rejects hidden-tree events before classification."""
@@ -132,6 +158,14 @@ class TestCodexWatchFilter:
     def test_deleted_comic_passes(self) -> None:
         assert self._filter()(Change.deleted, f"{_TEST_LIB_ROOT}/gone.cbz") is True
 
+    def test_folder_cover_dotfile_passes(self) -> None:
+        # Regression: ``.codex-cover.jpg`` is a dotfile by name but a
+        # legitimate folder cover. Both modify and delete events must
+        # reach the importer.
+        path = f"{_TEST_LIB_ROOT}/series/.codex-cover.jpg"
+        assert self._filter()(Change.modified, path) is True
+        assert self._filter()(Change.deleted, path) is True
+
 
 class TestExpandDirAddedSkipsDotfiles:
     """``os.walk`` recursion under a new dir must prune hidden subtrees."""
@@ -158,3 +192,18 @@ class TestExpandDirAddedSkipsDotfiles:
         expand_dir_added(str(sub), library_pk=1, batch=batch, covers_only=False)
         paths = {event.src_path for _pk, event in batch.added}
         assert paths == {str(sub / "comic.cbz")}
+
+    def test_folder_cover_dotfile_emits_event(self) -> None:
+        # Regression: ``expand_dir_added`` walks a freshly-added tree
+        # and used to skip ``.codex-cover.jpg`` via the dotfile filter
+        # before the cover classifier could see it.
+        sub = _TEST_LIB_ROOT / "new"
+        sub.mkdir()
+        (sub / "comic.cbz").touch()
+        (sub / ".codex-cover.jpg").touch()
+
+        batch = ChangeBatch()
+        expand_dir_added(str(sub), library_pk=1, batch=batch, covers_only=False)
+        paths = {event.src_path for _pk, event in batch.added}
+        assert str(sub / ".codex-cover.jpg") in paths
+        assert str(sub / "comic.cbz") in paths


### PR DESCRIPTION
## Summary

- Custom folder covers (`.codex-cover.jpg`) silently stopped importing in v1.12.5. Commit a709a740 added a `.` prefix to `_IGNORED_BASENAME_PREFIXES`, which made the poller's walker, the watchfiles filter, and `expand_dir_added` all skip the file before the cover predicate ever ran.
- `is_ignored_basename` now defers to `match_folder_cover` for dotfiles, so `.codex-cover.{jpg,jpeg,png,webp,gif,bmp}` passes through while `.DS_Store`, `.git`, `.Trashes`, `.codex-cover` (no extension), and `.codex-cover.txt` remain filtered.
- Added regression tests covering all four code paths that consult the ignore filter (`is_ignored_basename` / `is_ignored_path`, `DiskSnapshot`, `CodexWatchFilter`, `expand_dir_added`) plus a negative test for non-image dotfile matches.

## Test plan

- [x] `uv run pytest tests/test_fs_filters_ignore.py` — 22 passed (4 new regression tests)
- [x] `make lint` clean
- [x] `make ty` clean
- [ ] Drop a `.codex-cover.jpg` into a comic folder on a running instance and confirm the folder picks up the custom cover after the next poll / event

🤖 Generated with [Claude Code](https://claude.com/claude-code)