### PR TITLE
docs(news): compact and correct the v2.2.11 fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,36 +18,31 @@ border-radius: 128px;
     - Redesigned the Admin Tagging Status table to be more informative.
 
 - Fixes
-    - Tag writes rename each comic before writing it, and the database follows
-      the file immediately. Bookmarks and read progress now survive a rename or
-      a CBR conversion even when a library scan lands in the middle of one.
-    - Editing a comic's tags twice in a row no longer fails the second edit with
-      a "no such file" error when renaming is on.
-    - A watched library on a network share or removable volume that goes missing
-      no longer has all its comics deleted. Polling already refused to scan in
-      that state; watching now refuses to act on it too.
-    - Comics are never deleted from the database while their files are still on
-      disk, so a misread filesystem event can no longer take a comic's bookmarks
-      and read progress with it.
-    - A comic replaced in place, by a tool that removes and rewrites the file,
-      is re-read instead of deleted and re-added as a new comic.
-    - Deleting a folder refreshes the series and publishers it emptied, which
-      kept listing comics that were gone.
-    - Renaming follows a comic to its new path. Tagging a CBR converts it to CBZ
-      without the rename failing, and a watched library no longer mistakes an
-      unrelated new file for a renamed comic.
-    - Comics keep their bookmarks and read progress through renames, conversions
-      and long tag write batches. PDFs lost them every time, other formats
-      occasionally.
-    - Deleting or renaming a watched folder no longer deletes comics from
-      sibling folders whose names begin the same way, like "Batman" and "Batman
-      Beyond".
+    - Bookmarks and read progress survive tag writes. Comics are renamed before
+      they are written and the database moves with the file, so a rename, a CBR
+      conversion, or a library scan landing mid-batch can no longer lose them.
+      PDFs lost them every time before; other formats occasionally.
+    - Comics are no longer deleted while their files are still on disk. One
+      replaced in place, by a tool that removes and rewrites it, is re-read
+      instead of deleted and re-added as a new comic.
+    - A library that has gone missing, like an unmounted share or volume, no
+      longer has all of its comics deleted.
+    - Paths that merely begin the same way are no longer confused for one
+      another: deleting the folder "Batman" leaves "Batman Beyond" alone, and
+      libraries at /comics and /comics-kids no longer claim each other's
+      changes.
     - Renaming keeps each archive's own file extension. PDFs and unconverted
       CBRs were renamed to .cbz names.
-    - Libraries with paths like /comics and /comics-kids no longer claim each
-      other's file changes.
+    - Two comics that would end up with the same filename no longer overwrite
+      each other; the second is reported instead.
+    - Editing a comic's tags twice in a row no longer fails the second time with
+      a "no such file" error.
+    - Online tagging only offers Resume when a scan can actually resume, and
+      reports a failed pause or resume instead of silently doing nothing.
     - A second online tagging scan no longer re-queues comics the running scan
       already has.
+    - Deleting a folder refreshes the series and publishers it emptied, which
+      kept listing comics that were gone.
     - The librarian shuts down cleanly with work queued, and tasks queued in the
       same instant no longer collide and lose one.
 


### PR DESCRIPTION
The v2.2.11 fixes accumulated an entry per landing rather than per behavior. This makes the section describe what shipped, and fixes two omissions.

## Merged

- **Three items said the same thing.** "Renaming follows a comic to its new path", "Comics keep their bookmarks… through renames, conversions and long tag write batches", and the rename-first entry were three views of one guarantee, written as the work landed in stages. Now one item describing the behavior rather than the route to it.
- **Two path-prefix items** — sibling folders (`Batman` / `Batman Beyond`) and sibling libraries (`/comics` / `/comics-kids`) — are the same mistake in two places, so they read as one.
- **Two delete items** — a file still on disk, and a file replaced in place — are both "codex no longer deletes a comic that is still there", so they share an item.

## Added (these were missing)

- **The online-tag Resume button** (`99c92c586`) only offers itself when a scan can actually resume, and reports a failed pause or resume instead of silently doing nothing. It previously answered 400 and swallowed the error.
- **Two comics that would take the same filename** no longer overwrite each other. Codex refuses the second rename and reports it, and comicbox 4.8.6 (pinned in this version) refuses the second conversion with both originals intact — previously one archive's contents were lost.

## Checked

Every remaining item was verified against what is actually on develop, and the Features section was left alone. `fix(tagging): keep the source column headers on one line` is deliberately not its own entry — it is polish within the redesigned status table already listed under Features.

Thirteen items to eleven, each shorter, ordered by what costs the user most: lost data, then wrong output, then errors, then staleness.