### PR TITLE
Stop leaking a DB connection per ASGI request, and pool the workers that hold them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,8 @@ border-radius: 128px;
     - Covers are cached by the browser and revalidated instead of re-sent, so
       revisiting a page does not download them again. They also survive a scan,
       which used to discard every cached cover whether or not it had changed.
+    - Every web request leaked a database connection, and its open files, until
+      garbage collection.
 
 - Dev
     - Comicbox 5.0.0, and its metadata schema v3.0.

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,10 +65,16 @@ border-radius: 128px;
     - Every web request leaked a database connection, and its open files, until
       garbage collection.
 
+- Performance
+    - Web requests share a pool of database connections instead of opening one
+      each. `db_workers` under `[server]` sizes it, or turns it off with 0.
+
 - Dev
     - Comicbox 5.0.0, and its metadata schema v3.0.
     - Simyan, mokkari and requests-cache are declared directly rather than
       relied on through comicbox.
+    - Asgiref is declared directly; the connection pool uses its executor
+      registry.
 
 ## v2.2.11
 

--- a/codex/applications/http.py
+++ b/codex/applications/http.py
@@ -1,0 +1,63 @@
+"""
+HTTP ASGI application.
+
+Wraps Django's ASGI handler so every request releases its database
+connections before the thread that opened them is destroyed.
+"""
+
+from asgiref.sync import ThreadSensitiveContext, sync_to_async
+from django.core.asgi import get_asgi_application
+from django.db import connections
+
+
+class ConnectionClosingApplication:
+    """
+    Close what Django's own end-of-request hook cannot reach.
+
+    Django's ``ASGIHandler`` runs each request's synchronous ORM work in
+    a ``ThreadSensitiveContext``, which asgiref backs with a *private*
+    ``ThreadPoolExecutor(max_workers=1)`` that is shut down when the
+    request ends. ``django.db.connections`` is thread-local, so a
+    connection left open when that thread is retired is orphaned until
+    the garbage collector emits ``ResourceWarning: unclosed database``.
+
+    With ``CONN_MAX_AGE=0`` (see ``codex.settings``) Django closes the
+    connection itself on the paths it controls: ``handle()`` awaits
+    ``sync_to_async(response.close)()`` — or, when the client
+    disconnected, ``request_finished.asend()`` — and both dispatch
+    ``close_old_connections`` onto the request's own worker. On those
+    paths the ``finally`` below is a no-op costing one thread hop.
+
+    It exists for the exit Django has no hook on. ``send_response``
+    runs inside ``handle()``'s ``TaskGroup``; if it raises anything
+    other than ``RequestProcessed``/``RequestAborted`` the exception
+    group is re-raised before either close runs. A streaming response's
+    body is consumed *there*, outside the middleware chain, so an
+    iterator that raises is never converted to a 500 — and codex streams
+    comic archives straight off a user's library, where the librarian
+    can move or truncate a file mid-download. The ASGI ``send``
+    callable raising a transport error lands the same way.
+
+    Entering ``ThreadSensitiveContext`` here rather than letting
+    ``ASGIHandler`` open its own is what makes that cleanup reachable.
+    The context manager is re-entrant and only the outermost block owns
+    the executor, so Django's inner ``async with`` becomes a no-op and
+    the worker thread outlives the request just long enough for the
+    ``sync_to_async`` below — thread sensitive, so it lands on that same
+    worker — to close what the request opened.
+    """
+
+    def __init__(self, application) -> None:
+        """Wrap the Django ASGI application."""
+        self.application = application
+
+    async def __call__(self, scope, receive, send) -> None:
+        """Serve one request, then release its database connections."""
+        async with ThreadSensitiveContext():
+            try:
+                await self.application(scope, receive, send)
+            finally:
+                await sync_to_async(connections.close_all)()
+
+
+HTTP_APPLICATION = ConnectionClosingApplication(get_asgi_application())

--- a/codex/applications/http.py
+++ b/codex/applications/http.py
@@ -1,13 +1,19 @@
 """
 HTTP ASGI application.
 
-Wraps Django's ASGI handler so every request releases its database
-connections before the thread that opened them is destroyed.
+Serves requests on pooled workers that keep a warm database connection,
+falling back to a per-request thread whose connections are released
+before it is destroyed.
 """
+
+from functools import cache
 
 from asgiref.sync import ThreadSensitiveContext, sync_to_async
 from django.core.asgi import get_asgi_application
 from django.db import connections
+from django.urls import Resolver404, resolve
+
+from codex.applications.workers import WORKER_POOL
 
 
 class ConnectionClosingApplication:
@@ -28,7 +34,12 @@ class ConnectionClosingApplication:
     ``close_old_connections`` onto the request's own worker. On those
     paths the ``finally`` below is a no-op costing one thread hop.
 
-    It exists for the exit Django has no hook on. ``send_response``
+    When the worker pool is running this process opts into persistent
+    connections, and a bypassed request is back on a throwaway thread —
+    so for those the ``finally`` closes the connection on every path,
+    not just the abnormal one.
+
+    It also covers the exit Django has no hook on. ``send_response``
     runs inside ``handle()``'s ``TaskGroup``; if it raises anything
     other than ``RequestProcessed``/``RequestAborted`` the exception
     group is re-raised before either close runs. A streaming response's
@@ -60,4 +71,73 @@ class ConnectionClosingApplication:
                 await sync_to_async(connections.close_all)()
 
 
-HTTP_APPLICATION = ConnectionClosingApplication(get_asgi_application())
+@cache
+def _bypass_views() -> tuple[frozenset, tuple[type, ...]]:
+    """
+    Return the views that must not hold a pooled worker.
+
+    Imported on first use, not at module scope: this module is imported
+    to build the ASGI application, which is what calls ``django.setup``.
+    """
+    from codex.views.browser.download import CollectionDownloadView
+    from codex.views.download import DownloadView
+    from codex.views.healthcheck import health_check_view
+
+    return frozenset({health_check_view}), (DownloadView, CollectionDownloadView)
+
+
+def _is_bypassed(scope) -> bool:
+    """
+    Decide whether a request should skip the worker pool.
+
+    A pooled request holds its worker until its response is sent, so a
+    file download would hold one for as long as the client takes to
+    receive it. The health check is exempt for the opposite reason:
+    it touches no database at all, and a container's health must not
+    depend on the pool having a free worker.
+    """
+    path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :]
+    if not path.startswith("/"):
+        path = "/" + path
+    try:
+        match = resolve(path)
+    except Resolver404:
+        # Django will answer this with a 404. Pool it like anything else.
+        return False
+    views, view_classes = _bypass_views()
+    if match.func in views:
+        return True
+    view_class = getattr(match.func, "view_class", None)
+    return view_class is not None and issubclass(view_class, view_classes)
+
+
+class PooledApplication:
+    """
+    Serve requests on a pooled worker when there is one to lend.
+
+    Pooled requests skip ``ConnectionClosingApplication`` deliberately:
+    their worker outlives them, so the connection it holds is meant to
+    be reused by the next request rather than closed. Django's own
+    ``close_old_connections`` still recycles it on age or error, exactly
+    as it does for a WSGI worker thread.
+    """
+
+    def __init__(self, application, pool) -> None:
+        """Wrap the Django ASGI application and bind the worker pool."""
+        self.application = application
+        self.pool = pool
+        self.unpooled = ConnectionClosingApplication(application)
+
+    async def __call__(self, scope, receive, send) -> None:
+        """Serve one request, pooled if the pool has a worker for it."""
+        if self.pool.enabled and not _is_bypassed(scope):
+            async with self.pool.acquire():
+                await self.application(scope, receive, send)
+        else:
+            await self.unpooled(scope, receive, send)
+
+
+HTTP_APPLICATION = PooledApplication(get_asgi_application(), WORKER_POOL)

