### PR TITLE
fix(opds): recognize Panels as a facet capable client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,19 @@ width: 128px;
 border-radius: 128px;
 " />
 
+## v2.2.9
+
+- Fixes
+    - OPDS: Panels (iOS 3.13 and later) is recognized as a facet capable client
+      and receives real OPDS facets, which it shows in its native filter menu,
+      instead of sort options faked as navigation folders.
+    - OPDS v1: facet capable clients like kybooks no longer also receive a dead,
+      unclickable duplicate entry for every facet alongside the real facet
+      links.
+    - OPDS v1: facet groups are labeled "Order By", "Order Direction" and
+      "Views" instead of the internal query parameter names clients displayed
+      verbatim, like "orderBy".
+
 ## v2.2.8
 
 - Fixes

--- a/codex/serializers/opds/v1.py
+++ b/codex/serializers/opds/v1.py
@@ -12,7 +12,6 @@ from rest_framework.fields import (
 )
 from rest_framework.serializers import Serializer
 
-from codex.serializers.fields.collection import BrowseCollectionField
 from codex.serializers.models.pycountry import LanguageSerializer
 
 UTC_TZ = ZoneInfo("UTC")
@@ -26,7 +25,7 @@ class OPDS1TemplateLinkSerializer(Serializer):
     mime_type = CharField(read_only=True)
     title = CharField(read_only=True, required=False)
     length = IntegerField(read_only=True, required=False)
-    facet_group = BrowseCollectionField(read_only=True, required=False)
+    facet_group = CharField(read_only=True, required=False)
     facet_active = BooleanField(read_only=True, required=False)
     thr_count = IntegerField(read_only=True, required=False)
     pse_count = IntegerField(read_only=True, required=False)

--- a/codex/views/opds/const.py
+++ b/codex/views/opds/const.py
@@ -109,7 +109,7 @@ class UserAgentNames:
     """Control whether to hack in facets with nav links."""
 
     CLIENT_REORDERS = frozenset({"Chunky"})
-    FACET_SUPPORT = frozenset({"yar"})  # kybooks
+    FACET_SUPPORT = frozenset({"yar", "Panels"})  # kybooks, Panels iOS 3.13+
     SIMPLE_DOWNLOAD_MIME_TYPES = frozenset({"PocketBook Reader"})
     REQUIRE_ABSOLUTE_URL = frozenset()
 

--- a/codex/views/opds/v1/const.py
+++ b/codex/views/opds/v1/const.py
@@ -118,6 +118,9 @@ class FacetGroup:
     query_param: str
     glyph: str
     facets: tuple
+    # Rendered verbatim by clients as the facet group heading, so it's a
+    # display string, not the internal query param name.
+    display_name: str
 
 
 @dataclass
@@ -140,12 +143,14 @@ class FacetGroups:
             Facet("sort_name", "Name"),
             Facet("filename", "Filename"),
         ),
+        display_name="Order By",
     )
     ORDER_REVERSE = FacetGroup(
         "Order",
         "orderReverse",
         "⇕",
         (Facet("false", "Ascending"), Facet("true", "Descending")),
+        display_name="Order Direction",
     )
     ALL = (ORDER_BY, ORDER_REVERSE)
 
@@ -163,6 +168,7 @@ class RootFacetGroups:
             Facet("folders", "Folder View"),
             Facet("arcs", "Story Arc View"),
         ),
+        display_name="Views",
     )
     ALL = (TOP_GROUP,)
 

--- a/codex/views/opds/v1/facets.py
+++ b/codex/views/opds/v1/facets.py
@@ -90,7 +90,7 @@ class OPDS1FacetsView(CodexXMLTemplateMixin, OPDSBrowserView):
             href,
             MimeType.NAV,
             title=title,
-            facet_group=facet_group.query_param,
+            facet_group=facet_group.display_name,
             facet_active=facet_active,
         )
 

--- a/codex/views/opds/v1/feed.py
+++ b/codex/views/opds/v1/feed.py
@@ -200,14 +200,16 @@ class OPDS1FeedView(OPDS1LinksView):
     def entries(self) -> list:
         """Create all the entries."""
         entries = []
-        # if not self.use_facets:  # and self.kwargs.get("page") == 1:
-        facet_entries = not self.use_facets
         if self.IS_START_PAGE:
             entries += self.add_top_links(RootTopLinks.ALL)
         else:
             entries += self.add_start_link()
 
-        entries += self.facets(entries=facet_entries)
+        if not self.use_facets:
+            # Facet-blind clients get facets hacked in as fake nav folders.
+            # Facet-aware clients get real facet links from ``links`` instead,
+            # so adding them here too would render dead duplicate entries.
+            entries += self.facets(entries=True)
 
         if not self.IS_START_PAGE:
             entries += self._get_entries_section("groups", metadata=False)

