### PR TITLE
fix(opds): send v1 entry contributors, which were silently dropped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ width: 128px;
 border-radius: 128px;
 " />
 
+## v2.2.9
+
+- Fixes
+    - OPDS v1: comic credits that are not writing credits, like artists and
+      colorists, appear as contributors in metadata feeds. They had never been
+      sent.
+
 ## v2.2.8
 
 - Fixes

--- a/codex/serializers/opds/v1.py
+++ b/codex/serializers/opds/v1.py
@@ -54,7 +54,7 @@ class OPDS1TemplateEntrySerializer(Serializer):
     language = LanguageSerializer(read_only=True, required=False)
     summary = CharField(read_only=True, required=False)
     authors = OPDS1CreditSerializer(many=True, required=False, read_only=True)
-    credits = OPDS1CreditSerializer(many=True, required=False, read_only=True)
+    contributors = OPDS1CreditSerializer(many=True, required=False, read_only=True)
     category_groups = DictField(required=False, read_only=True)
 
 

--- a/tests/test_opds_contributors.py
+++ b/tests/test_opds_contributors.py
@@ -1,0 +1,90 @@
+"""
+OPDS v1 entry credit emission.
+
+Codex splits a comic's credits by role: people in ``AUTHOR_ROLES`` become
+Atom ``<author>`` elements, everyone else becomes ``<contributor>``.
+Both only appear on metadata feeds (``?opdsMetadata=1``), which is why
+the base feed fixtures never exercised them.
+"""
+
+import xml.etree.ElementTree as ET
+from typing import Final, override
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from codex.models import Comic, Credit, CreditPerson, CreditRole, Series
+from tests.test_opds_feed import (
+    _HTTP_OK,
+    _V1_START,
+    _OPDSFixtureMixin,
+)
+
+# "Writer" is in AUTHOR_ROLES, "Colorist" is not, so one person lands in
+# each bucket and the two elements can be told apart.
+_AUTHOR_NAME: Final = "Jane Writer"
+_CONTRIBUTOR_NAME: Final = "Cole Orist"
+
+
+def _local_name(tag: str) -> str:
+    """Strip any XML namespace from a tag."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _person_names(content: bytes, element: str) -> set[str]:
+    """Every ``<name>`` under the named person element in any entry."""
+    root = ET.fromstring(content)  # noqa: S314 - server-rendered, trusted
+    return {
+        (name.text or "").strip()
+        for el in root.iter()
+        if _local_name(el.tag) == element
+        for name in el
+        if _local_name(name.tag) == "name"
+    }
+
+
+class OPDSv1ContributorTestCase(_OPDSFixtureMixin, TestCase):
+    """Entry credits reach the feed, split by role."""
+
+    @override
+    def setUp(self) -> None:
+        """Give every comic one author-role and one other-role credit."""
+        super().setUp()
+        writer = Credit.objects.create(
+            person=CreditPerson.objects.create(name=_AUTHOR_NAME),
+            role=CreditRole.objects.create(name="Writer"),
+        )
+        colorist = Credit.objects.create(
+            person=CreditPerson.objects.create(name=_CONTRIBUTOR_NAME),
+            role=CreditRole.objects.create(name="Colorist"),
+        )
+        for comic in Comic.objects.all():
+            comic.credits.add(writer, colorist)
+        series = Series.objects.order_by("pk").first()
+        assert series
+        # An acquisition feed: the entries are comics, so they carry
+        # credits. Metadata is opt-in, and both credit properties
+        # short-circuit to [] without it.
+        self.feed = f"{_V1_START}series/{series.pk}?opdsMetadata=1"  # pyright: ignore[reportUninitializedInstanceVariable]
+        # Browser feeds go through cachalot; clear so the new rows surface.
+        cache.clear()
+
+    def test_authors_and_contributors_both_render(self) -> None:
+        """Author-role and other-role credits each reach their element."""
+        response = self.client.get(self.feed)
+        assert response.status_code == _HTTP_OK
+
+        # <author> has always worked: the serializer field, the entry
+        # property and the template all agree on the name. <contributor>
+        # is the regression -- the serializer called it "credits", which
+        # matches nothing on the entry, so DRF dropped it and the
+        # template's contributor loop silently iterated nothing.
+        assert _person_names(response.content, "author") == {_AUTHOR_NAME}
+        assert _person_names(response.content, "contributor") == {_CONTRIBUTOR_NAME}
+
+    def test_no_credits_without_metadata(self) -> None:
+        """Credits stay off feeds that didn't ask for metadata."""
+        response = self.client.get(self.feed.split("?")[0])
+        assert response.status_code == _HTTP_OK
+        assert not _person_names(response.content, "author")
+        assert not _person_names(response.content, "contributor")


### PR DESCRIPTION
Found while working on #810. Split out alongside #812 (Panels facets) and #813 (cache varies on User-Agent).

## The bug

Three layers name the same data differently, and one of them is the odd one out:

| Layer | Name |
|---|---|
| `OPDS1TemplateEntrySerializer` | `credits` |
| `OPDS1Entry` property | `contributors` |
| `opds_v1/index.xml` | `entry.contributors` |

The template renders **serialized** data — DRF's `TemplateHTMLRenderer.get_template_context` returns the serializer dict, and the view passes `serializer.data`. So:

- `credits` looks for an attribute the entry doesn't have. The field is `read_only` and not required, so `get_attribute` raises `SkipField` and the key is dropped with no error.
- `contributors` is never declared, so it's never serialized, and the template's `{% for cont in entry.contributors %}` iterates nothing.

Net effect: every comic credit outside `AUTHOR_ROLES` — artists, colorists, letterers, editors — has never appeared in an OPDS v1 feed. `<author>` was unaffected because all three layers agree on that name.

It stayed invisible because nothing errors: Django's template layer swallows the missing key, Atom permits `atomContributor*` (zero or more) inside an entry so the schema tests pass, and the credits only surface on `?opdsMetadata=1` requests at all.

## The fix

Rename the serializer field to `contributors`, matching the entry property and the template. One line — the payload shape was already correct, since `get_credit_people` and its batched variant return objects with `.name` and `.url`, exactly what `OPDS1CreditSerializer` expects.

## Tests

New `tests/test_opds_contributors.py`. The base feed fixture's comics are metadata-thin, so it seeds a `Writer` (in `AUTHOR_ROLES` → `<author>`) and a `Colorist` (not → `<contributor>`) and asserts each name lands in its own element on an acquisition feed with `?opdsMetadata=1`. A second test pins that credits stay off feeds that didn't request metadata.

The asymmetry matters here: with the rename reverted, the `<author>` assertion still passes and only the `<contributor>` one fails (`assert set() == {'Cole Orist'}`) — verified. A test that merely checked "some person element exists" would have passed on the broken code.

## Verification

- `./bin/lint-python.sh` — ruff check, ruff format, basedpyright, vulture, complexity, codespell all clean.
- `uv run --group test pytest tests/` — 858 passed.
- Frontend tests were not run; node dependencies aren't installed in this environment and no frontend code changed.

No version bump — NEWS bullet only, under a `## v2.2.9` heading. The sibling PRs add their own bullets under the same heading, so expect a trivial NEWS.md conflict that resolves by keeping both.

## Related, not fixed here

Commit `ec9e22f4` removed the feed-level `<author>`, and Atom's Schematron rule says an entry must have an author if its feed does not. Entries only carry `<author>` under `?opdsMetadata=1` with author-role credits, so plain feeds now satisfy neither. The RNC validator doesn't enforce Schematron assertions, so tests stay green. Worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYYLr3w4xZJA1StYH2WwN)_