### PR TITLE
Make the stored-id prepass report what it did

### DIFF
--- a/codex/librarian/onlinetag/explicit_id.py
+++ b/codex/librarian/onlinetag/explicit_id.py
@@ -36,6 +36,7 @@ from codex.librarian.onlinetag.issue_id import parse_issue_id
 from codex.settings import COMICBOX_ONLINE_CONFIG
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from comicbox.config.settings import ComicboxSettings
@@ -112,6 +113,25 @@ def _result_has_requested_id(tags: dict[str, Any], source: str, issue_id: int) -
     id_obj = (tags.get(IDENTIFIERS_KEY) or {}).get(source) or {}
     parsed = parse_issue_id(id_obj.get(ID_KEY_KEY))
     return parsed is not None and parsed == issue_id
+
+
+def resolved_id_sources(
+    tags: dict[str, Any], requested_ids: Mapping[str, int]
+) -> tuple[str, ...]:
+    """
+    Which of the requested sources actually landed their fetch, in order.
+
+    A merged multi-source fetch reports one record, so the only evidence of
+    who contributed to it is whose requested id came back in the merged
+    identifiers. Callers attribute the write with this; without it a comic
+    refreshed from both sources is credited to the primary alone and the
+    status table shows the other one as never consulted.
+    """
+    return tuple(
+        source
+        for source, issue_id in requested_ids.items()
+        if _result_has_requested_id(tags, source, issue_id)
+    )
 
 
 def fetch_tags_by_explicit_id(

--- a/codex/librarian/onlinetag/outcome_stats.py
+++ b/codex/librarian/onlinetag/outcome_stats.py
@@ -61,6 +61,7 @@ from codex.librarian.onlinetag.statuses import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
     from pathlib import Path
 
     from comicbox.events import Event
@@ -159,16 +160,20 @@ class OnlineTagOutcomeStats:
         for source in self.started_sources_by_path.get(path, ()):
             cells.setdefault(source, NO_MATCH)
 
-    def record_prefetch_match(self, path: Path, source: str) -> None:
+    def record_prefetch_match(self, path: Path, sources: Collection[str]) -> None:
         """
-        Record a comic matched from its stored id before the search pass.
+        Record a comic matched from its stored ids before the search pass.
 
         The prepass fetches by id outside the event-emitting session, so it
         seeds by hand what an ``AutoWritten`` + ``FileFinished`` pair would.
+        Every source whose id landed is credited, not just the primary: a
+        merged fetch writes all of their tags, and crediting one leaves the
+        others reading as never consulted.
         """
         self.written_paths.add(path)
-        self._add_matched_source(path, source)
-        self._set_source_status(path, source, MATCHED)
+        for source in sources:
+            self._add_matched_source(path, source)
+            self._set_source_status(path, source, MATCHED)
 
     @property
     def matched(self) -> int:

--- a/codex/librarian/onlinetag/session_manager.py
+++ b/codex/librarian/onlinetag/session_manager.py
@@ -47,7 +47,10 @@ from codex.librarian.notifier.tasks import (
     TAG_WRITE_ERRORS_CHANGED_TASK,
 )
 from codex.librarian.onlinetag.estimate import estimate_seconds
-from codex.librarian.onlinetag.explicit_id import fetch_tags_by_explicit_id
+from codex.librarian.onlinetag.explicit_id import (
+    fetch_tags_by_explicit_id,
+    resolved_id_sources,
+)
 from codex.librarian.onlinetag.session_cache import (
     PROMPT_VERSION,
     add_pending_prompts,
@@ -561,14 +564,16 @@ class OnlineTagSessionManager:
         credentials: OnlineCredentials,
         *,
         merge_all_sources: bool,
-    ) -> tuple[str, dict] | None:
+    ) -> tuple[tuple[str, ...], dict] | None:
         """
-        Fetch one already-identified comic by its primary stored id.
+        Fetch one already-identified comic by its stored ids.
 
-        Returns ``(primary_source, tags)`` on success, or ``None`` when the id
-        didn't resolve or the fetch errored — the caller leaves such a comic to
-        the search pass. Under ``merge_all_sources`` the comic's other stored
-        ids are fetched and merged onto the primary record.
+        Returns ``(resolved_sources, tags)`` on success, or ``None`` when the
+        primary id didn't resolve or the fetch errored — the caller leaves such
+        a comic to the search pass. Under ``merge_all_sources`` the comic's
+        other stored ids are fetched and merged onto the primary record, and
+        each one that lands is reported: a merged fetch is every contributing
+        source's match, not only the primary's.
         """
         primary_source, primary_id = next(iter(source_ids.items()))
         extra_ids = (
@@ -587,7 +592,13 @@ class OnlineTagSessionManager:
         except (ComicboxError, OSError) as exc:
             self.log.warning(f"Online tag stored-id prefetch failed for {path}: {exc}")
             return None
-        return (primary_source, tags) if tags else None
+        if not tags:
+            return None
+        # The primary is proven by the fetch itself, which returns nothing
+        # unless its own id came back. Each extra has to show its id in the
+        # merged record: an extra that didn't resolve contributed nothing.
+        extras = resolved_id_sources(tags, dict(extra_ids))
+        return (primary_source, *extras), tags
 
     def _commit_prefetch(
         self,
@@ -643,6 +654,11 @@ class OnlineTagSessionManager:
         if not id_map:
             return
 
+        # Opened here rather than in the search pass: on a re-tag every comic
+        # resolves in this loop, and a scan whose whole runtime is the prepass
+        # showed the admin an empty status rail. Totalled over the batch, not
+        # the id map, so the count doesn't jump when the search pass adopts it.
+        status = self._pass_runner.begin_status(len(comic_paths))
         batch: dict[int, dict] = {}
         for pk, source_ids in id_map.items():
             path = comic_paths[pk]
@@ -658,9 +674,13 @@ class OnlineTagSessionManager:
             state.live.end(path)
             if result is None:
                 continue
-            primary_source, tags = result
+            sources, tags = result
             batch[pk] = tags
-            state.stats.record_prefetch_match(path, primary_source)
+            state.stats.record_prefetch_match(path, sources)
+            # The rail's own progress: the prepass is the whole run on a
+            # re-tag, and its comics are the ones the search pass never sees.
+            status.complete = len(batch)
+            self.status_controller.update(status)
 
         if batch:
             self._commit_prefetch(state, comic_paths, batch)
@@ -787,6 +807,9 @@ class OnlineTagSessionManager:
             # that died by raising is still holding one, and a frozen snapshot
             # must not claim a lookup is running.
             state.live.clear()
+            # No-op unless the prepass raised before the search pass could
+            # adopt (and finish) the status row it opened.
+            self._pass_runner.finish_status()
             self._publish_snapshot(
                 state, active=False, force=True, session_id=task.session_id
             )

--- a/codex/librarian/onlinetag/tag_pass_runner.py
+++ b/codex/librarian/onlinetag/tag_pass_runner.py
@@ -153,6 +153,35 @@ class TagPassRunner:
             if flush_writes and was_rate_limited and batch:
                 self._flush_batch(state, batch)
 
+    def begin_status(self, total: int) -> OnlineLookupStatus:
+        """
+        Open the scan's status row before any lookups run.
+
+        The stored-id prepass fetches outside the session, so without this
+        the rail has no row to render for what is, on a re-tag, the whole
+        run — and the live marker has no status to name its source on.
+        ``collect_results`` adopts the row and finishes it.
+        """
+        status = OnlineLookupStatus()
+        status.total = total
+        status.complete = 0
+        self.lookup_status = status
+        self.status_controller.start(status)
+        return status
+
+    def finish_status(self) -> None:
+        """
+        Close a status row no pass took ownership of.
+
+        ``collect_results`` finishes (and clears) its own in a ``finally``,
+        so this only fires when the prepass raised before it ran — the case
+        that would otherwise strand an active row in the rail forever.
+        """
+        if self.lookup_status is None:
+            return
+        self.status_controller.finish(self.lookup_status)
+        self.lookup_status = None
+
     def collect_results(
         self,
         state: SessionState,
@@ -163,7 +192,13 @@ class TagPassRunner:
         """Iterate tag_many, merging new tasks that arrive mid-run."""
         path_list = list(paths)
         state.total_comics += len(path_list)
-        status = OnlineLookupStatus()
+        # The stored-id prepass may already have opened the scan's status
+        # row. Adopt it rather than starting a second one, so the rail shows
+        # one continuous job whose elapsed time counts the prepass too.
+        status = self.lookup_status
+        fresh = status is None
+        if status is None:
+            status = OnlineLookupStatus()
         status.total = state.total_comics
         status.complete = state.completed_comics
         self._update_eta(state, status)
@@ -171,7 +206,10 @@ class TagPassRunner:
         self.rate_limited = False
         self.source_retry_at.clear()
         self._publish_snapshot(state)
-        self.status_controller.start(status)
+        if fresh:
+            self.status_controller.start(status)
+        else:
+            self.status_controller.update(status, force=True)
 
         batch: dict[int, dict] = {}
         try:

--- a/tests/onlinetag_session_fakes.py
+++ b/tests/onlinetag_session_fakes.py
@@ -19,6 +19,7 @@ from django.test import TestCase
 from loguru import logger
 
 from codex.librarian.onlinetag.session_manager import OnlineTagSessionManager
+from codex.librarian.onlinetag.status import OnlineLookupStatus
 from codex.librarian.scribe.tasks import BulkTagWriteTask
 from codex.models import (
     Comic,
@@ -76,6 +77,18 @@ class FakePassRunner:
         self.source_retry_at: dict[str, float] = {}
         self.lookup_status = None
         self.rate_limited = False
+
+    def begin_status(self, total: int) -> OnlineLookupStatus:
+        """Open the scan's status row the way the real runner does."""
+        status = OnlineLookupStatus()
+        status.total = total
+        status.complete = 0
+        self.lookup_status = status
+        return status
+
+    def finish_status(self) -> None:
+        """Drop the row the prepass opened."""
+        self.lookup_status = None
 
 
 class FakeCandidate:

--- a/tests/test_onlinetag_outcome_stats.py
+++ b/tests/test_onlinetag_outcome_stats.py
@@ -239,11 +239,33 @@ def test_record_prefetch_match_seeds_every_structure() -> None:
     stats = OnlineTagOutcomeStats()
     path = Path("/c/1.cbz")
 
-    stats.record_prefetch_match(path, "metron")
+    stats.record_prefetch_match(path, ("metron",))
     # A second call for the same source must not double-list it.
-    stats.record_prefetch_match(path, "metron")
+    stats.record_prefetch_match(path, ("metron",))
 
     assert stats.written_paths == {path}
     assert stats.matched_source_by_path[path] == ["metron"]
     assert stats.source_status_by_path[path] == {"metron": statuses.MATCHED}
+    assert stats.matched == 1
+
+
+def test_record_prefetch_match_credits_every_source_that_landed() -> None:
+    """
+    A merged stored-id refresh is every contributing source's match.
+
+    Crediting the primary alone left the other source's column blank on a
+    comic it had just refreshed — indistinguishable from never having been
+    asked.
+    """
+    stats = OnlineTagOutcomeStats()
+    path = Path("/c/1.cbz")
+
+    stats.record_prefetch_match(path, ("comicvine", "metron"))
+
+    assert stats.matched_source_by_path[path] == ["comicvine", "metron"]
+    assert stats.source_status_by_path[path] == {
+        "comicvine": statuses.MATCHED,
+        "metron": statuses.MATCHED,
+    }
+    # One comic, however many sources fetched for it.
     assert stats.matched == 1

--- a/tests/test_onlinetag_session_manager.py
+++ b/tests/test_onlinetag_session_manager.py
@@ -20,6 +20,8 @@ from comicbox.events import (
     SearchCompleted,
     SearchStarted,
 )
+from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
+from comicbox.identifiers import ID_KEY_KEY
 from loguru import logger
 
 from codex.librarian.onlinetag.session_cache import (
@@ -28,7 +30,12 @@ from codex.librarian.onlinetag.session_cache import (
 )
 from codex.librarian.onlinetag.session_state import SessionState
 from codex.librarian.onlinetag.tasks import BulkOnlineTagTask
-from codex.models import Comic, Identifier, IdentifierSource
+from codex.models import (
+    Comic,
+    ComicboxTaggingDefaults,
+    Identifier,
+    IdentifierSource,
+)
 from tests.onlinetag_session_fakes import (
     FETCH_TARGET,
     PATCH_TARGET,
@@ -54,6 +61,11 @@ class OnlineTagScanTests(OnlineTagSessionTestCase):
         source, _ = IdentifierSource.objects.get_or_create(name=source_name)
         identifier = Identifier.objects.create(source=source, id_type="comic", key=key)
         comic.identifiers.add(identifier)
+
+    @staticmethod
+    def _configure_comicvine() -> None:
+        """Give Comic Vine a key so the prepass doesn't drop it unconfigured."""
+        ComicboxTaggingDefaults.objects.filter(pk=1).update(comicvine_key="cv")
 
     def _capture_search_paths(self, captured: list) -> None:
         """Make the (mocked) search pass record the comics it's handed."""
@@ -258,6 +270,135 @@ class OnlineTagScanTests(OnlineTagSessionTestCase):
         assert state.stats.matched_source_by_path[path] == ["metron"]
         assert state.stats.source_status_by_path[path] == {"metron": "matched"}
         assert remaining_pks(state, set()) == []
+
+    def test_prefetch_credits_every_source_that_merged(self) -> None:
+        """
+        A merged stored-id refresh credits both sources, not just the primary.
+
+        Under merge-all the prepass pins every stored id and comicbox fetches
+        them all into one record. Crediting the primary alone left the other
+        source's column blank on a comic it had just refreshed — which the
+        status table renders as an em-dash, reading as "never consulted".
+        """
+        self._configure_comicvine()
+        comic = make_comic()
+        self._add_issue_id(comic, "metron", "123495")
+        self._add_issue_id(comic, "comicvine", "4000-4242")
+        path = Path(comic.path)
+        comic_paths = {comic.pk: path}
+        state = SessionState(
+            session=double(FakeSession()),
+            path_to_pk={path: comic.pk},
+            sources=("comicvine", "metron"),
+        )
+        credentials = self.manager._build_credentials()  # noqa: SLF001
+        assert credentials is not None
+        task = BulkOnlineTagTask(
+            comic_pks=frozenset({comic.pk}),
+            session_id="s",
+            sources=("comicvine", "metron"),
+            mode="auto",
+            merge_all_sources=True,
+        )
+        merged = {
+            "series": "X",
+            IDENTIFIERS_KEY: {
+                "comicvine": {ID_KEY_KEY: "4000-4242"},
+                "metron": {ID_KEY_KEY: "123495"},
+            },
+        }
+
+        with patch(FETCH_TARGET, lambda *_a, **_k: merged):
+            self.manager._prefetch_stored_ids(  # noqa: SLF001
+                state, comic_paths, task, credentials
+            )
+
+        assert state.stats.source_status_by_path[path] == {
+            "comicvine": "matched",
+            "metron": "matched",
+        }
+
+    def test_prefetch_credits_only_the_ids_it_asked_for(self) -> None:
+        """
+        First-wins pins one source, so the other must stay blank.
+
+        The comic still holds a stored id for the source that sat out, and an
+        em-dash is the honest cell for a source this scan never fetched.
+        """
+        self._configure_comicvine()
+        comic = make_comic()
+        self._add_issue_id(comic, "comicvine", "4000-4242")
+        self._add_issue_id(comic, "metron", "123495")
+        path = Path(comic.path)
+        comic_paths = {comic.pk: path}
+        state = SessionState(
+            session=double(FakeSession()),
+            path_to_pk={path: comic.pk},
+            sources=("comicvine", "metron"),
+        )
+        credentials = self.manager._build_credentials()  # noqa: SLF001
+        assert credentials is not None
+        task = BulkOnlineTagTask(
+            comic_pks=frozenset({comic.pk}),
+            session_id="s",
+            sources=("comicvine", "metron"),
+            mode="auto",
+        )
+        # comicbox returns the comic's whole merged record, metron id and all.
+        # Only the pinned source may be credited for this fetch.
+        record = {
+            "series": "X",
+            IDENTIFIERS_KEY: {
+                "comicvine": {ID_KEY_KEY: "4000-4242"},
+                "metron": {ID_KEY_KEY: "123495"},
+            },
+        }
+
+        with patch(FETCH_TARGET, lambda *_a, **_k: record):
+            self.manager._prefetch_stored_ids(  # noqa: SLF001
+                state, comic_paths, task, credentials
+            )
+
+        assert state.stats.source_status_by_path[path] == {"comicvine": "matched"}
+
+    def test_prefetch_opens_the_status_row_and_names_its_source(self) -> None:
+        """
+        The rail's whole view of a re-tag is the prepass.
+
+        Only the search pass used to open a status row, so a scan that
+        resolved every comic from a stored id ran to completion with nothing
+        in the rail at all — while the Tagging tab's table, published from
+        the same loop, showed each lookup as it happened.
+        """
+        comic = make_comic()
+        self._add_issue_id(comic, "metron", "123495")
+        path = Path(comic.path)
+        comic_paths = {comic.pk: path}
+        state = SessionState(
+            session=double(FakeSession()),
+            path_to_pk={path: comic.pk},
+            sources=("metron",),
+        )
+        credentials = self.manager._build_credentials()  # noqa: SLF001
+        assert credentials is not None
+        task = BulkOnlineTagTask(
+            comic_pks=frozenset({comic.pk}),
+            session_id="s",
+            sources=("metron",),
+            mode="auto",
+        )
+        self.manager._pass_runner = double(FakePassRunner())  # noqa: SLF001
+
+        with patch(FETCH_TARGET, lambda *_a, **_k: {"series": "X"}):
+            self.manager._prefetch_stored_ids(  # noqa: SLF001
+                state, comic_paths, task, credentials
+            )
+
+        status = self.manager._pass_runner.lookup_status  # noqa: SLF001
+        assert status is not None
+        assert status.total == 1
+        assert status.complete == 1
+        assert status.subtitle == "looking up on metron"
 
     def test_run_session_never_prompts_skips_persistence(self) -> None:
         comic = make_comic()

--- a/tests/test_onlinetag_tag_pass.py
+++ b/tests/test_onlinetag_tag_pass.py
@@ -84,6 +84,101 @@ class TagPassRunnerFinishTests(TestCase):
         assert runner.rate_limited is False
         assert runner.source_retry_at == {}
 
+    def test_collect_results_adopts_the_prepass_status(self) -> None:
+        """
+        One status row per scan, opened by whichever pass runs first.
+
+        The prepass opens it so the rail isn't blank through a re-tag; the
+        search pass must then continue that row rather than starting a
+        second one, which would reset the elapsed time and flash the rail.
+        """
+        from codex.librarian.onlinetag.tag_pass_runner import TagPassRunner
+
+        started: list = []
+        updated: list = []
+        finished: list = []
+
+        class _RecordingStatusController:
+            def start(self, status, **_kwargs) -> None:
+                started.append(status)
+
+            def update(self, status, **_kwargs) -> None:
+                updated.append(status)
+
+            def finish(self, status, **_kwargs) -> None:
+                finished.append(status)
+
+        class _EmptySession:
+            def tag_many(self, _paths):
+                return iter([])
+
+        state = double(
+            SimpleNamespace(
+                session=_EmptySession(),
+                cancelled=False,
+                pending_paths=[],
+                # What the prepass left behind: one comic already done.
+                total_comics=1,
+                completed_comics=1,
+                path_to_pk={},
+                collected_tags={},
+                match_mode="auto",
+                effort="balanced",
+                sources=("metron",),
+                merge_all_sources=False,
+            )
+        )
+        runner = TagPassRunner(
+            double(logger),
+            double(FakeQueue()),
+            double(_RecordingStatusController()),
+            lambda _state: None,
+            lambda _state: None,
+        )
+        prepass_status = runner.begin_status(3)
+        started.clear()
+
+        runner.collect_results(state, [Path("/c/b.cbz"), Path("/c/c.cbz")])
+
+        # Adopted, not replaced: no second start, and the row carries the
+        # prepass's completed comic in a total covering the whole batch.
+        assert started == []
+        assert updated
+        assert updated[0] is prepass_status
+        assert (prepass_status.complete, prepass_status.total) == (1, 3)
+        assert finished == [prepass_status]
+        assert runner.lookup_status is None
+
+    def test_finish_status_closes_a_row_no_pass_adopted(self) -> None:
+        """A prepass that raised would otherwise strand an active row."""
+        from codex.librarian.onlinetag.tag_pass_runner import TagPassRunner
+
+        finished: list = []
+
+        class _RecordingStatusController:
+            def start(self, _status, **_kwargs) -> None:
+                pass
+
+            def finish(self, status, **_kwargs) -> None:
+                finished.append(status)
+
+        runner = TagPassRunner(
+            double(logger),
+            double(FakeQueue()),
+            double(_RecordingStatusController()),
+            lambda _state: None,
+            lambda _state: None,
+        )
+        status = runner.begin_status(2)
+
+        runner.finish_status()
+        # Idempotent: the manager calls it in a finally the search pass
+        # usually reaches first.
+        runner.finish_status()
+
+        assert finished == [status]
+        assert runner.lookup_status is None
+
     def test_collect_results_clears_retry_deadlines_when_cancelled(self) -> None:
         """Pausing mid-wait must not leave the table counting down forever."""
         from codex.librarian.onlinetag.tag_pass_runner import TagPassRunner


### PR DESCRIPTION
Follow-up to #840, which fixed neither symptom in practice. Both of its fixes hooked comicbox's event-emitting search session, and a re-tag never enters that session: comics codex already holds an issue id for are fetched by explicit id in the **stored-id prepass**, outside it. On a re-tag that prepass is the entire run.

Evidence from the reporting instance: the frozen snapshot had five comics, all `{"comicvine": "matched"}` with no Metron cell, `merge_all_sources: true` — while the log for the same run showed `online metron: added id=134167`, `id=170212`, `id=8862`… Metron had refreshed every one of those comics.

## A merged refresh now credits every source that landed

`record_prefetch_match` took a single primary source. Under merge-all the prepass pins *every* stored id and comicbox fetches and merges them all, so a comic refreshed from both sources showed Matched in one column and an em-dash in the other — the cell that reads "never consulted".

`resolved_id_sources` reports which of the requested ids came back in the merged record, and every one of them is credited. The primary needs no such check: `fetch_tags_by_explicit_id` already returns nothing unless its own id landed. A source this scan never pinned — first-wins, or no credentials — still reports nothing, which is what the em-dash is for.

This matches what the search path already does: under merge-all comicbox emits one `AutoWritten` per contributing source, and the fold accumulates them.

## The status rail covers the prepass

Only `collect_results` opened an `OnlineLookupStatus`, so a scan that resolved everything from stored ids ran start to finish with **no active row at all** — an empty rail, while the Tagging tab's table, published from the same loop, showed each lookup as it happened. #840's `looking up on <source>` subtitle was written to `self._pass_runner.lookup_status`, which is `None` for the whole prepass.

The prepass now opens the row (`begin_status`), totalled over the whole batch so the count doesn't jump when the search pass takes over, and advances `complete` per committed comic. `collect_results` adopts an already-open row instead of starting a second one, so the rail shows one continuous job whose elapsed time counts the prepass, and still finishes it in its `finally`. `finish_status()` in `run_session`'s `finally` closes the row if the prepass raises before the search pass can adopt it.

## Testing

- `pytest`: 1113 passed. New coverage: merged-fetch attribution, first-wins attribution (the source that sat out stays blank), the prepass opening and naming its status row, `collect_results` adopting rather than restarting it, and `finish_status` idempotence.
- `make fix`, `make lint`, `make ty`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