--- a/codex/applications/lifespan.py
+++ b/codex/applications/lifespan.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 
 from loguru import logger
 
+from codex.applications.workers import WORKER_POOL
 from codex.signals.os_signals import bind_signals_to_loop
 from codex.startup.loguru import loguru_init
 from codex.websockets.listener import BroadcastListener
@@ -38,12 +39,16 @@ class LifespanApplication:
     async def _startup(self) -> None:
         """Startup tasks."""
         bind_signals_to_loop()
+        await WORKER_POOL.start()
         self.broadcast_listener_task = asyncio.create_task(
             self.broadcast_listener.listen()
         )
 
     async def _shutdown(self) -> None:
         """Shutdown tasks."""
+        # First: in-flight requests still hold pooled workers, and the
+        # connections on them have to be closed from those threads.
+        await WORKER_POOL.stop()
         with suppress(ValueError):
             # Depending on timing this can be closed already
             self.broadcast_queue.put(None)

--- a/codex/applications/workers.py
+++ b/codex/applications/workers.py
@@ -1,0 +1,249 @@
+"""
+A fixed pool of long-lived thread-sensitive workers for HTTP requests.
+
+Django's ``ASGIHandler`` enters an asgiref ``ThreadSensitiveContext`` per
+request, and asgiref backs each context with a private one-thread
+executor it shuts down when the context exits. Every request therefore
+gets a brand new thread, and since ``django.db.connections`` is
+thread-local, a brand new database connection — which is why Django
+documents that persistent connections do not work under ASGI.
+
+This pool owns a fixed number of contexts that are *never* entered,
+pre-seeds each with its own one-thread executor, and lends one to each
+request. The worker thread, and the connection it holds, outlive the
+request, which restores the stable-thread model ``CONN_MAX_AGE`` was
+written for. Django's own ``request_started`` / ``request_finished``
+hygiene then recycles those connections exactly as it does under WSGI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Final
+
+from asgiref.sync import SyncToAsync, ThreadSensitiveContext, sync_to_async
+from django.db import connections
+from loguru import logger
+
+from codex.librarian.db import enable_persistent_connections
+from codex.settings import DB_WORKERS
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Iterable
+
+_THREAD_NAME_PREFIX: Final[str] = "codex-http-db"
+# Seconds to wait for the pooled worker to answer the startup self-check.
+_SELF_CHECK_TIMEOUT: Final[float] = 5.0
+
+
+class WorkerPool:
+    """A fixed set of pooled ``ThreadSensitiveContext`` workers."""
+
+    # Seconds to wait at shutdown for in-flight requests to hand back
+    # their worker before closing connections out from under them.
+    STOP_TIMEOUT: Final[float] = 10.0
+
+    def __init__(self, size: int) -> None:
+        """Size the pool. Nothing is created until ``start``."""
+        self.size = max(0, int(size))
+        self.enabled = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._free: asyncio.LifoQueue[ThreadSensitiveContext] | None = None
+        self._contexts: tuple[ThreadSensitiveContext, ...] = ()
+        self._executors: dict[ThreadSensitiveContext, ThreadPoolExecutor] = {}
+
+    async def _run_on(self, context: ThreadSensitiveContext, func: Callable) -> None:
+        """Run ``func`` on ``context``'s worker thread."""
+        token = SyncToAsync.thread_sensitive_context.set(context)
+        try:
+            await sync_to_async(func)()
+        finally:
+            SyncToAsync.thread_sensitive_context.reset(token)
+
+    async def _self_check(self) -> bool:
+        """
+        Prove asgiref still routes onto the thread we seeded.
+
+        The pool reaches into two of asgiref's class attributes to
+        install a context the way asgiref would have installed it
+        lazily. They have been stable for years but are not part of a
+        documented contract, so rather than trust them, check them: run
+        the exact shape a request will (Django's own inner
+        ``ThreadSensitiveContext``, two thread-sensitive calls) and
+        confirm both land on the seeded worker. A failure here disables
+        the pool rather than silently serving requests on the wrong
+        thread.
+        """
+        context = self._contexts[0]
+        try:
+            expected = (
+                self._executors[context]
+                .submit(threading.get_ident)
+                .result(_SELF_CHECK_TIMEOUT)
+            )
+            token = SyncToAsync.thread_sensitive_context.set(context)
+            try:
+                async with ThreadSensitiveContext():
+                    first = await sync_to_async(threading.get_ident)()
+                    second = await sync_to_async(threading.get_ident)()
+            finally:
+                SyncToAsync.thread_sensitive_context.reset(token)
+        except Exception:
+            logger.exception("HTTP database worker pool self-check failed")
+            return False
+        return (
+            first == expected
+            and second == expected
+            and context in SyncToAsync.context_to_thread_executor
+        )
+
+    async def start(self) -> None:
+        """Create the workers on the running loop. Idempotent per loop."""
+        loop = asyncio.get_running_loop()
+        if self._free is not None:
+            if self._loop is loop:
+                return
+            # A previous loop owned it. Only reachable under tests.
+            await self.stop()
+        if not self.size:
+            logger.debug("HTTP database worker pool disabled.")
+            return
+        contexts = []
+        for index in range(self.size):
+            context = ThreadSensitiveContext()
+            executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix=f"{_THREAD_NAME_PREFIX}-{index}"
+            )
+            # The write asgiref would make lazily on the first
+            # thread-sensitive call inside this context. Making it here
+            # is what pins the context to a thread we own and can join.
+            SyncToAsync.context_to_thread_executor[context] = executor
+            self._executors[context] = executor
+            contexts.append(context)
+        self._contexts = tuple(contexts)
+        if not await self._self_check():
+            logger.warning(
+                "asgiref no longer routes thread-sensitive work onto pooled"
+                " workers. Serving requests on per-request threads instead."
+            )
+            await self._retire(self._contexts)
+            self._reset()
+            return
+        # Safe only now that requests land on threads that outlive them.
+        enable_persistent_connections()
+        self._loop = loop
+        free: asyncio.LifoQueue[ThreadSensitiveContext] = asyncio.LifoQueue()
+        for context in self._contexts:
+            free.put_nowait(context)
+        self._free = free
+        self.enabled = True
+        logger.debug(f"HTTP database worker pool started with {self.size} workers.")
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncGenerator[None]:
+        """
+        Lend a worker to one request for its whole duration.
+
+        Waiting for a free worker happens on the event loop and costs no
+        thread. Holding the worker across the whole request — not just
+        its ORM calls — is what bounds concurrency: a request keeps its
+        database connection, and its share of the page cache, from its
+        first query until its response is sent.
+        """
+        free = self._free
+        if free is None:
+            msg = "Worker pool is not started."
+            raise RuntimeError(msg)
+        context = await free.get()
+        token = SyncToAsync.thread_sensitive_context.set(context)
+        try:
+            yield
+        finally:
+            SyncToAsync.thread_sensitive_context.reset(token)
+            # Hand the worker back to the queue it came from, which may
+            # no longer be the pool's: a request that outlasts
+            # ``STOP_TIMEOUT`` returns its worker after shutdown has
+            # already stopped waiting for it.
+            free.put_nowait(context)
+
+    async def _retire(
+        self,
+        idle: Iterable[ThreadSensitiveContext],
+        busy: Iterable[ThreadSensitiveContext] = (),
+    ) -> None:
+        """Close each worker's connections, then join its thread."""
+        for context in idle:
+            await self._run_on(context, connections.close_all)
+        for context in busy:
+            # A one-thread executor runs this after the in-flight
+            # request finishes with the worker.
+            self._executors[context].submit(connections.close_all)
+        for context in self._contexts:
+            SyncToAsync.context_to_thread_executor.pop(context, None)
+        await _join(tuple(self._executors.values()))
+
+    async def stop(self) -> None:
+        """Take the pool out of service and release its workers."""
+        if self._free is None:
+            return
+        self.enabled = False
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.STOP_TIMEOUT
+        idle: list[ThreadSensitiveContext] = []
+        while len(idle) < len(self._contexts):
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                idle.append(await asyncio.wait_for(self._free.get(), remaining))
+            except TimeoutError:
+                break
+        busy = [context for context in self._contexts if context not in idle]
+        if busy:
+            logger.warning(
+                f"{len(busy)} HTTP database worker(s) still busy at shutdown."
+            )
+        await self._retire(idle, busy)
+        self._reset()
+        logger.debug("HTTP database worker pool stopped.")
+
+    def _reset(self) -> None:
+        """Drop every reference to the retired workers."""
+        self.enabled = False
+        self._loop = None
+        self._free = None
+        self._contexts = ()
+        self._executors = {}
+
+
+async def _join(executors: tuple[ThreadPoolExecutor, ...]) -> None:
+    """
+    Join worker threads without blocking the event loop.
+
+    A worker may itself be parked waiting on this loop, so a blocking
+    ``shutdown()`` here would deadlock it — the same hazard asgiref
+    handles in ``ThreadSensitiveContext.__aexit__``. The loop's default
+    executor is no good either: work queued there may be what unparks
+    the worker. So join in a thread of our own.
+    """
+    if not executors:
+        return
+    done: Future[None] = Future()
+
+    def join() -> None:
+        try:
+            for executor in executors:
+                executor.shutdown()
+        except Exception as exc:  # pragma: no cover - defensive
+            done.set_exception(exc)
+        else:
+            done.set_result(None)
+
+    threading.Thread(target=join, daemon=True).start()
+    await asyncio.wrap_future(done)
+
+
+WORKER_POOL: Final[WorkerPool] = WorkerPool(DB_WORKERS)

