### PR TITLE
fix(opds): vary the response cache on User-Agent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ width: 128px;
 border-radius: 128px;
 " />
 
+## v2.2.9
+
+- Fixes
+    - OPDS responses are cached per client User-Agent. Clients that support
+      different features no longer receive each other's cached feeds for a
+      minute.
+
 ## v2.2.8
 
 - Fixes

--- a/codex/urls/opds/__init__.py
+++ b/codex/urls/opds/__init__.py
@@ -15,8 +15,19 @@ def opds_cached(view):
     across users / auth schemes (mirrors ``codex/urls/opds/binary.py``'s
     cover-route composition; sub-plan 01 #1).
 
+    Feed bodies also vary by client User-Agent: ``UserAgentNames``
+    switches facet emission (FACET_SUPPORT), download mime types
+    (SIMPLE_DOWNLOAD_MIME_TYPES), order facet suppression
+    (CLIENT_REORDERS) and absolute hrefs (REQUIRE_ABSOLUTE_URL). Without
+    User-Agent in the key, a facet-capable client and a facet-blind one
+    served the same URL within the timeout get each other's variant
+    (#811). Varying also tells intermediary caches the same.
+
     Used by ``v1.py``, ``v2.py``, and ``root.py``'s ``/opds/v2.0`` entry.
     Progression and binary routes are NOT wrapped — see their respective
-    modules for the rationale.
+    modules for the rationale. Covers don't vary by User-Agent, so the
+    binary routes keep the narrower Cookie/Authorization vary.
     """
-    return cache_page(OPDS_TIMEOUT)(vary_on_headers("Cookie", "Authorization")(view))
+    return cache_page(OPDS_TIMEOUT)(
+        vary_on_headers("Cookie", "Authorization", "User-Agent")(view)
+    )

--- a/tests/test_opds_cache.py
+++ b/tests/test_opds_cache.py
@@ -1,0 +1,55 @@
+"""
+OPDS response caching.
+
+``opds_cached`` wraps every feed route in ``cache_page``, but OPDS feed
+bodies depend on the client: ``UserAgentNames`` switches facet emission,
+download mime types and href absoluteness. These pin that the cache key
+and the ``Vary`` header both account for the User-Agent, so one client is
+never served a variant rendered for another.
+"""
+
+from typing import Final
+
+from django.test import TestCase
+
+from tests.test_opds_feed import (
+    _HTTP_OK,
+    _V1_START,
+    _OPDSFixtureMixin,
+)
+
+_YAR_UA: Final = "yar/1.0"  # kybooks, a facet capable client
+_FEED: Final = f"{_V1_START}publishers"
+
+# Only ever appears as the opds:facetGroup attribute name, so a plain
+# containment check is unambiguous. The internal param names it can
+# carry ("orderBy") also appear in facet hrefs, hence matching the
+# attribute name rather than its value.
+_FACET_MARKER: Final = b"facetGroup"
+
+
+class OPDSCacheTestCase(_OPDSFixtureMixin, TestCase):
+    """The OPDS response cache accounts for the client User-Agent."""
+
+    def test_feed_varies_on_user_agent(self) -> None:
+        """The Vary header lets caches key on the client."""
+        response = self.client.get(_FEED, headers={"user-agent": _YAR_UA})
+        assert response.status_code == _HTTP_OK
+        vary = {part.strip().lower() for part in response.headers["Vary"].split(",")}
+        assert "user-agent" in vary, response.headers["Vary"]
+
+    def test_cache_not_served_across_user_agents(self) -> None:
+        """A feed rendered for one client is never replayed to another."""
+        # A facet capable client primes the cache for this URL. The
+        # session cookie is shared with the request below, so a key
+        # blind to User-Agent matches both.
+        first = self.client.get(_FEED, headers={"user-agent": _YAR_UA})
+        assert first.status_code == _HTTP_OK
+        assert _FACET_MARKER in first.content
+
+        # Well inside OPDS_TIMEOUT, so a stale entry would still be
+        # live. This client can't read facets and must not get them.
+        second = self.client.get(_FEED)
+        assert second.status_code == _HTTP_OK
+        assert second.content != first.content
+        assert _FACET_MARKER not in second.content


### PR DESCRIPTION
Fixes #811.

Split out of the original combined PR alongside #812 (Panels facets) and the OPDS v1 contributor fix.

## The bug

`opds_cached` wraps every OPDS feed route in `cache_page` with `vary_on_headers("Cookie", "Authorization")`. Django's `cache_page` keys on the URL plus the values of headers named in the response's `Vary`, so two clients with the same session and different User-Agents hash to the same entry — and the second one gets whatever the first one's client was sent, until the entry expires.

The body genuinely depends on the User-Agent in four places:

| Site | Switches on |
|---|---|
| `v1/facets.py` `use_facets` | `FACET_SUPPORT` — real facets vs fake nav folders |
| `v1/facets.py` `mime_type_map` | `SIMPLE_DOWNLOAD_MIME_TYPES` — download mime types |
| `v1/facets.py` `facets()` | `CLIENT_REORDERS` — order facet suppression |
| `v2/href.py`, `v2/feed/links.py` | `REQUIRE_ABSOLUTE_URL` — absolute vs relative hrefs |

The last is dormant today (empty frozenset) but wired; the first three are live.

This became reachable when `OPDS_TIMEOUT` went from `0` to `60` — while it was `0`, `cache_page` was a no-op.

## The fix

Add `User-Agent` to the existing `vary_on_headers` call, which covers all eight wrapped v1 and v2 feed, start, manifest and opensearch routes through the one helper. `Vary` already includes `Cookie`, so per-session keys existed anyway and this barely fragments the cache further; it also corrects what intermediary caches are told.

Cover routes in `binary.py` keep the narrower `Cookie`/`Authorization` vary since covers don't depend on the client, and the static authentication document is left alone.

## Tests

New `tests/test_opds_cache.py`, reusing the fixture from `test_opds_feed.py`:

- `test_feed_varies_on_user_agent` — the response `Vary` header names User-Agent.
- `test_cache_not_served_across_user_agents` — a feed primed by a facet-capable client and then requested by a default client returns a different body without facets.

Both were verified to fail with the fix reverted. This PR is independent of #812: the assertions hold on `develop` with only this change, since a facet-capable client already received facet links before the #810 work.

## Verification

- `./bin/lint-python.sh` — ruff check, ruff format, basedpyright, vulture, complexity, codespell all clean.
- `uv run --group test pytest tests/test_opds_cache.py tests/test_opds_feed.py` — passes.
- Frontend tests were not run; node dependencies aren't installed in this environment and no frontend code changed.

No version bump — NEWS bullet only, under a `## v2.2.9` heading. The sibling PRs add their own bullets under the same heading, so expect a trivial NEWS.md conflict that resolves by keeping both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYYLr3w4xZJA1StYH2WwN)_