### PR TITLE
fix(opds): gate Panels facet support on build number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,9 +15,11 @@ border-radius: 128px;
     - OPDS v1: comic credits that are not writing credits, like artists and
       colorists, appear as contributors in metadata feeds. They had never been
       sent.
-    - OPDS: Panels (iOS 3.13 and later) is recognized as a facet capable client
-      and receives real OPDS facets, which it shows in its native filter menu,
-      instead of sort options faked as navigation folders.
+    - OPDS: Panels iOS builds 952 and later (3.13+) are recognized as facet
+      capable clients and receive real OPDS facets, shown in the native filter
+      menu, instead of sort options faked as navigation folders. The macOS
+      build (951), which does not support facets, keeps the navigation folder
+      sort options.
     - OPDS v1: facet capable clients like kybooks no longer also receive a dead,
       unclickable duplicate entry for every facet alongside the real facet
       links.

--- a/codex/views/opds/auth.py
+++ b/codex/views/opds/auth.py
@@ -20,12 +20,22 @@ class OPDSAuthMixin(AuthMixin):
     )
     # Class-level default doubles as the unmemoized sentinel so
     # subclasses don't need to redeclare. Lazily resolved on first
-    # access via ``user_agent_name``.
-    _user_agent_name: str | None = None
+    # access via ``user_agent_name`` / ``user_agent_build``.
+    _user_agent_parts: tuple[str, int | None] | None = None
+
+    @property
+    def _user_agent(self) -> tuple[str, int | None]:
+        """Memoize the parsed user agent."""
+        if self._user_agent_parts is None:
+            self._user_agent_parts = get_user_agent_name(self.request)
+        return self._user_agent_parts
 
     @property
     def user_agent_name(self) -> str:
-        """Memoize user agent name."""
-        if self._user_agent_name is None:
-            self._user_agent_name = get_user_agent_name(self.request)
-        return self._user_agent_name
+        """User agent client name."""
+        return self._user_agent[0]
+
+    @property
+    def user_agent_build(self) -> int | None:
+        """User agent build number, for clients whose builds gate features."""
+        return self._user_agent[1]

--- a/codex/views/opds/const.py
+++ b/codex/views/opds/const.py
@@ -110,6 +110,9 @@ class UserAgentNames:
 
     CLIENT_REORDERS = frozenset({"Chunky"})
     FACET_SUPPORT = frozenset({"yar", "Panels"})  # kybooks, Panels iOS 3.13+
+    # Minimum build for facet support, for clients whose platforms diverge
+    # under one UA name. Panels iOS (952+) renders facets; macOS 951 doesn't.
+    FACET_SUPPORT_MIN_BUILD = MappingProxyType({"Panels": 952})
     SIMPLE_DOWNLOAD_MIME_TYPES = frozenset({"PocketBook Reader"})
     REQUIRE_ABSOLUTE_URL = frozenset()
 

--- a/codex/views/opds/feed.py
+++ b/codex/views/opds/feed.py
@@ -19,4 +19,4 @@ class OPDSBrowserView(OPDSBrowserSettingsMixin, UserActiveMixin, BrowserView):
     def __init__(self, *args, **kwargs) -> None:
         """Add User Agent Name."""
         super().__init__(*args, **kwargs)
-        self._user_agent_name = None
+        self._user_agent_parts = None

--- a/codex/views/opds/user_agent.py
+++ b/codex/views/opds/user_agent.py
@@ -1,14 +1,21 @@
 """OPDS Get User Agent."""
 
+from contextlib import suppress
+from typing import Final
+
 from rest_framework.request import Request
 
+# Clients whose feature support diverges by build under one UA name, so
+# the build number right after the slash gates features. Panels: iOS
+# builds (952+) render facets, the macOS build (951) does not.
+_BUILD_UA_NAMES: Final = frozenset({"Panels"})
 
-def get_user_agent_name(request: Request) -> str:
-    """Parse User Agent Name from Request."""
-    if (user_agent := request.headers.get("User-Agent")) and (
-        user_agent_parts := user_agent.split("/", 1)
-    ):
-        user_agent_name = user_agent_parts[0]
-    else:
-        user_agent_name = ""
-    return user_agent_name
+
+def get_user_agent_name(request: Request) -> tuple[str, int | None]:
+    """Parse User Agent name, and build number for clients that need it."""
+    build = None
+    name, _, rest = (request.headers.get("User-Agent") or "").partition("/")
+    if name in _BUILD_UA_NAMES and rest:
+        with suppress(ValueError):
+            build = int(rest.split(maxsplit=1)[0])
+    return name, build