--- a/codex/asgi.py
+++ b/codex/asgi.py
@@ -8,15 +8,15 @@ https://docs.djangoproject.com/en/dev/howto/deployment/asgi/
 """
 
 from channels.routing import ProtocolTypeRouter
-from django.core.asgi import get_asgi_application
 
+from codex.applications.http import HTTP_APPLICATION
 from codex.applications.lifespan import LifespanApplication
 from codex.applications.websocket import WEBSOCKET_APPLICATION
 from codex.websockets.mp_queue import BROADCAST_QUEUE
 
 application = ProtocolTypeRouter(
     {
-        "http": get_asgi_application(),
+        "http": HTTP_APPLICATION,
         "websocket": WEBSOCKET_APPLICATION,
         "lifespan": LifespanApplication(BROADCAST_QUEUE),
     }

--- a/codex/librarian/cron/crond.py
+++ b/codex/librarian/cron/crond.py
@@ -113,7 +113,7 @@ class CronThread(NamedThread):
                     # ``cond.wait`` doesn't pin a file handle + a few
                     # tens of KiB of in-process state through that
                     # whole window. Reopen on the next query is
-                    # ~5-20 ms, invisible against the wait.
+                    # ~1 ms, invisible against the wait.
                     connections.close_all()
                     # ``Condition.wait`` returns False only when the whole
                     # timeout elapsed; True means ``end_timeout`` notified.

--- a/codex/librarian/db.py
+++ b/codex/librarian/db.py
@@ -1,0 +1,34 @@
+"""Per-process database connection policy."""
+
+from django.db import DEFAULT_DB_ALIAS, connections
+
+from codex.settings import LIBRARIAN_CONN_MAX_AGE
+
+
+def enable_persistent_connections(
+    max_age: int | None = LIBRARIAN_CONN_MAX_AGE, *, alias: str = DEFAULT_DB_ALIAS
+) -> None:
+    """
+    Turn on persistent Django connections for the *calling process*.
+
+    ``DATABASES`` ships with Django's default ``CONN_MAX_AGE=0`` because
+    an ASGI request's worker thread is retired when the request ends, so
+    a connection kept open past ``request_finished`` is orphaned rather
+    than reused (see ``codex.settings``). Threads that genuinely outlive
+    a unit of work — the librarian's queue workers, and the HTTP worker
+    pool when it is enabled — are the opposite case: reusing a
+    connection saves them a SQLite open per task, most of which is
+    SQLite re-parsing the schema.
+
+    ``connections.settings[alias]`` is the very dict every
+    ``DatabaseWrapper`` for that alias holds as ``settings_dict`` and
+    re-reads ``CONN_MAX_AGE`` from on each ``connect()``, so this
+    applies to wrappers created later on any thread, and to an existing
+    wrapper the next time it reconnects. It is process-local state and
+    cannot leak to another process.
+
+    Call it before the threads that should benefit exist. Never call it
+    for a process whose only DB work is per-request on throwaway
+    threads.
+    """
+    connections.settings[alias]["CONN_MAX_AGE"] = max_age

--- a/codex/librarian/fs/poller/poller.py
+++ b/codex/librarian/fs/poller/poller.py
@@ -305,7 +305,7 @@ class LibraryPollerThread(NamedThread, WorkerStatusMixin):
                 # ``poll=False`` "manual poll only" case is unbounded.
                 # Release the conn so the wait doesn't pin a file
                 # handle through the entire interval. Reopen on the
-                # next poll is ~5-20 ms, invisible against the work.
+                # next poll is ~1 ms, invisible against the work.
                 connections.close_all()
                 with self._cond:
                     self._cond.wait(timeout)

--- a/codex/librarian/librariand.py
+++ b/codex/librarian/librariand.py
@@ -16,6 +16,7 @@ from codex.librarian.covers.coverd import (  # codespell:ignore coverd, typos:ig
 )
 from codex.librarian.covers.tasks import CoverTask
 from codex.librarian.cron.crond import CronThread
+from codex.librarian.db import enable_persistent_connections
 from codex.librarian.fs.poller.poller import LibraryPollerThread
 from codex.librarian.fs.poller.tasks import FSPollLibrariesTask
 from codex.librarian.fs.watcher.tasks import FSWatcherRestartTask
@@ -32,6 +33,7 @@ from codex.librarian.scribe.tasks import ScribeTask
 from codex.librarian.status_controller import StatusController
 from codex.librarian.tasks import LibrarianShutdownTask, LibrarianTask, WakeCronTask
 from codex.librarian.threads import NamedThread
+from codex.settings import LIBRARIAN_CONN_MAX_AGE
 
 _THREAD_CLASSES: Final[tuple[type[NamedThread], ...]] = (
     BookmarkThread,
@@ -189,6 +191,14 @@ class LibrarianDaemon(Process):
         This process also runs the crond thread and the watcher Observer
         threads.
         """