--- a/tests/test_opds_user_agent.py
+++ b/tests/test_opds_user_agent.py
@@ -1,0 +1,182 @@
+"""
+OPDS v1 behavior that varies by client User-Agent.
+
+``UserAgentNames`` (``codex/views/opds/const.py``) switches how sort
+options reach a client: facet-aware readers get real ``opds:facetGroup``
+links, everyone else gets them hacked in as fake navigation folders.
+These pin both variants, the human-readable facet group names, and
+that the User-Agent itself parses to the client name Codex matches on.
+"""
+
+import xml.etree.ElementTree as ET
+from typing import Final
+
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from rest_framework.request import Request
+
+from codex.views.opds.user_agent import get_user_agent_name
+from tests.test_opds_feed import (
+    _HTTP_OK,
+    _V1_START,
+    _OPDSFixtureMixin,
+)
+
+# Panels sends a CFNetwork style UA; the name is the part before the
+# first slash. Panels 3.13+ (July 2026) renders OPDS facets natively.
+_PANELS_UA: Final = "Panels/950 CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
+_YAR_UA: Final = "yar/1.0"  # kybooks
+_FACET_UAS: Final = (_YAR_UA, _PANELS_UA)
+
+# A non-start feed: start pages emit the topCollection group instead of
+# the order groups.
+_FEED: Final = f"{_V1_START}publishers"
+
+_FACET_REL: Final = "http://opds-spec.org/facet"
+_ORDER_BY_ENTRY_TITLE: Final = "➠ Order By Date"
+_ORDER_REVERSE_ENTRY_TITLE: Final = "⇕ Order Ascending"
+# The internal query param names that used to leak into facetGroup.
+_QUERY_PARAM_NAMES: Final = frozenset({"orderBy", "orderReverse", "topCollection"})
+
+
+def _local_name(tag: str) -> str:
+    """Strip any XML namespace from a tag or attribute name."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _feed_links(content: bytes) -> list[ET.Element]:
+    """Every feed level ``<link>`` (entry links excluded)."""
+    root = ET.fromstring(content)  # noqa: S314 - server-rendered, trusted
+    return [el for el in root if _local_name(el.tag) == "link"]
+
+
+def _facet_groups(content: bytes) -> set[str]:
+    """
+    Every ``opds:facetGroup`` attribute value in the feed.
+
+    Matched by local name because the ``opds:`` namespace URI differs
+    between catalog and acquisition feeds.
+    """
+    root = ET.fromstring(content)  # noqa: S314 - server-rendered, trusted
+    return {
+        value
+        for el in root.iter()
+        for name, value in el.attrib.items()
+        if _local_name(name) == "facetGroup"
+    }
+
+
+def _entries(content: bytes) -> list[ET.Element]:
+    """Every ``<entry>`` element."""
+    root = ET.fromstring(content)  # noqa: S314 - server-rendered, trusted
+    return [el for el in root if _local_name(el.tag) == "entry"]
+
+
+def _entry_titles(content: bytes) -> list[str]:
+    """Collect the title text of every ``<entry>``."""
+    titles = []
+    for entry in _entries(content):
+        titles.extend(
+            (child.text or "").strip()
+            for child in entry
+            if _local_name(child.tag) == "title"
+        )
+    return titles
+
+
+class OPDSv1UserAgentTestCase(_OPDSFixtureMixin, TestCase):
+    """Facet emission varies by client User-Agent."""
+
+    def test_facet_ua_gets_facet_links_no_fake_entries(self) -> None:
+        """Facet-aware clients get real facet links and no fake folders."""
+        for user_agent in _FACET_UAS:
+            with self.subTest(user_agent=user_agent):
+                # Same URL and session cookie as the previous iteration:
+                # without this the cache would answer for the other UA.
+                cache.clear()
+                response = self.client.get(_FEED, headers={"user-agent": user_agent})
+                assert response.status_code == _HTTP_OK
+
+                facet_links = [
+                    link
+                    for link in _feed_links(response.content)
+                    if link.get("rel") == _FACET_REL
+                ]
+                assert facet_links, "no facet links for a facet-capable client"
+
+                titles = _entry_titles(response.content)
+                assert not [
+                    title
+                    for title in titles
+                    if "Order By" in title or "➠" in title or "⇕" in title
+                ], titles
+
+                # The old duplicate facet entries serialized to nothing:
+                # an empty <id> and no <link> children. Every real entry
+                # is navigable.
+                for entry in _entries(response.content):
+                    links = [el for el in entry if _local_name(el.tag) == "link"]
+                    assert links, ET.tostring(entry)
+
+    def test_default_ua_gets_fake_sort_entries_no_facet_links(self) -> None:
+        """Facet-blind clients still get sort options as nav folders."""
+        response = self.client.get(_FEED)
+        assert response.status_code == _HTTP_OK
+
+        assert not [
+            link
+            for link in _feed_links(response.content)
+            if link.get("rel") == _FACET_REL
+        ]
+        assert not _facet_groups(response.content)
+
+        titles = _entry_titles(response.content)
+        assert _ORDER_BY_ENTRY_TITLE in titles, titles
+        assert _ORDER_REVERSE_ENTRY_TITLE in titles, titles
+
+    def test_facet_group_display_names(self) -> None:
+        """Facet groups are display strings, not internal query params."""
+        cache.clear()
+        response = self.client.get(_FEED, headers={"user-agent": _YAR_UA})
+        assert response.status_code == _HTTP_OK
+        groups = _facet_groups(response.content)
+        assert groups == {"Order By", "Order Direction"}, groups
+        assert not groups & _QUERY_PARAM_NAMES
+
+        cache.clear()
+        response = self.client.get(_V1_START, headers={"user-agent": _YAR_UA})
+        assert response.status_code == _HTTP_OK
+        groups = _facet_groups(response.content)
+        assert groups == {"Views"}, groups
+        assert not groups & _QUERY_PARAM_NAMES
+
+        # The start page top links remain entries; the view facets do not.
+        titles = _entry_titles(response.content)
+        assert "⊙ Publishers View" not in titles, titles
+        assert "Publishers View" not in titles, titles
+
+
+def _user_agent_name(user_agent: str | None) -> str:
+    """Parse a raw header value the way a request would deliver it."""
+    headers = {} if user_agent is None else {"user-agent": user_agent}
+    return get_user_agent_name(Request(RequestFactory().get("/", headers=headers)))
+
+
+def test_get_user_agent_name_panels() -> None:
+    """Panels' CFNetwork UA parses to its client name."""
+    assert _user_agent_name(_PANELS_UA) == "Panels"
+
+
+def test_get_user_agent_name_kybooks() -> None:
+    """A simple name/version UA parses to the name."""
+    assert _user_agent_name(_YAR_UA) == "yar"
+
+
+def test_get_user_agent_name_missing() -> None:
+    """A missing User-Agent parses to the empty name."""
+    assert _user_agent_name(None) == ""
+
+
+def test_get_user_agent_name_no_version() -> None:
+    """A UA without a version is its own name."""
+    assert _user_agent_name("Weird") == "Weird"


