### PR TITLE
fix(opds): denylist facet-blind Panels builds instead of a build floor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,11 +15,11 @@ border-radius: 128px;
     - OPDS v1: comic credits that are not writing credits, like artists and
       colorists, appear as contributors in metadata feeds. They had never been
       sent.
-    - OPDS: Panels iOS builds 952 and later (3.13+) are recognized as facet
-      capable clients and receive real OPDS facets, shown in the native filter
-      menu, instead of sort options faked as navigation folders. The macOS
-      build (951), which does not support facets, keeps the navigation folder
-      sort options.
+    - OPDS: Panels on iOS (3.13 and later) is recognized as a facet capable
+      client and receives real OPDS facets, shown in the native filter menu,
+      instead of sort options faked as navigation folders. The macOS build
+      (951), which does not support facets, keeps the navigation folder sort
+      options.
     - OPDS v1: facet capable clients like kybooks no longer also receive a dead,
       unclickable duplicate entry for every facet alongside the real facet
       links.

--- a/codex/views/opds/const.py
+++ b/codex/views/opds/const.py
@@ -110,9 +110,12 @@ class UserAgentNames:
 
     CLIENT_REORDERS = frozenset({"Chunky"})
     FACET_SUPPORT = frozenset({"yar", "Panels"})  # kybooks, Panels iOS 3.13+
-    # Minimum build for facet support, for clients whose platforms diverge
-    # under one UA name. Panels iOS (952+) renders facets; macOS 951 doesn't.
-    FACET_SUPPORT_MIN_BUILD = MappingProxyType({"Panels": 952})
+    # Known facet-blind builds, for clients whose platforms diverge under
+    # one UA name. Build numbers interleave across platforms (iOS 942 and
+    # 950 render facets, macOS 951 doesn't), so a minimum-build floor
+    # can't separate them: refuse the known-blind builds instead and let
+    # every other build - unknown ones included - have facets.
+    FACET_BLIND_BUILDS = MappingProxyType({"Panels": frozenset({951})})
     SIMPLE_DOWNLOAD_MIME_TYPES = frozenset({"PocketBook Reader"})
     REQUIRE_ABSOLUTE_URL = frozenset()
 

--- a/codex/views/opds/user_agent.py
+++ b/codex/views/opds/user_agent.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 
 # Clients whose feature support diverges by build under one UA name, so
 # the build number right after the slash gates features. Panels: iOS
-# builds (952+) render facets, the macOS build (951) does not.
+# builds render facets, the macOS build (951) does not.
 _BUILD_UA_NAMES: Final = frozenset({"Panels"})
 
 

--- a/codex/views/opds/v1/facets.py
+++ b/codex/views/opds/v1/facets.py
@@ -49,11 +49,10 @@ class OPDS1FacetsView(CodexXMLTemplateMixin, OPDSBrowserView):
         """Memoize use_facets."""
         if self._use_facets is None:
             name = self.user_agent_name
-            # A build the client didn't send or codex couldn't parse fails
-            # the floor: fake nav folder sort works on every client.
-            min_build = UserAgentNames.FACET_SUPPORT_MIN_BUILD.get(name, 0)
-            self._use_facets = name in UserAgentNames.FACET_SUPPORT and (
-                (self.user_agent_build or 0) >= min_build
+            blind_builds = UserAgentNames.FACET_BLIND_BUILDS.get(name, frozenset())
+            self._use_facets = (
+                name in UserAgentNames.FACET_SUPPORT
+                and self.user_agent_build not in blind_builds
             )
         return self._use_facets
 

--- a/tests/test_opds_user_agent.py
+++ b/tests/test_opds_user_agent.py
@@ -23,12 +23,16 @@ from tests.test_opds_feed import (
 )
 
 # Panels sends a CFNetwork style UA; the name is the part before the
-# first slash and the build number follows it. iOS builds (952+) render
-# OPDS facets natively; the macOS build (951) does not.
-_PANELS_UA: Final = "Panels/952 CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
+# first slash and the build number follows it. Build numbers interleave
+# across platforms: iOS builds like 942 and 950 render OPDS facets
+# natively, the macOS build (951) does not, so known facet-blind builds
+# are denylisted and every other build gets facets.
+_PANELS_UA: Final = "Panels/942 CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
 _PANELS_MACOS_UA: Final = "Panels/951 CFNetwork/3896.100.1.2.1 Darwin/25.0.0"
+# An unlisted build must default to facets, the pre-gate behavior.
+_PANELS_ODD_UA: Final = "Panels/beta CFNetwork/3896.100.1.2.1 Darwin/27.0.0"
 _YAR_UA: Final = "yar/1.0"  # kybooks
-_FACET_UAS: Final = (_YAR_UA, _PANELS_UA)
+_FACET_UAS: Final = (_YAR_UA, _PANELS_UA, _PANELS_ODD_UA)
 
 # A non-start feed: start pages emit the topCollection group instead of
 # the order groups.
@@ -182,7 +186,7 @@ def _user_agent(user_agent: str | None) -> tuple[str, int | None]:
 
 def test_get_user_agent_name_panels() -> None:
     """Panels' CFNetwork UA parses to its client name and build."""
-    assert _user_agent(_PANELS_UA) == ("Panels", 952)
+    assert _user_agent(_PANELS_UA) == ("Panels", 942)
     assert _user_agent(_PANELS_MACOS_UA) == ("Panels", 951)
 
 


### PR DESCRIPTION
Fixes a wrong premise in #815: Panels build numbers interleave across platforms, so a minimum-build floor can't separate facet-capable builds from facet-blind ones.

## The field data

| Build | Platform | Facets? |
|---|---|---|
| 942 | iOS (reported in the field, `name='Panels' build=942`) | ✅ |
| 950 | iOS (issue #810's reporter, 3.13.3) | ✅ |
| 951 | macOS | ❌ |

Real iOS builds run *lower* than the macOS build, so the `build >= 952` floor shut real iOS users out of facets and handed them the fake nav folder sort instead — the exact regression reported after #815 merged.

## The change

`FACET_SUPPORT_MIN_BUILD` becomes `FACET_BLIND_BUILDS`, a per-client frozenset of known facet-blind builds (`Panels: {951}`). `use_facets` refuses only those builds; every other build — unknown and unparseable ones included — gets facets, which is the pre-gate behavior that worked on iOS.

Trade-off: a future facet-blind macOS build must be added to the set as discovered. Until then it receives facets it ignores — the pre-#815 status quo, and the safer direction than shutting out unknown iOS builds. The build parsing from #815 (`get_user_agent_name` returning `(name, build)`) is unchanged.

## Tests

- The iOS constant moves to the field-reported build 942.
- An unparseable-build UA (`Panels/beta …`) joins the facet-capable cases, pinning facets-by-default for unknown builds.
- The macOS 951 test still asserts the nav folder fallback and no facet links.
- Verified: the 942 and unparseable-build cases fail under the old floor gate and pass under the denylist; the 951 case passes under both.

## Verification

- `./bin/lint-python.sh` — all clean.
- `uv run --group test pytest tests/` — 869 passed.
- CI skips `claude/*` branches targeting `develop`; local lint + pytest is the verification, as with the previous PRs.

No version bump — the v2.2.9 Panels NEWS bullet is amended in place to drop the build-number claim (iOS gets facets, the macOS build keeps the nav folder sort).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYYLr3w4xZJA1StYH2WwN)_