+        # This process's worker threads outlive their tasks, so unlike
+        # the web process they reuse a connection rather than orphaning
+        # it. Must precede ``_startup``, which spawns those threads.
+        enable_persistent_connections()
+        self.log.debug(
+            f"{self.name} enabled persistent db connections "
+            f"({LIBRARIAN_CONN_MAX_AGE}s)."
+        )
         self._startup()
         try:
             while self.run_loop:

--- a/codex/librarian/scribe/scribed.py
+++ b/codex/librarian/scribe/scribed.py
@@ -58,7 +58,7 @@ class ScribeThread(QueuedThread):
     # Importer / janitor / search bursts are minutes-to-hours apart on
     # a typical install. Releasing the conn between bursts saves an
     # open file handle + ~50 KiB pinned for the entire idle gap; the
-    # ~5-20 ms reopen cost on the next task is invisible against the
+    # ~1 ms reopen cost on the next task is invisible against the
     # work that follows.
     CLOSE_DB_BETWEEN_TASKS = True
 

--- a/codex/librarian/threads.py
+++ b/codex/librarian/threads.py
@@ -68,8 +68,10 @@ class QueuedThread(NamedThread, ABC):
     # so the next ``queue.get()`` doesn't hold it through the wait.
     # Subclasses with long idle gaps between tasks (ScribeThread,
     # CoverCreateThread) opt in. Heavy-throughput threads where the
-    # ~5-20ms reopen cost outweighs the resource savings keep the
-    # default and rely on Django's CONN_MAX_AGE-based ``close_old_connections``.
+    # ~1ms reopen cost outweighs the resource savings keep the default
+    # and rely on ``close_old_connections`` recycling the connection
+    # every ``LIBRARIAN_CONN_MAX_AGE`` seconds — this process opts into
+    # persistent connections at startup (see ``codex.librarian.db``).
     CLOSE_DB_BETWEEN_TASKS: bool = False
 
     def __init__(self, *args, **kwargs) -> None:
@@ -105,14 +107,15 @@ class QueuedThread(NamedThread, ABC):
         Release the thread-local DB connection between tasks.
 
         ``close_old_connections`` only closes connections older than
-        ``CONN_MAX_AGE`` (10 min in codex), and only fires at the top
+        ``LIBRARIAN_CONN_MAX_AGE`` (10 min), and only fires at the top
         of a loop iteration — by which point a thread that blocked on
         ``queue.get(timeout=None)`` for hours has already held its
         connection for that whole period. ``CLOSE_DB_BETWEEN_TASKS``
         subclasses elect to close eagerly so an open file handle and
         ~50 KiB of in-process state aren't pinned through the next
-        long idle. The reopen cost on the next task (~5-20 ms incl.
-        ``init_command`` PRAGMAs) is amortized away by the wait time.
+        long idle. The reopen cost on the next task (~1 ms, nearly all
+        of it SQLite re-parsing the schema; the ``init_command``
+        PRAGMAs are ~0.01 ms) is amortized away by the wait time.
         """
         if self.CLOSE_DB_BETWEEN_TASKS:
             connections.close_all()

--- a/codex/run.py
+++ b/codex/run.py
@@ -4,7 +4,7 @@
 import asyncio
 from os import execv
 
-from django.db import connection
+from django.db import connection, connections
 from granian.constants import HTTPModes, Interfaces
 from granian.server.embed import Server
 from loguru import logger
@@ -74,10 +74,11 @@ def _raise_fd_limit() -> None:
     Raise RLIMIT_NOFILE soft limit toward the hard cap.
 
     macOS ships a 256 soft cap for RLIMIT_NOFILE which a cold burst of ~100
-    parallel cover requests can easily exhaust: each Django thread keeps a
-    sticky SQLite connection (CONN_MAX_AGE=600) and SQLite WAL mode opens
-    3 FDs per connection (main + -wal + -shm). Bumping the soft limit is a
-    non-invasive equivalent to running with ``ulimit -Sn 8192``.
+    parallel cover requests can easily exhaust: each in-flight request holds
+    a SQLite connection for its duration, the librarian's worker threads hold
+    persistent ones, and SQLite WAL mode opens 3 FDs per connection
+    (main + -wal + -shm). Bumping the soft limit is a non-invasive
+    equivalent to running with ``ulimit -Sn 8192``.
     No-op on platforms without the resource module (e.g. Windows).
     """
     try:
@@ -170,6 +171,11 @@ async def _serve(server: Server) -> None:
 def run() -> None:
     """Run Codex."""
     logger.success(f"Running Codex v{VERSION}")
+    # Release the connection ``codex_startup`` opened on this thread. The
+    # web process has no use for it until shutdown checkpoints the WAL,
+    # and it guarantees no open sqlite handle is inherited by the
+    # librarian if a deployment forces the ``fork`` start method.
+    connections.close_all()
     librarian = LibrarianDaemon(logger, LIBRARIAN_QUEUE, BROADCAST_QUEUE)
     librarian.start()
     server = _build_server()

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -660,10 +660,14 @@ if not DB_PATH.exists() and OLD_DB_PATH.exists():
 BACKUP_DB_DIR = CONFIG_PATH / "backups"
 BACKUP_DB_PATH = (BACKUP_DB_DIR / DB_PATH.stem).with_suffix(DB_PATH.suffix + ".bak")
 
-# Per-connection PRAGMAs. ``init_command`` fires on every new connection
-# (which, with ``CONN_MAX_AGE=600``, means at most once per 10-minute
-# window per worker). The pragma list below trades durability-of-a-
-# single-unfsynced-write for throughput while staying safe under WAL:
+# Per-connection PRAGMAs. ``init_command`` fires on every new connection:
+# in the librarian process at most once per ``LIBRARIAN_CONN_MAX_AGE``
+# window per worker thread, but in the web process once per DB-touching
+# request (see ``DATABASES`` below). That is cheaper than it sounds — the
+# five statements measure ~0.01 ms of a ~0.8 ms connection open, which is
+# dominated by SQLite parsing the schema. The pragma list below trades
+# durability-of-a-single-unfsynced-write for throughput while staying
+# safe under WAL:
 #
 # * ``journal_mode=wal`` — already in place; enables concurrent readers
 #   alongside one writer, and lets ``synchronous=NORMAL`` be safe.
@@ -688,17 +692,33 @@ _SQLITE_PRAGMAS = (
     "PRAGMA cache_size=-64000;"
 )
 
+# Persistent connections are deliberately absent here, leaving Django's
+# default of ``CONN_MAX_AGE=0``. Django's docs: "When using ASGI,
+# persistent connections should be disabled." Under ASGI every request
+# runs its ORM work on a private worker thread that Django retires when
+# the request ends, and ``django.db.connections`` is thread-local, so a
+# connection held open by ``CONN_MAX_AGE`` can never be reused — only
+# orphaned with its thread, surfacing as ``ResourceWarning: unclosed
+# database``. At 0, Django's own ``close_old_connections`` receiver
+# closes it at ``request_finished``, on that same thread.
+#
+# Processes whose threads *do* persist opt back in for themselves:
+# the librarian at startup and, when it is enabled, the HTTP worker
+# pool. See ``codex.librarian.db.enable_persistent_connections``.
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": DB_PATH,
-        "CONN_MAX_AGE": 600,
         "OPTIONS": {
             "init_command": _SQLITE_PRAGMAS,
             "timeout": 120,
         },
     },
 }