--- a/codex/views/opds/v1/facets.py
+++ b/codex/views/opds/v1/facets.py
@@ -27,7 +27,7 @@ class OPDS1FacetsView(CodexXMLTemplateMixin, OPDSBrowserView):
     def __init__(self, *args, **kwargs) -> None:
         """Initialize properties."""
         super().__init__(*args, **kwargs)
-        self._user_agent_name: str | None = None
+        self._user_agent_parts: tuple[str, int | None] | None = None
         self._mime_type_map: MappingProxyType[str, str] | None = None
         self._use_facets: bool | None = None
         self._obj: MappingProxyType[str, Any] | None = None
@@ -47,7 +47,13 @@ class OPDS1FacetsView(CodexXMLTemplateMixin, OPDSBrowserView):
     def use_facets(self) -> bool:
         """Memoize use_facets."""
         if self._use_facets is None:
-            self._use_facets = self.user_agent_name in UserAgentNames.FACET_SUPPORT
+            name = self.user_agent_name
+            # A build the client didn't send or codex couldn't parse fails
+            # the floor: fake nav folder sort works on every client.
+            min_build = UserAgentNames.FACET_SUPPORT_MIN_BUILD.get(name, 0)
+            self._use_facets = name in UserAgentNames.FACET_SUPPORT and (
+                (self.user_agent_build or 0) >= min_build
+            )
         return self._use_facets
 
     @property

--- a/codex/views/opds/v2/feed/links.py
+++ b/codex/views/opds/v2/feed/links.py
@@ -35,7 +35,7 @@ class OPDS2LinksView(OPDS2HrefMixin, OPDSBrowserView):
         self._collection_and_books: (
             tuple[QuerySet, QuerySet, int, int, int | None, datetime | None, int] | None
         ) = None