### PR DESCRIPTION
Fixes #810.

Split out of the original combined PR: #811 (cache varies on User-Agent) and the OPDS v1 contributor fix are now separate PRs.

## Panels facet support

Panels on iOS added OPDS facet and sort support in 3.13.0, so it joins `UserAgentNames.FACET_SUPPORT`. Its CFNetwork style UA (`Panels/950 CFNetwork/… Darwin/…`) parses to `Panels` through `get_user_agent_name`, so the existing exact-name match works unchanged.

Two more fixes came out of testing that allowlist, both reported in the issue:

**Facet-capable clients received the facets twice.** The gate in the v1 feed `entries` property had been commented out, so `facets()` ran unconditionally and its `OPDS1Link` objects were appended to the *entries* list alongside the real facet links already emitted by `_links_facets`. `OPDS1TemplateEntrySerializer` drops every field those link objects don't have, so each one rendered as a dead `<entry>`: empty `<id>`, no `<link>` children, unclickable. The gate is restored, so the fake navigation folders are emitted only for clients that can't read facets.

**Facet group headings showed internal query parameter names.** `opds:facetGroup` carried `orderBy` / `orderReverse` / `topCollection`, which Panels displays verbatim as its filter menu headings. `FacetGroup` gains a `display_name` that is emitted instead, so headings read "Order By", "Order Direction" and "Views". The query param still drives hrefs and active-facet detection, and OPDS 1.2 groups facets by matching string within one feed, so existing clients are unaffected beyond the label.

`facet_group` also becomes a `CharField`. It was typed as `BrowseCollectionField`, a collection-name `ChoiceField` whose choices never included any value actually assigned to it; it only passed because the field is response-only.

## Tests

New `tests/test_opds_user_agent.py`, reusing the fixture from `test_opds_feed.py`. No test previously set a User-Agent at all, so none of this behavior was covered.

- Facet-capable UAs (`yar` and Panels) get facet links, no fake sort folders, and every entry has at least one link — the sharpest check on the dead-entry regression.
- Default UA still gets the fake sort folders and no facet links.
- `facetGroup` values are the display strings on both a feed page and the start page, and none of the query parameter names.
- `get_user_agent_name` parsing, including the Panels UA and the no-slash case.

Each test was verified to fail with its corresponding fix reverted and to pass with it applied; the Panels subtest fails on its own when only the allowlist entry is removed.

## Verification

- `./bin/lint-python.sh` — ruff check, ruff format, basedpyright, vulture, complexity, codespell all clean.
- `uv run --group test pytest tests/` — full suite passes.
- Frontend tests were not run; node dependencies aren't installed in this environment and no frontend code changed.

No version bump — NEWS bullets only, under a `## v2.2.9` heading. The sibling PRs add their own bullets under the same heading, so expect a trivial NEWS.md conflict that resolves by keeping both.