+
+# Seconds a persistent connection is reused before it is recycled, for
+# the processes that opt in above.
+LIBRARIAN_CONN_MAX_AGE = 600
 
 if FEATURES.silk:
     # django-silk captures live in their own DB so perf traces don't

--- a/codex/settings/__init__.py
+++ b/codex/settings/__init__.py
@@ -135,6 +135,10 @@ GRANIAN_URL_PATH_PREFIX = normalize_url_path_prefix(
 WATCH_FOR_CHANGES = DEBUG and get_bool(
     CODEX_CONFIG, "server.watch_for_changes", default=False
 )
+# Worker threads that keep a warm database connection between requests.
+# See ``codex.applications.workers``. 0 serves every request on its own
+# throwaway thread, which opens and closes a connection per request.
+DB_WORKERS = get_int(CODEX_CONFIG, "server.db_workers", default=8)
 
 ##############################
 # Codex Config: Logging      #

--- a/codex/settings/codex.toml.default
+++ b/codex/settings/codex.toml.default
@@ -15,6 +15,12 @@
 # websockets = true
 # HTTP path prefix for codex (e.g. "/codex" for reverse proxy sub-path)
 # url_path_prefix = ""
+# Worker threads that keep a warm database connection between requests.
+# Opening one costs a few milliseconds, mostly SQLite re-reading the
+# schema, so reusing them makes short requests noticeably cheaper. Each
+# worker can grow its own page cache (see cache_size, 64MB), so lower
+# this on a memory-constrained host. 0 opens a connection per request.
+# db_workers = 8
 
 # [logging]
 # Log level: TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL

--- a/codex/startup/db.py
+++ b/codex/startup/db.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import subprocess
+from contextlib import closing
 from threading import Event, Lock
 
 from django.core.management import call_command
@@ -150,7 +151,10 @@ def _rebuild_db() -> bool:
         "PRAGMA writable_schema = off;",
         "PRAGMA writable_schema = reset;",
     )
-    with sqlite3.connect(_REBUILT_DB_PATH) as new_db_conn:
+    # ``closing()`` as well as the transaction context manager:
+    # ``with sqlite3.connect(...)`` only commits, it does not close, and
+    # the rebuilt file is renamed over the live database two lines down.
+    with closing(sqlite3.connect(_REBUILT_DB_PATH)) as new_db_conn, new_db_conn:
         new_db_conn.executescript(sql)
 
     backup_path = _get_backup_db_path("before-rebuild")