-        self._user_agent_name: str | None = None
+        self._user_agent_parts: tuple[str, int | None] | None = None
 
     @property
     def collection_and_books(

--- a/tests/test_opds_user_agent.py
+++ b/tests/test_opds_user_agent.py
@@ -23,8 +23,10 @@ from tests.test_opds_feed import (
 )
 
 # Panels sends a CFNetwork style UA; the name is the part before the
-# first slash. Panels 3.13+ (July 2026) renders OPDS facets natively.
-_PANELS_UA: Final = "Panels/950 CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
+# first slash and the build number follows it. iOS builds (952+) render
+# OPDS facets natively; the macOS build (951) does not.
+_PANELS_UA: Final = "Panels/952 CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
+_PANELS_MACOS_UA: Final = "Panels/951 CFNetwork/3896.100.1.2.1 Darwin/25.0.0"
 _YAR_UA: Final = "yar/1.0"  # kybooks
 _FACET_UAS: Final = (_YAR_UA, _PANELS_UA)
 
@@ -134,6 +136,22 @@ class OPDSv1UserAgentTestCase(_OPDSFixtureMixin, TestCase):
         assert _ORDER_BY_ENTRY_TITLE in titles, titles
         assert _ORDER_REVERSE_ENTRY_TITLE in titles, titles
 
+    def test_facet_blind_panels_build_gets_fake_entries(self) -> None:
+        """Panels builds below the facet floor keep the nav folder sort."""
+        response = self.client.get(_FEED, headers={"user-agent": _PANELS_MACOS_UA})
+        assert response.status_code == _HTTP_OK
+
+        assert not [
+            link
+            for link in _feed_links(response.content)
+            if link.get("rel") == _FACET_REL
+        ]
+        assert not _facet_groups(response.content)
+
+        titles = _entry_titles(response.content)
+        assert _ORDER_BY_ENTRY_TITLE in titles, titles
+        assert _ORDER_REVERSE_ENTRY_TITLE in titles, titles
+
     def test_facet_group_display_names(self) -> None:
         """Facet groups are display strings, not internal query params."""
         cache.clear()
@@ -156,27 +174,34 @@ class OPDSv1UserAgentTestCase(_OPDSFixtureMixin, TestCase):
         assert "Publishers View" not in titles, titles
 
 
-def _user_agent_name(user_agent: str | None) -> str:
+def _user_agent(user_agent: str | None) -> tuple[str, int | None]:
     """Parse a raw header value the way a request would deliver it."""
     headers = {} if user_agent is None else {"user-agent": user_agent}
     return get_user_agent_name(Request(RequestFactory().get("/", headers=headers)))
 
 
 def test_get_user_agent_name_panels() -> None:
-    """Panels' CFNetwork UA parses to its client name."""
-    assert _user_agent_name(_PANELS_UA) == "Panels"
+    """Panels' CFNetwork UA parses to its client name and build."""
+    assert _user_agent(_PANELS_UA) == ("Panels", 952)
+    assert _user_agent(_PANELS_MACOS_UA) == ("Panels", 951)
+
+
+def test_get_user_agent_name_panels_unparseable_build() -> None:
+    """A Panels UA without a numeric build parses to no build."""
+    assert _user_agent("Panels/beta CFNetwork/1.0") == ("Panels", None)
+    assert _user_agent("Panels") == ("Panels", None)
 
 
 def test_get_user_agent_name_kybooks() -> None:
-    """A simple name/version UA parses to the name."""
-    assert _user_agent_name(_YAR_UA) == "yar"
+    """Only clients with build floors get a build parse."""
+    assert _user_agent(_YAR_UA) == ("yar", None)
 
 
 def test_get_user_agent_name_missing() -> None:
     """A missing User-Agent parses to the empty name."""
-    assert _user_agent_name(None) == ""
+    assert _user_agent(None) == ("", None)
 
 
 def test_get_user_agent_name_no_version() -> None:
     """A UA without a version is its own name."""
-    assert _user_agent_name("Weird") == "Weird"
+    assert _user_agent("Weird") == ("Weird", None)


### PR DESCRIPTION
Follow-up to #812 (#810): Panels' facet support is per platform, and the platforms share one UA name. The macOS build (951) does **not** render OPDS facets; iOS builds (952+) do. Matching `FACET_SUPPORT` on the name alone left macOS Panels in the worst state of all — facet links it can't render *and* no fake nav folders, i.e. no sort UI at all.

## The change

**`get_user_agent_name` returns a `(name, build)` pair.** The build number is parsed from the token right after the first slash (`Panels/951 …` → 951), only for clients listed in a new `_BUILD_UA_NAMES` constant — Panels only today. An unparseable or absent build is `None`. Name parsing is unchanged for everyone.

**The auth mixin memoizes the pair** and exposes it as `user_agent_name` and `user_agent_build`, so the five existing name consumers are untouched.

**`use_facets` gains a build floor.** `UserAgentNames.FACET_SUPPORT_MIN_BUILD = {"Panels": 952}`; facet emission now requires name membership *and* build ≥ floor. A missing or unparseable build fails the floor, falling back to the fake nav folder sort that works on every client. kybooks has no floor and is unaffected. The threshold is a data map rather than logic, so the next client with a platform-split UA is one constant line.

**No cache change needed:** #813 already varies the response cache on the full User-Agent header, so builds 951 and 952 key separately.

## Tests

- The iOS test constant moves to build 952 (it was 950, which the new gate correctly refuses — the old constant would have failed the suite, which is itself a sign the gate bites).
- New `test_facet_blind_panels_build_gets_fake_entries`: build 951 gets no facet links, no `facetGroup`, and keeps the "➠ Order By Date" nav folders. Verified to fail against the name-only gate while the 952 tests still pass — the exact shape of the bug.
- Parse unit tests cover the pair: `("Panels", 952)`, `("Panels", 951)`, unparseable build → `("Panels", None)`, no-slash `("Panels", None)`, `("yar", None)` (no build parse for non-Panels), missing header `("", None)`.

## Verification

- `./bin/lint-python.sh` — ruff check, ruff format, basedpyright, vulture, complexity, codespell all clean.
- `uv run --group test pytest tests/` — 869 passed.
- CI skips `claude/*` branches targeting `develop`, so local lint + pytest is the verification, as with the previous three PRs.
- Frontend untouched.

No version bump — the existing v2.2.9 Panels NEWS bullet is amended in place (v2.2.9 is still unreleased) to say builds 952+ get facets and the macOS build keeps the nav folder sort.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYYLr3w4xZJA1StYH2WwN)_