### PR TITLE
fix(auth): allow Remote-User SSO for DRF API endpoints

### DIFF
--- a/codex/authentication.py
+++ b/codex/authentication.py
@@ -1,13 +1,32 @@
 """Custom Authentication classes."""
 
 from django.contrib.auth.middleware import RemoteUserMiddleware
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import (
+    RemoteUserAuthentication,
+    TokenAuthentication,
+)
 
 
 class BearerTokenAuthentication(TokenAuthentication):
     """Bearer Token Authentication."""
 
     keyword = "Bearer"
+
+
+class HttpRemoteUserAuthentication(RemoteUserAuthentication):
+    """
+    Http Remote User Authentication for DRF.
+
+    DRF's stock ``RemoteUserAuthentication`` reads ``REMOTE_USER``,
+    which is only populated by on-machine WSGI/ASGI socket magic.
+    Behind a reverse proxy that forwards a ``Remote-User`` header,
+    the value arrives under ``HTTP_REMOTE_USER`` instead. DRF needs
+    its own auth class for that path because ``SessionAuthentication``
+    enforces CSRF on unsafe methods, which breaks proxy-authenticated
+    API clients that do not carry a CSRF token.
+    """
+
+    header = "HTTP_REMOTE_USER"
 
 
 class HttpRemoteUserMiddleware(RemoteUserMiddleware):

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -750,11 +750,22 @@ if DEBUG:
     _RENDERER_CLASSES.append(
         "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer"
     )
+
+# DRF auth classes are tried in order; the first to return a user wins.
+# When AUTH_REMOTE_USER is on, ``HttpRemoteUserAuthentication`` runs
+# first so proxy-forwarded ``Remote-User`` API requests authenticate
+# without ``SessionAuthentication``'s CSRF enforcement (the proxy is
+# the auth authority; API clients there carry no CSRF token).
+_AUTHENTICATION_CLASSES = [
+    "rest_framework.authentication.SessionAuthentication",
+    "codex.authentication.BearerTokenAuthentication",
+]
+if AUTH_REMOTE_USER:
+    _AUTHENTICATION_CLASSES.insert(
+        0, "codex.authentication.HttpRemoteUserAuthentication"
+    )
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.SessionAuthentication",
-        "codex.authentication.BearerTokenAuthentication",
-    ),
+    "DEFAULT_AUTHENTICATION_CLASSES": tuple(_AUTHENTICATION_CLASSES),
     "DEFAULT_RENDERER_CLASSES": tuple(_RENDERER_CLASSES),
     "DEFAULT_PARSER_CLASSES": (
         "djangorestframework_camel_case.parser.CamelCaseJSONParser",


### PR DESCRIPTION
## Summary

Reverse-proxy `Remote-User` SSO (enabled via `CODEX_AUTH_REMOTE_USER`) worked
for Django views but DRF API endpoints (`/api/v3/...`) returned 403 on
proxy-authenticated requests that carried no CSRF token — typical of non-browser
clients sitting behind Authentik / tinyauth / SWAG.

Root cause: DRF's only configured auth classes were `SessionAuthentication`
(which enforces CSRF on unsafe methods, the proxy is the auth authority so
clients legitimately have no token) and `BearerTokenAuthentication` (irrelevant
to Remote-User). The middleware set `request.user`, but DRF never had an auth
class that read the header and skipped CSRF.

- Adds `HttpRemoteUserAuthentication` in `codex/authentication.py` — a subclass
  of DRF's stock `RemoteUserAuthentication` that reads `HTTP_REMOTE_USER`
  (the WSGI/ASGI normalization of the proxy-forwarded `Remote-User` header)
  instead of `REMOTE_USER` (which only the on-machine socket path populates).
- Conditionally prepends it to `REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]`
  when `AUTH_REMOTE_USER` is on. Order matters: it must run before
  `SessionAuthentication` so Remote-User clients authenticate via the existing
  `RemoteUserBackend` without hitting CSRF.

No behavior change when `CODEX_AUTH_REMOTE_USER` is off.

Closes the bug report about `403 Forbidden` from `/api/v3/auth/profile/` and
other DRF endpoints behind Authentik / SWAG / NGINX forward-auth setups.

## Test plan

- [x] `make fix` clean
- [x] `make lint` clean (ruff, basedpyright, vulture, complexipy, codespell, hadolint, actionlint)
- [x] `make test` clean (257 backend + 69 frontend tests)
- [ ] Manual: stand up Codex behind a proxy that forwards `Remote-User`, hit `/api/v3/auth/profile/` as a non-session client (curl), confirm 200 instead of 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)