--- a/codex/user_data/restore.py
+++ b/codex/user_data/restore.py
@@ -63,6 +63,7 @@ def restore(
     process store). ``dry_run`` resolves every row without writing.
     """
     resolved, cleanup = _resolve_sidecar(sidecar_path)
+    store = None
     try:
         store = SidecarStore(resolved) if resolved is not None else get_store()
         report = RestoreReport()
@@ -83,6 +84,14 @@ def restore(
         logger.info(f"{mode}: {total_written} written, {total_skipped} skipped.")
         return report
     finally:
+        if store is not None:
+            # The restore runs on an ASGI request's worker thread, which
+            # is retired when the request ends. ``SidecarStore`` caches
+            # its sqlite connection in a ``threading.local``, so leaving
+            # it open orphans it exactly the way an unclosed Django
+            # connection would (and no ASGI wrapper can reach a
+            # non-Django handle).
+            store.close()
         cleanup()
 
 

--- a/codex/views/admin/stats.py
+++ b/codex/views/admin/stats.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 from typing import Any, Final
 
 from adrf.mixins import get_data
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.core.cache import cache
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
@@ -90,7 +90,10 @@ class AdminStatsView(AsyncAdminGenericAPIView):
             # ``CodexStats.get`` runs ~30 sync COUNT/GROUP BY queries.
             # Off-load it from the event loop; ``thread_sensitive=False``
             # lets concurrent stats requests run on separate workers.
-            cached = await sync_to_async(
+            # Those are the event loop's own executor threads, which no
+            # request lifecycle ever cleans up, so use channels' wrapper
+            # to close the connection on the way out.
+            cached = await database_sync_to_async(
                 CodexStats(self.params).get, thread_sensitive=False
             )()
             await cache.aset(cache_key, cached, _CACHE_TTL_SECONDS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ classifiers = [
 ]
 dependencies = [
   "adrf~=0.1.12",
+  # Declared directly, not just inherited through Django and channels:
+  # codex.applications.workers installs its own thread-sensitive
+  # contexts into asgiref's executor registry, so a major version is a
+  # conscious upgrade rather than a transitive one.
+  "asgiref~=3.12",
   "bidict~=0.23",
   "channels~=4.2",
   "comicbox[pdf]~=5.0.0",

--- a/tests/test_asgi_db_connections.py
+++ b/tests/test_asgi_db_connections.py
@@ -1,0 +1,282 @@
+"""An ASGI request must release its database connections before its thread dies."""
+
+import asyncio
+import threading
+from typing import Final
+
+import pytest
+from asgiref.sync import ThreadSensitiveContext, sync_to_async
+from django.db import connections
+from django.http import HttpResponse, StreamingHttpResponse
+from django.test import override_settings
+from django.urls import path
+
+from codex.applications.http import ConnectionClosingApplication
+from codex.asgi import application
+from codex.librarian.db import enable_persistent_connections
+
+_ALIAS: Final = "test_asgi_db_connections"
+_PERSISTENT: Final = 600
+_SCOPE: Final = {
+    "type": "http",
+    "asgi": {"version": "3.0", "spec_version": "2.1"},
+    "http_version": "1.1",
+    "method": "GET",
+    "scheme": "http",
+    "path": "/",
+    "raw_path": b"/",
+    "query_string": b"",
+    "root_path": "",
+    "headers": [(b"host", b"testserver")],
+    "client": ("127.0.0.1", 12345),
+    "server": ("testserver", 80),
+}
+
+
+def _alias_settings(tmp_path, max_age):
+    """Build a file-backed alias mirroring the default database."""
+    return {
+        **connections.settings["default"],
+        "NAME": str(tmp_path / "asgi_conn.sqlite3"),
+        "CONN_MAX_AGE": max_age,
+    }
+
+
+@pytest.fixture
+def alias(tmp_path, django_db_blocker):
+    """
+    Register a throwaway file-backed database for the duration of a test.
+
+    It has to be a *file*: Django's sqlite backend makes ``close()`` a
+    no-op for in-memory databases so the test database isn't destroyed
+    mid-suite, which would make every assertion here vacuously pass.
+    It starts at ``CONN_MAX_AGE=0`` like the real default database;
+    tests that need persistence raise it themselves.
+
+    Only the alias needs unregistering afterwards: the connection itself
+    is opened on a worker thread, and each test accounts for it there.
+    """
+    connections.settings[_ALIAS] = _alias_settings(tmp_path, 0)
+    with django_db_blocker.unblock():
+        yield _ALIAS
+    del connections.settings[_ALIAS]
+
+
+class OrmApplication:
+    """
+    A miniature of Django's ``ASGIHandler``.
+
+    It opens a database connection from inside its own
+    ``ThreadSensitiveContext``, exactly as ``ASGIHandler.__call__`` does,
+    and records the connection wrapper and worker thread so a test can
+    inspect them after the executor backing that context is gone.
+    """
+
+    def __init__(self, alias) -> None:
+        """Bind to a database alias and prepare the recordings."""
+        self.alias = alias
+        self.wrapper = None
+        self.thread = None
+
+    def _query(self) -> None:
+        """Open the thread's connection and remember where it landed."""
+        wrapper = connections[self.alias]
+        with wrapper.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        self.wrapper = wrapper
+        self.thread = threading.current_thread()
+
+    async def __call__(self, scope, receive, send) -> None:  # noqa: ARG002
+        """Run the query on the request's thread-sensitive worker."""
+        async with ThreadSensitiveContext():
+            await sync_to_async(self._query)()
+
+
+def _make_receive():
+    """
+    Build an ASGI ``receive`` that sends one empty body, then blocks.
+
+    Django's handler drains the request body before doing anything else
+    and then leaves ``listen_for_disconnect`` parked on ``receive``, so
+    the second call must never return — the handler cancels that task
+    when the response is done.
+    """
+    sent = False
+
+    async def receive():
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    return receive
+
+
+async def _send(message) -> None:
+    """Discard the response."""
+
+
+class Probe:
+    """Records the wrapper and thread a Django view's ORM work landed on."""
+
+    def __init__(self) -> None:
+        """Start with nothing recorded."""
+        self.wrapper = None
+        self.thread = None
+
+    def query(self) -> None:
+        """Open this thread's connection to the throwaway alias."""
+        wrapper = connections[_ALIAS]
+        with wrapper.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        self.wrapper = wrapper
+        self.thread = threading.current_thread()
+
+
+_PROBE = Probe()
+
+
+def _close_orphan(wrapper) -> None:
+    """
+    Close a connection nothing else can reach.
+
+    Its thread is gone, so ``wrapper.close()`` would fail
+    ``validate_thread_sharing``. Leaving it open would emit the very
+    ResourceWarning this module is about.
+    """
+    if wrapper is not None and wrapper.connection is not None:
+        wrapper.connection.close()
+        wrapper.connection = None
+
+
+def _probe_view(_request):
+    """Touch the database and return a plain response."""
+    _PROBE.query()
+    return HttpResponse(b"ok")
+
+
+def _raising_body():
+    """Yield one chunk, then fail the way a vanishing archive would."""
+    yield b"chunk"
+    msg = "the librarian moved the file"
+    raise OSError(msg)
+
+
+def _streaming_probe_view(_request):
+    """Touch the database and stream a body that fails mid-transfer."""
+    _PROBE.query()
+    return StreamingHttpResponse(_raising_body())
+
+
+urlpatterns = [
+    path("probe/", _probe_view),
+    path("stream/", _streaming_probe_view),
+]
+
+
+def _http_application() -> ConnectionClosingApplication:
+    """Return the application codex actually serves HTTP with."""
+    app = application.application_mapping["http"]
+    assert isinstance(app, ConnectionClosingApplication)
+    return app
+
+
+def _drive_django(app, path_):
+    """Run one request through a real Django handler, recording on _PROBE."""
+    _PROBE.wrapper = None
+    _PROBE.thread = None
+    scope = {**_SCOPE, "path": path_, "raw_path": path_.encode()}
+    with override_settings(ROOT_URLCONF=__name__):
+        return asyncio.run(app(scope, _make_receive(), _send))
+
+
+def test_web_process_has_no_persistent_connections():
+    """The shipped settings leave Django's ASGI-safe default in place."""
+    assert connections.settings["default"]["CONN_MAX_AGE"] == 0
+
+
+def test_django_closes_the_request_connection_itself(alias):  # noqa: ARG001
+    """At CONN_MAX_AGE=0 Django's own request_finished hook is enough."""
+    django_app = _http_application().application
+    _drive_django(django_app, "/probe/")
+
+    assert _PROBE.thread is not None
+    assert not _PROBE.thread.is_alive()
+    assert _PROBE.wrapper is not None
+    assert _PROBE.wrapper.connection is None
+
+
+def test_django_alone_orphans_it_when_the_body_raises(alias):  # noqa: ARG001
+    """The exit Django has no hook on: a streaming body that fails."""
+    django_app = _http_application().application
+    with pytest.raises(OSError, match="librarian moved"):
+        _drive_django(django_app, "/stream/")
+
+    assert _PROBE.thread is not None
+    assert not _PROBE.thread.is_alive()
+    assert _PROBE.wrapper is not None
+    # Re-raised out of ASGIHandler.handle()'s TaskGroup before either
+    # request_finished or response.close() runs, so nothing closed it.
+    assert _PROBE.wrapper.connection is not None
+    _close_orphan(_PROBE.wrapper)
+
+
+def test_backstop_closes_when_the_body_raises(alias):  # noqa: ARG001
+    """That is what the wrapper is for — it closes on the same worker."""
+    with pytest.raises(OSError, match="librarian moved"):
+        _drive_django(_http_application(), "/stream/")
+
+    assert _PROBE.thread is not None
+    assert not _PROBE.thread.is_alive()
+    assert _PROBE.wrapper is not None
+    assert _PROBE.wrapper.connection is None
+
+
+def test_http_application_closes_request_connections(alias):
+    """The wrapper closes what the request opened, on the request's thread."""
+    inner = OrmApplication(alias)
+    asyncio.run(ConnectionClosingApplication(inner)(_SCOPE, _make_receive(), _send))
+
+    assert inner.thread is not None
+    assert not inner.thread.is_alive()
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is None
+
+
+def test_unwrapped_application_orphans_a_persistent_connection(alias, tmp_path):
+    """``CONN_MAX_AGE>0`` under ASGI outlives its thread — the original bug."""
+    connections.settings[alias] = _alias_settings(tmp_path, _PERSISTENT)
+    inner = OrmApplication(alias)
+    asyncio.run(inner(_SCOPE, _make_receive(), _send))
+
+    assert inner.thread is not None
+    assert not inner.thread.is_alive()
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is not None
+    # Close it by hand: nothing else can reach it now, and leaving it
+    # open would emit the very ResourceWarning this module is about.
+    _close_orphan(inner.wrapper)
+
+
+def test_enable_persistent_connections_is_process_scoped(alias):
+    """The librarian's opt-in reaches wrappers created after the call."""
+    assert connections.settings[alias]["CONN_MAX_AGE"] == 0
+    enable_persistent_connections(_PERSISTENT, alias=alias)
+    assert connections.settings[alias]["CONN_MAX_AGE"] == _PERSISTENT
+
+    inner = OrmApplication(alias)
+    asyncio.run(inner(_SCOPE, _make_receive(), _send))
+
+    # ``connect()`` re-reads CONN_MAX_AGE, so the wrapper the worker built
+    # after the call schedules its close 600s out rather than immediately
+    # — which is why the connection is still open.
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is not None
+    _close_orphan(inner.wrapper)
+
+
+def test_asgi_http_route_is_wrapped():
+    """The served HTTP application is the connection-closing one."""
+    assert _http_application().application is not None

--- a/tests/test_asgi_db_connections.py
+++ b/tests/test_asgi_db_connections.py
@@ -2,21 +2,32 @@
 
 import asyncio
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from typing import Final
 
 import pytest
-from asgiref.sync import ThreadSensitiveContext, sync_to_async
+from asgiref.sync import SyncToAsync, ThreadSensitiveContext, sync_to_async
 from django.db import connections
 from django.http import HttpResponse, StreamingHttpResponse
 from django.test import override_settings
 from django.urls import path
 
-from codex.applications.http import ConnectionClosingApplication
+from codex.applications.http import (
+    ConnectionClosingApplication,
+    PooledApplication,
+    _is_bypassed,
+)
+from codex.applications.workers import WORKER_POOL, WorkerPool
 from codex.asgi import application
 from codex.librarian.db import enable_persistent_connections
 
 _ALIAS: Final = "test_asgi_db_connections"
 _PERSISTENT: Final = 600
+_REQUESTS: Final = 3
+_CONCURRENT: Final = 6
+_WORKERS: Final = 2
 _SCOPE: Final = {
     "type": "http",
     "asgi": {"version": "3.0", "spec_version": "2.1"},
@@ -176,10 +187,10 @@ urlpatterns = [
 ]
 
 
-def _http_application() -> ConnectionClosingApplication:
+def _http_application() -> PooledApplication:
     """Return the application codex actually serves HTTP with."""
     app = application.application_mapping["http"]
-    assert isinstance(app, ConnectionClosingApplication)
+    assert isinstance(app, PooledApplication)
     return app
 
 
@@ -226,7 +237,7 @@ def test_django_alone_orphans_it_when_the_body_raises(alias):  # noqa: ARG001
 def test_backstop_closes_when_the_body_raises(alias):  # noqa: ARG001
     """That is what the wrapper is for — it closes on the same worker."""
     with pytest.raises(OSError, match="librarian moved"):
-        _drive_django(_http_application(), "/stream/")
+        _drive_django(_http_application().unpooled, "/stream/")
 
     assert _PROBE.thread is not None
     assert not _PROBE.thread.is_alive()
@@ -277,6 +288,204 @@ def test_enable_persistent_connections_is_process_scoped(alias):
     _close_orphan(inner.wrapper)
 
 
-def test_asgi_http_route_is_wrapped():
-    """The served HTTP application is the connection-closing one."""
-    assert _http_application().application is not None
+def test_asgi_http_route_is_wired():
+    """The served HTTP application pools, and can fall back."""
+    app = _http_application()
+    assert app.pool is WORKER_POOL
+    assert isinstance(app.unpooled, ConnectionClosingApplication)
+
+
+class SlowOrmApplication(OrmApplication):
+    """Records every thread it ran on, and dawdles so requests overlap."""
+
+    def __init__(self, alias, delay=0.02) -> None:
+        """Bind to an alias and set how long each request occupies a worker."""
+        super().__init__(alias)
+        self.delay = delay
+        self.threads = []
+
+    def _query(self) -> None:
+        """Occupy this worker long enough for another request to queue."""
+        super()._query()
+        self.threads.append(threading.current_thread())
+        time.sleep(self.delay)
+
+
+@asynccontextmanager
+async def _pool(size):
+    """Start a worker pool for one test and always stop it."""
+    pool = WorkerPool(size)
+    await pool.start()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+
+
+def test_pooled_requests_reuse_one_worker_and_connection(alias):
+    """The point of the pool: the thread and its connection survive."""
+    inner = SlowOrmApplication(alias, delay=0)
+
+    async def main():
+        async with _pool(1) as pool:
+            app = PooledApplication(inner, pool)
+            for _ in range(_REQUESTS):
+                await app(_SCOPE, _make_receive(), _send)
+            # Read the recordings before ``stop`` retires the worker.
+            assert inner.thread is not None
+            assert inner.wrapper is not None
+            return inner.thread, inner.wrapper, inner.wrapper.connection
+
+    thread, wrapper, connection = asyncio.run(main())
+
+    assert thread.name.startswith("codex-http-db-0")
+    assert len({id(t) for t in inner.threads}) == 1
+    assert len(inner.threads) == _REQUESTS
+    # One connection served all three requests, and it was open the
+    # whole time — which is what CONN_MAX_AGE means and could not mean
+    # while every request got its own thread.
+    assert connection is not None
+    assert wrapper.connection is None
+    assert not thread.is_alive()
+
+
+def test_pool_bounds_concurrency(alias):
+    """A pool of two serves six concurrent requests on two threads."""
+    inner = SlowOrmApplication(alias)
+
+    async def main():
+        async with _pool(_WORKERS) as pool:
+            app = PooledApplication(inner, pool)
+            await asyncio.gather(
+                *(app(_SCOPE, _make_receive(), _send) for _ in range(_CONCURRENT))
+            )
+
+    asyncio.run(main())
+
+    assert len(inner.threads) == _CONCURRENT
+    assert len({id(t) for t in inner.threads}) == _WORKERS
+
+
+def test_disabled_pool_falls_back_to_per_request_threads(alias):
+    """Size 0 serves every request the way it was served before."""
+    inner = OrmApplication(alias)
+
+    async def main():
+        async with _pool(0) as pool:
+            assert not pool.enabled
+            await PooledApplication(inner, pool)(_SCOPE, _make_receive(), _send)
+
+    asyncio.run(main())
+
+    assert inner.thread is not None
+    assert not inner.thread.is_alive()
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is None
+
+
+def test_failed_self_check_disables_the_pool(alias, monkeypatch):
+    """If asgiref ever stops routing as we expect, nothing is pooled."""
+    monkeypatch.setattr(WorkerPool, "_self_check", lambda _self: _false(), raising=True)
+    inner = OrmApplication(alias)
+
+    async def main():
+        async with _pool(_WORKERS) as pool:
+            assert not pool.enabled
+            await PooledApplication(inner, pool)(_SCOPE, _make_receive(), _send)
+
+    asyncio.run(main())
+
+    assert inner.thread is not None
+    assert not inner.thread.is_alive()
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is None
+
+
+async def _false() -> bool:
+    """Stand in for a self-check that fails."""
+    return False
+
+
+def test_stop_closes_a_busy_worker(alias):
+    """A request still in flight at shutdown keeps its worker, then frees it."""
+    inner = SlowOrmApplication(alias, delay=0.3)
+    pool = WorkerPool(1)
+
+    async def main():
+        await pool.start()
+        app = PooledApplication(inner, pool)
+        request = asyncio.create_task(app(_SCOPE, _make_receive(), _send))
+        # Stop while the request still holds the worker.
+        await asyncio.sleep(0.05)
+        await asyncio.gather(pool.stop(), request)
+
+    asyncio.run(main())
+
+    assert inner.wrapper is not None
+    assert inner.wrapper.connection is None
+    assert inner.thread is not None
+    assert not inner.thread.is_alive()
+
+
+def test_asgiref_still_routes_onto_a_seeded_context():
+    """
+    Pin the asgiref behavior the pool is built on.
+
+    The pool installs a context asgiref would otherwise create lazily.
+    That is two non-underscored class attributes and a documented
+    re-entrancy guarantee, none of it a promised API — so assert it
+    directly. A failure here explains a pool that silently disabled
+    itself.
+    """
+
+    async def main():
+        context = ThreadSensitiveContext()
+        executor = ThreadPoolExecutor(max_workers=1)
+        SyncToAsync.context_to_thread_executor[context] = executor
+        try:
+            expected = executor.submit(threading.get_ident).result(5)
+            token = SyncToAsync.thread_sensitive_context.set(context)
+            try:
+                # Django's own inner block must be a re-entrant no-op.
+                async with ThreadSensitiveContext() as inner_context:
+                    assert inner_context.token is None
+                    return expected, await sync_to_async(threading.get_ident)()
+            finally:
+                SyncToAsync.thread_sensitive_context.reset(token)
+        finally:
+            SyncToAsync.context_to_thread_executor.pop(context, None)
+            executor.shutdown()
+
+    expected, actual = asyncio.run(main())
+    assert actual == expected
+
+
+def test_downloads_and_health_bypass_the_pool():
+    """Requests that would hold a worker for a transfer are exempt."""
+    assert _is_bypassed({"path": "/health"})
+    assert _is_bypassed({"path": "/api/v4/comics/1/download/book.cbz"})
+    assert _is_bypassed({"path": "/api/v4/browse/publishers/1/download/all.cbz"})
+    assert _is_bypassed({"path": "/opds/bin/c/1/download/book.cbz"})
+    assert _is_bypassed({"path": "/read/1/book.pdf"})
+    assert not _is_bypassed({"path": "/api/v4/auth/csrf"})
+    assert not _is_bypassed({"path": "/no/such/route"})
+    # The url path prefix is stripped before resolving.
+    assert _is_bypassed({"path": "/codex/health", "root_path": "/codex"})
+
+
+def test_a_worker_can_be_returned_after_the_pool_is_stopped(monkeypatch):
+    """A request that outlasts the shutdown wait must not break on release."""
+    monkeypatch.setattr(WorkerPool, "STOP_TIMEOUT", 0.01)
+    pool = WorkerPool(1)
+
+    async def main():
+        await pool.start()
+        # Shut down while the only worker is checked out. ``stop`` gives
+        # up waiting for it, resets the pool, and the request then hands
+        # a worker back to a pool that no longer has a queue.
+        async with pool.acquire():
+            await pool.stop()
+
+    asyncio.run(main())
+
+    assert not pool.enabled

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,7 @@ version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "adrf" },
+    { name = "asgiref" },
     { name = "bidict" },
     { name = "channels" },
     { name = "comicbox", extra = ["pdf"] },
@@ -722,6 +723,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "adrf", specifier = "~=0.1.12" },
+    { name = "asgiref", specifier = "~=3.12" },
     { name = "bidict", specifier = "~=0.23" },
     { name = "channels", specifier = "~=4.2" },
     { name = "comicbox", extras = ["pdf"], specifier = "~=5.0.0" },


### PR DESCRIPTION
## Why

Every DB-touching web request leaked an open SQLite connection until the garbage collector emitted `ResourceWarning: unclosed database` — three file descriptors apiece under WAL, dozens per page of covers. That is what `_raise_fd_limit()` was papering over.

**This is not a Django bug.** Django's `ASGIHandler` wraps each request in an asgiref `ThreadSensitiveContext`, backed by a private one-thread executor it shuts down when the request ends. `django.db.connections` is thread-local, so `CONN_MAX_AGE=600` kept a connection alive on a thread about to be retired: never reusable, never closed. Django [documents this](https://docs.djangoproject.com/en/6.0/ref/databases/#persistent-connections) — *"When using ASGI, persistent connections should be disabled"* — and closed [#33497](https://code.djangoproject.com/ticket/33497) as documentation only. The per-request thread came from [#32889](https://code.djangoproject.com/ticket/32889), deliberately.

## What changed

Two commits, separable.

### 1. `fix(db)` — take the documented configuration

`DATABASES` drops to Django's default `CONN_MAX_AGE=0`, and the processes whose threads actually persist opt back in for themselves (`codex/librarian/db.py`). Django's own `close_old_connections` then closes each request's connection on the request's own worker — verified: the **bare** `get_asgi_application()` now leaks 0 where it leaked 6.

`ConnectionClosingApplication` stays, but for a narrower job. `send_response` runs inside `handle()`'s `TaskGroup`; if it raises, the exception group is re-raised **before** `request_finished` or `response.close()`. A streaming body is consumed there, outside the middleware chain, so an iterator that raises is never converted to a 500 — and codex streams comic archives off a user's library, where the librarian can move a file mid-download. Reproduced three ways; two tests now pin it (bare handler orphans, wrapper closes).

Also closes two connections nothing was closing: the admin restore endpoint's sidecar sqlite handle, and the admin stats view's off-loop query on an event-loop executor thread.

### 2. `perf(db)` — pool the workers

Benchmarked first: a fresh connection costs **0.76 ms**, **~90% of it SQLite re-parsing the schema** (84 tables + 266 indexes) — not the PRAGMAs (1.3%) or Django's function registration (2%). With statement re-preparation, a five-query request pays **+1.26 ms, 53% of its DB time**. Modest on an M1, 5–20× on the NAS/Pi hosts codex ships to.

A SQLite *connection* pool was rejected: a handle returned with an unexhausted cursor pins a WAL read snapshot that `rollback()` does not release, so the next borrower reads stale rows and its first write fails `database is locked` (reproduced). Pool the **threads** instead — `WorkerPool` lends each request one of N never-entered `ThreadSensitiveContext`s, so the worker and its connection outlive the request. That is the stable-thread model `CONN_MAX_AGE` was written for.

| | connections opened | leaks |
|---|---|---|
| before | 6 per 9 requests | 6 |
| `db_workers = 0` | 6 | 0 |
| pooled (default 8) | **1** | 0 |

## For the reviewer

- **Base is `comicbox-5`, not main/develop.** This is stacked on it; against `main` the PR would bury ~20 files under 161 files of in-flight comicbox-5 work, and `comicbox-5` is not merged anywhere yet.
- **The pool reaches into two semi-public asgiref attributes** (`SyncToAsync.thread_sensitive_context`, `context_to_thread_executor`), unchanged since 3.3.2 (2021) but not a documented contract. So it doesn't trust them: a startup self-check runs the exact shape a request will, and on failure logs and disables the pool — every request then takes the per-request path from commit 1. `asgiref` is now a direct dependency so a major bump is deliberate, and a test pins the routing behavior to fail loudly rather than degrade silently.
- **Bypass list**: downloads and `/health` skip the pool, since a pooled request holds its worker until its response is sent.
- **`db_workers` under `[server]`** sizes it; `0` restores per-request connections. Each worker can grow its own page cache (`cache_size`, 64MB), so lower it on constrained hosts.
- Six comments estimating the reconnect at "~5-20 ms" were wrong by an order of magnitude; corrected to the measured ~1 ms.

## Verification

- `make fix` / `make lint` clean; `make ty` reports only the 6 pre-existing `redundant-condition` warnings.
- `make test`: **1094 passed, 0 failed.**
- A live Granian server under `PYTHONDEVMODE=1 PYTHONWARNINGS=always`: pool started via lifespan with 8 workers, 24 requests plus a bypassed download served, **zero ResourceWarnings**, clean pool stop at shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)